### PR TITLE
#88 expectation fails

### DIFF
--- a/lib/Redmine/Client.php
+++ b/lib/Redmine/Client.php
@@ -343,7 +343,7 @@ class Client
 
         $tmp = parse_url($this->url.$path);
         $httpHeader = array();
-        $httpHeaders[] = 'Expect: ';
+        $httpHeader[] = 'Expect: ';
 
         if ('xml' === substr($tmp['path'], -3)) {
             $httpHeader[] = 'Content-Type: text/xml';


### PR DESCRIPTION
Adds Expect: header so we don't get 417 Expectation fails on some web servers, with long messages
