### PR TITLE
Project prefix on Issues

### DIFF
--- a/lib/Redmine/Api/Issue.php
+++ b/lib/Redmine/Api/Issue.php
@@ -33,9 +33,9 @@ class Issue extends AbstractApi
      * @param  array $params the additional parameters (cf avaiable $params above)
      * @return array list of issues found
      */
-    public function all(array $params = array())
+    public function all(array $params = array(),$project = NULL)
     {
-        return $this->get('/issues.json?'.$this->http_build_str($params));
+        return $this->get((!is_null($project) ? '/projects/'.$project : '').'/issues.json?'.$this->http_build_str($params));
     }
 
     /**


### PR DESCRIPTION
I needed a list of issues from a specific version. To do that, you need to prefix the issues url with the project name so I added a second parameter to the Issues->all method.

/projects/project-name/issues.json?fixed_version_id=8
