### PR TITLE
Strict mode error

### DIFF
--- a/lib/Redmine/Api/SimpleXMLElement.php
+++ b/lib/Redmine/Api/SimpleXMLElement.php
@@ -8,7 +8,7 @@ class SimpleXMLElement extends \SimpleXMLElement
      * Makes sure string is properly escaped
      * http://stackoverflow.com/questions/552957/rationale-behind-simplexmlelements-handling-of-text-values-in-addchild-and-adda)
      */
-    public function addChild()
+    public function addChild($name, $value = null, $ns = null)
     {
         $args = func_get_args();
         if (count($args) > 1 && is_string($args[1])) {


### PR DESCRIPTION
Declaration of Redmine\Api\SimpleXMLElement::addChild() should be compatible with SimpleXMLElement::addChild($name, $value = NULL, $ns = NULL)
