### PR TITLE
allow parameters to be set when requesting users

### DIFF
--- a/lib/Redmine/Api/User.php
+++ b/lib/Redmine/Api/User.php
@@ -55,10 +55,20 @@ class User extends AbstractApi
     /**
      * Return the current user data.
      *
+     * @link http://www.redmine.org/projects/redmine/wiki/Rest_Users#usersidformat
+     * available $params :
+     * include: fetch associated data (optional). Possible values:
+     *  - memberships: adds extra information about user's memberships and roles on the projects
+     *  - groups (added in 2.1): adds extra information about user's groups
+     *  - api_key: the API key of the user, visible for admins and for yourself (added in 2.3.0)
+     *  - status: a numeric id representing the status of the user, visible for admins only (added in 2.4.0).
+     *
+     * @param array  $params extra associated data
      * @return array current user data
      */
-    public function getCurrentUser()
+    public function getCurrentUser(array $params = array())
     {
+        return $this->show('current', $params);
         return $this->get('/users/current.json');
     }
 
@@ -85,13 +95,38 @@ class User extends AbstractApi
      *
      * @link http://www.redmine.org/projects/redmine/wiki/Rest_Users#GET-2
      *
+     * @link http://www.redmine.org/projects/redmine/wiki/Rest_Users#usersidformat
+     * available $params :
+     * include: fetch associated data (optional). Possible values:
+     *  - memberships: adds extra information about user's memberships and roles on the projects
+     *  - groups (added in 2.1): adds extra information about user's groups
+     *  - api_key: the API key of the user, visible for admins and for yourself (added in 2.3.0)
+     *  - status: a numeric id representing the status of the user, visible for admins only (added in 2.4.0).
+     *
      * @param string $id the user id
+     * @param array  $params extra associated data
      *
      * @return array information about the user
      */
-    public function show($id)
+    public function show($id, array $params = array())
     {
-        return $this->get('/users/'.urlencode($id).'.json?include=memberships,groups');
+        // set default ones
+        $params['include'] = array_unique(
+            array_merge(
+                isset($params['include']) ? $params['include'] : array(),
+                array(
+                    'memberships',
+                    'groups',
+                )
+            )
+        );
+        $params['include'] = implode(',', $params['include']);
+
+        return $this->get(sprintf(
+            '/users/%s.json?%s',
+            urlencode($id),
+            http_build_query($params)
+        ));
     }
 
     /**

--- a/test/Redmine/Tests/Api/UserTest.php
+++ b/test/Redmine/Tests/Api/UserTest.php
@@ -28,7 +28,12 @@ class UserTest extends \PHPUnit_Framework_TestCase
             ->getMock();
         $client->expects($this->once())
             ->method('get')
-            ->with('/users/current.json')
+            ->with(
+                $this->logicalAnd(
+                    $this->stringStartsWith('/users/current.json'),
+                    $this->stringContains(urlencode('memberships,groups'))
+                )
+            )
             ->willReturn($getResponse);
 
         // Create the object under test
@@ -154,7 +159,12 @@ class UserTest extends \PHPUnit_Framework_TestCase
             ->getMock();
         $client->expects($this->once())
             ->method('get')
-            ->with('/users/5.json?include=memberships,groups')
+            ->with(
+                $this->logicalAnd(
+                    $this->stringStartsWith('/users/5.json'),
+                    $this->stringContains(urlencode('memberships,groups'))
+                )
+            )
             ->willReturn($getResponse);
 
         // Create the object under test
@@ -162,6 +172,40 @@ class UserTest extends \PHPUnit_Framework_TestCase
 
         // Perform the tests
         $this->assertSame($getResponse, $api->show(5));
+    }
+
+    /**
+     * Test show().
+     *
+     * @covers ::get
+     * @covers ::show
+     * @test
+     */
+    public function testShowReturnsClientGetResponseWithUniqueParameters()
+    {
+        // Test values
+        $parameters = array('include' => array('parameter1', 'parameter2', 'memberships'));
+        $getResponse = 'API Response';
+
+        // Create the used mock objects
+        $client = $this->getMockBuilder('Redmine\Client')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $client->expects($this->once())
+            ->method('get')
+            ->with(
+                $this->logicalAnd(
+                    $this->stringStartsWith('/users/5.json'),
+                    $this->stringContains(urlencode('parameter1,parameter2,memberships,groups'))
+                )
+            )
+            ->willReturn($getResponse);
+
+        // Create the object under test
+        $api = new User($client);
+
+        // Perform the tests
+        $this->assertSame($getResponse, $api->show(5, $parameters));
     }
 
     /**

--- a/test/Redmine/Tests/UrlTest.php
+++ b/test/Redmine/Tests/UrlTest.php
@@ -246,7 +246,16 @@ class UrlTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($res, array('path' => '/users.json', 'method' => 'GET'));
 
         $res = $this->client->api('user')->show(1);
-        $this->assertEquals($res, array('path' => '/users/1.json?include=memberships,groups', 'method' => 'GET'));
+        $this->assertEquals($res, array('path' => '/users/1.json?include=' . urlencode('memberships,groups'), 'method' => 'GET'));
+
+        $res = $this->client->api('user')->show(1, array('include' => array('memberships', 'groups')));
+        $this->assertEquals($res, array('path' => '/users/1.json?include=' . urlencode('memberships,groups'), 'method' => 'GET'));
+
+        $res = $this->client->api('user')->show(1, array('include' => array('memberships', 'groups', 'parameter1')));
+        $this->assertEquals($res, array('path' => '/users/1.json?include=' . urlencode('memberships,groups,parameter1'), 'method' => 'GET'));
+
+        $res = $this->client->api('user')->show(1, array('include' => array('parameter1', 'memberships', 'groups')));
+        $this->assertEquals($res, array('path' => '/users/1.json?include=' . urlencode('parameter1,memberships,groups'), 'method' => 'GET'));
 
         $res = $this->client->api('user')->remove(1);
         $this->assertEquals($res, array('path' => '/users/1.xml', 'method' => 'DELETE'));


### PR DESCRIPTION
This commits introduces setting parameters for methods show() and
getCurrentUser() in class Redmine\Api\User.

Default behaviour remained the same, if show() is called without
parameters, `include=memberships,groups` is set. At the same time,
getCurrentUser() was refactored to call show() rather then initiate
request on its own.