### PR TITLE
Save users with custom fields attached

### DIFF
--- a/lib/Redmine/Api/AbstractApi.php
+++ b/lib/Redmine/Api/AbstractApi.php
@@ -113,4 +113,24 @@ abstract class AbstractApi
 
         return $ret;
     }
+
+    /**
+     * Attaches Custom Fields to a create/update query
+     *
+     * @param SimpleXMLElement $xml XML Element the custom fields are attached to
+     * @param array $fields array of fields to attach, each field needs name, id and value set
+     * @return $xml Element
+     * @see http://www.redmine.org/projects/redmine/wiki/Rest_api#Working-with-custom-fields
+     */
+    protected function attachCustomFieldXML($xml,$fields) {
+        $fieldsXML = $xml->addChild("custom_fields");
+        $fieldsXML->addAttribute('type','array');
+        foreach ($fields as $field) {
+            $fieldXML = $fieldsXML->addChild("custom_field");
+            $fieldXML->addAttribute('name',$field['name']);
+            $fieldXML->addAttribute('id',$field['id']);
+            $fieldXML->addChild('value',$field['value']);
+        }
+        return $xml;
+    }
 }

--- a/lib/Redmine/Api/User.php
+++ b/lib/Redmine/Api/User.php
@@ -113,7 +113,11 @@ class User extends AbstractApi
 
         $xml = new \SimpleXMLElement('<?xml version="1.0"?><user></user>');
         foreach ($params as $k => $v) {
-            $xml->addChild($k, $v);
+            if ($k == 'custom_fields') {
+                $this->attachCustomFieldXML($xml,$v);
+            } else {
+                $xml->addChild($k, $v);
+            }
         }
 
         return $this->post('/users.xml', $xml->asXML());
@@ -142,7 +146,11 @@ class User extends AbstractApi
 
         $xml = new \SimpleXMLElement('<?xml version="1.0"?><user></user>');
         foreach ($params as $k => $v) {
-            $xml->addChild($k, $v);
+            if ($k == 'custom_fields') {
+                $this->attachCustomFieldXML($xml,$v);
+            } else {
+                $xml->addChild($k, $v);
+            }
         }
 
         return $this->put('/users/'.$id.'.xml', $xml->asXML());


### PR DESCRIPTION
Implemented a generic method for attaching custom fields (as described in http://www.redmine.org/projects/redmine/wiki/Rest_api#Working-with-custom-fields) but only implemented and tested it for the User api - but it should be easy to use it in all the other fields as well.
