### PR TITLE
Fixed broken retrieveAll() method

### DIFF
--- a/lib/Redmine/Api/AbstractApi.php
+++ b/lib/Redmine/Api/AbstractApi.php
@@ -91,6 +91,9 @@ abstract class AbstractApi
         $params = array_filter(array_merge($defaults, $params));
 
         $ret = array();
+        
+        $limit = $params['limit'];
+        $offset = $params['offset'];
 
         while ($limit > 0) {
             if ($limit > 100) {


### PR DESCRIPTION
see [this comment](https://github.com/kbsali/php-redmine-api/commit/691e145173f90caa0867ba5925ef3cb05b794ad5#commitcomment-4574872).
