### PR TITLE
Add array_merge_recursive instead of simply array_merge in retrieveAll o...

### DIFF
--- a/lib/Redmine/Api/AbstractApi.php
+++ b/lib/Redmine/Api/AbstractApi.php
@@ -107,7 +107,7 @@ abstract class AbstractApi
             }
             $params['limit'] = $_limit;
             $params['offset'] = $offset;
-            $ret = array_merge($ret, $this->get($endpoint . '?' . http_build_query($params)));
+            $ret = array_merge_recursive($ret, $this->get($endpoint . '?' . http_build_query($params)));
             $offset += $_limit;
         }
 


### PR DESCRIPTION
Use array_merge_recursive instead of simply array_merge in retrieveAll of AbstractApi unless merge don't work and retrieveAll return only the last result (limit/offset mecanism)
