### PR TITLE
Altered the array filter on create method to allow indexes with false eq...

### DIFF
--- a/lib/Redmine/Api/Project.php
+++ b/lib/Redmine/Api/Project.php
@@ -90,7 +90,10 @@ class Project extends AbstractApi
             'description' => null,
         );
 
-        $params = array_filter(array_merge($defaults, $params), array( $this, 'isNotNull'));
+        $params = array_filter(
+            array_merge($defaults, $params),
+            array( $this, '_isNotNull')
+        );
 
         if(
             !isset($params['name'])
@@ -107,8 +110,16 @@ class Project extends AbstractApi
         return $this->post('/projects.xml', $xml->asXML());
     }
 
-    private function isNotNull($var) {
-      return !is_null($var);
+    /**
+     * Checks if the variable passed is not null
+     *
+     * @param mixed $var Variable to be checked
+     *
+     * @return bool
+     */
+    private function _isNotNull($var)
+    {
+        return !is_null($var);
     }
 
     /**


### PR DESCRIPTION
...uivalent content

I was trying to create a private project, so I had to define the 'is_public' index as false in the params array, but the array_filter function was eliminating it so my projects were being created as public projects.
I added a callback function to the array_filter so that it only eliminates the null indexes of the params and not those that are equivalent to false.
