### PR TITLE
Better way of checking for XML responses

### DIFF
--- a/lib/Redmine/Client.php
+++ b/lib/Redmine/Client.php
@@ -396,7 +396,7 @@ class Client
 
         if ($response) {
             // if response is XML, return an SimpleXMLElement object
-            if ('application/xml' === substr($contentType, 0, strlen('application/xml'))) {
+            if (0 === strpos($contentType, 'application/xml')) {
                 return new SimpleXMLElement($response);
             }
 


### PR DESCRIPTION
Instead of checking for the first character being '<', we should check the content type of the response, if it matches "application/xml".

Reason for this is if you get an HTML response, it will incorrectly try and parse it as XML. (HTML response being an Apache/Nginx fail page for example)
