### PR TITLE
Added CDATA escaping for correct handling of return carriage.

### DIFF
--- a/lib/Redmine/Api/Issue.php
+++ b/lib/Redmine/Api/Issue.php
@@ -80,8 +80,11 @@ class Issue extends AbstractApi
                       $upload_item->addChild($upload_k, $upload_v);
                     }
                 }
-            } else {
-                $xml->addChild($k, $v);
+            } else {          
+                $node = $xml->addChild($k);
+                $domNode = dom_import_simplexml($node); 
+                $no = $domNode->ownerDocument; 
+                $domNode->appendChild($no->createCDATASection($v)); 
             }
         }
 


### PR DESCRIPTION
Hello,

I tried using https://github.com/juanmf/RedmineIssueImporter but the issues I wanted to import had line breaks in their "description".
This patch wraps all the fields in <![CDATA[ nodes.
The impact on performance if negligible.

Thanks.
