### PR TITLE
Forced type of overloaded property to integer.

### DIFF
--- a/lib/Redmine/Api/SimpleXMLElement.php
+++ b/lib/Redmine/Api/SimpleXMLElement.php
@@ -18,7 +18,7 @@ class SimpleXMLElement extends \SimpleXMLElement
             $args[1] = '';
             $node = call_user_func_array(array('parent', 'addChild'), $args);
             // next, all characters like "&", "<", ">" will be properly escaped
-            $node->{0} = $text;
+            $node->{intval(0)} = $text;
         } else {
             $node = call_user_func_array(array('parent', 'addChild'), $args);
         }


### PR DESCRIPTION
Forced type of overloaded property to integer. Fixes creation of <0>-Tags in PHP 7.
Checked in PHP 5.6.17 and 7.0.4

Signed-off-by: Marc Reitz <marc.reitz@kreativstrecke.de>