### PR TITLE
Fix user removal from group URL

### DIFF
--- a/lib/Redmine/Api/Group.php
+++ b/lib/Redmine/Api/Group.php
@@ -126,6 +126,6 @@ class Group extends AbstractApi
      */
     public function removeUser($id, $userId)
     {
-        return $this->delete('/groups/'.$id.'/user/'.$userId.'.xml');
+        return $this->delete('/groups/'.$id.'/users/'.$userId.'.xml');
     }
 }


### PR DESCRIPTION
The URL to remove a user from a group has a small typo (`user` should be `users`).

This can be checked at http://www.redmine.org/projects/redmine/wiki/Rest_Groups#DELETE-2
