### PR TITLE
added skip of new iteration if no limit can be set

### DIFF
--- a/lib/Redmine/Api/AbstractApi.php
+++ b/lib/Redmine/Api/AbstractApi.php
@@ -123,7 +123,7 @@ abstract class AbstractApi
             $ret = array_merge_recursive($ret, $newDataSet);
 
             $offset += $_limit;
-            if (empty($newDataSet) || !array_key_exists('limit', $newDataSet) || (
+            if (empty($newDataSet) || !isset($newDataSet['limit']) || (
                     isset($newDataSet['offset']) &&
                     isset($newDataSet['total_count']) &&
                     $newDataSet['offset'] >= $newDataSet['total_count']


### PR DESCRIPTION
If the response don't has the "limit" key, no limit can be set and therefor we don't need a further iteration. Maybe the complete part should be refactored some day.
