### PR TITLE
Fix losing bytes when downloading attachments

### DIFF
--- a/lib/Redmine/Client.php
+++ b/lib/Redmine/Client.php
@@ -615,7 +615,7 @@ class Client
     {
         $curl = $this->prepareRequest($path, $method, $data);
 
-        $response = trim(curl_exec($curl));
+        $response = curl_exec($curl);
         $this->responseCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
         $contentType = curl_getinfo($curl, CURLINFO_CONTENT_TYPE);
 


### PR DESCRIPTION
Example:
The size of the original file (.xls file), that was attached to issue, is 572928 bytes.
I'm trying to download it via
```
$attachmentContent = $redmineApi->api('attachment')->download($attachmentId);
file_put_contents('example.xls', $attachmentContent);
```
The size of _example.xls_ is 572922 bytes and the example.xls is corrupted (MS Excel can't open it)

It's just because of trimming curl_exec response
`$response = trim(curl_exec($curl));`