### PR TITLE
Backwards compatibility of include parameters

### DIFF
--- a/lib/Redmine/Api/Issue.php
+++ b/lib/Redmine/Api/Issue.php
@@ -55,7 +55,7 @@ class Issue extends AbstractApi
      */
     public function show($id, array $params = array())
     {
-        if (isset($params['include'])) {
+        if (isset($params['include']) && is_array($params['include'])) {
             $params['include'] = implode(',', $params['include']);
         }
 


### PR DESCRIPTION
Value $params[‘include’] might be already comma-concatenated string as
it has been used in previous versions