### PR TITLE
Fixed example

### DIFF
--- a/example.php
+++ b/example.php
@@ -249,7 +249,7 @@ $client->api('query')->all();
 // Time entries
 $client->api('time_entry')->all();
 $client->api('time_entry')->show($timeEntryId);
-$client->api('time_entry')->show(array(
+$client->api('time_entry')->all(array(
     'issue_id' => 1234,
     'project_id' => 1234,
     'spent_on' => '2015-04-13',


### PR DESCRIPTION
Run into this testing the library.

The method you should use to query all time_entries with filters is "all" not "show".

Tested it both ways and "show" throws a Syntax Error while "all" works as expected