### PR TITLE
Turning off HTTP Basic Auth

### DIFF
--- a/lib/Redmine/Client.php
+++ b/lib/Redmine/Client.php
@@ -50,8 +50,6 @@ class Client
      */
     private $apis = array();
 
-
-
     /**
      * Error strings if json is invalid
      */


### PR DESCRIPTION
Fix two issues:
1. When server responds with 401 error message you can turn off http basic authentication by setting
   $client->setUseHttpAuth(false);
   Client will use redmine headers to authorize instead.
2. When server responds with destroyed json data client will return human readable error message instead of null
