### PR TITLE
downloading attachments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ composer.phar
 vendor
 coverage.clover
 
+/nbproject/private/
+/nbproject

--- a/lib/Redmine/Api/Attachment.php
+++ b/lib/Redmine/Api/Attachment.php
@@ -34,7 +34,7 @@ class Attachment extends AbstractApi
      */
     public function download($id)
     {
-        return $this->get('/attachments/'.urlencode($id), false);
+        return $this->get('/attachments/download/'.urlencode($id), false);
     }
 
     /**


### PR DESCRIPTION
If you are downloading a file that is CSV/TXT then the REST url /attachments/FILE_ID is not ok.

This is because for these types of files redmine will return not the csv content, but rather a full html with a preview of the file.
The corret url is /attachments/download/FILE_ID.
This might also be for other types of attachments.