### PR TITLE
[Fixed #121] Correctly creating issue include parameters

### DIFF
--- a/lib/Redmine/Api/Issue.php
+++ b/lib/Redmine/Api/Issue.php
@@ -55,6 +55,10 @@ class Issue extends AbstractApi
      */
     public function show($id, array $params = array())
     {
+        if (isset($params['include'])) {
+            $params['include'] = implode(',', $params['include']);
+        }
+
         return $this->get('/issues/'.urlencode($id).'.json?'.http_build_query($params));
     }
 


### PR DESCRIPTION
API builds a request using the `http_build_query` method. The output would be:

    /issues/<id>.json?include[0]=attachments&include[1]=children

Where as the redmine API requires this format:

    /issues/<id>.json?include=attachments,children