### PR TITLE
Improve fetching items with high limits

### DIFF
--- a/lib/Redmine/Api/AbstractApi.php
+++ b/lib/Redmine/Api/AbstractApi.php
@@ -123,7 +123,11 @@ abstract class AbstractApi
             $offset += $_limit;
             // Break if the data set is the last one, as the offset is greater
             // than the total count
-            if ($newDataSet['offset'] >= $newDataSet['total_count']) {
+            if (empty($newDataSet)
+                || (array_key_exists('offset', $newDataSet)
+                && array_key_exists('total_count', $newDataSet)
+                && $newDataSet['offset'] >= $newDataSet['total_count'])
+            ) {
                 $limit = 0;
             }
         }


### PR DESCRIPTION
This PR will fixe a minor PHP error if the GET request fails and does not return an array and a check was added to break the while loop if the last data set is retrieved from redmine.
