### PR TITLE
Allows Project::all() handle more than 100 projects

### DIFF
--- a/lib/Redmine/Api/Project.php
+++ b/lib/Redmine/Api/Project.php
@@ -26,15 +26,11 @@ class Project extends AbstractApi
 
         $projects = array();
 
-        while ( $limit > 0 )
-        {
-            if ( $limit > 100 )
-            {
+        while ($limit > 0) {
+            if ($limit > 100) {
                 $_limit = 100;
                 $limit -= 100;
-            }
-            else
-            {
+            } else {
                 $_limit = $limit;
                 $limit = 0;
             }


### PR DESCRIPTION
This is a quick solution for #35. **I am not able to test it** because I don't have a Redmine instance with more than 100 projects.
