### PR TITLE
Added CDATA escaping for correct handling of return carriage in issue decsription.

### DIFF
--- a/lib/Redmine/Api/Issue.php
+++ b/lib/Redmine/Api/Issue.php
@@ -80,12 +80,14 @@ class Issue extends AbstractApi
                       $upload_item->addChild($upload_k, $upload_v);
                     }
                 }
-            } else {          
+            } elseif ('description' === $k && strpos($v, '\n') !== false) {
+                // surround the description with CDATA if there is any '\n' in the description 
                 $node = $xml->addChild($k);
-                $domNode = dom_import_simplexml($node); 
-                $no = $domNode->ownerDocument; 
-                $domNode->appendChild($no->createCDATASection($v)); 
-                //$xml->addChild($k, $v);
+                $domNode = dom_import_simplexml($node);
+                $no = $domNode->ownerDocument;
+                $domNode->appendChild($no->createCDATASection($v));
+            } else {
+                $xml->addChild($k, $v);
             }
         }
 

--- a/test/Redmine/Tests/IssueXmlTest.php
+++ b/test/Redmine/Tests/IssueXmlTest.php
@@ -97,6 +97,48 @@ class IssueXmlTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($this->formatXml($xml), $this->formatXml($res));
     }
 
+    public function testCreateComplexWithLineBreakInDescription()
+    {
+        $res = $this->client->api('issue')->create(array(
+            'project_id'     => 'test',
+            'subject'        => 'test api (xml) 3',
+            'description'    => 'line1\nline2',
+            'assigned_to_id' => 1,
+            'custom_fields'  => array(
+                array(
+                    'id'    => 2,
+                    'name'  => 'Issuer',
+                    'value' => 'asdf',
+                ),
+                array(
+                    'id'    => 5,
+                    'name'  => 'Phone',
+                    'value' => '9939494',
+                ),
+                array(
+                    'id'    => '8',
+                    'name'  => 'Email',
+                    'value' => 'asdf@asdf.com',
+                ),
+            ),
+            'watcher_user_ids' => array(),
+        ));
+
+        $xml = '<?xml version="1.0"?>
+<issue>
+    <subject>test api (xml) 3</subject>
+    <description><![CDATA[line1\nline2]]></description>
+    <project_id>test</project_id>
+    <assigned_to_id>1</assigned_to_id>
+    <custom_fields type="array">
+        <custom_field name="Issuer" id="2"><value>asdf</value></custom_field>
+        <custom_field name="Phone" id="5"><value>9939494</value></custom_field>
+        <custom_field name="Email" id="8"><value>asdf@asdf.com</value></custom_field>
+    </custom_fields>
+</issue>';
+        $this->assertEquals($this->formatXml($xml), $this->formatXml($res));
+    }
+
     public function testUpdateIssue()
     {
         $res = $this->client->api('issue')->update(1, array(


### PR DESCRIPTION
Hello,

I tried using https://github.com/juanmf/RedmineIssueImporter but the issues I wanted to import had line breaks in their "description".
This patch wraps the decsription field in a <![CDATA[ node.
The impact on performance if negligible.

Thanks.
