### PR TITLE
Time Entries needs PARAMS like issues

### DIFF
--- a/lib/Redmine/Api/TimeEntry.php
+++ b/lib/Redmine/Api/TimeEntry.php
@@ -15,12 +15,12 @@ class TimeEntry extends AbstractApi
     /**
      * List time entries
      * @link http://www.redmine.org/projects/redmine/wiki/Rest_TimeEntries
-     *
+     * @param array $params to allow offset/limit to be passed
      * @return array list of time entries found
      */
-    public function all()
+    public function all(array $params = array())
     {
-        $this->timeEntries = $this->get('/time_entries.json');
+        $this->timeEntries = $this->get('/time_entries.json?'.$this->http_build_str($params));
 
         return $this->timeEntries;
     }


### PR DESCRIPTION
Time Entries all is limited to 25 by default but if you pass params like the issue class you can set offset/limit to pull whatever amount of entries you want. Mix for limit is 100 per Redmine tho.

In my case I did limit 25 and keep increasing the offset until I pulled all the entries I needed.
