### PR TITLE
add system line terminators

### DIFF
--- a/lib/Redmine/Api/Issue.php
+++ b/lib/Redmine/Api/Issue.php
@@ -91,7 +91,7 @@ class Issue extends AbstractApi
                         $upload_item->addChild($upload_k, $upload_v);
                     }
                 }
-            } elseif ('description' === $k && strpos($v, "\n") !== false) {
+            } elseif ('description' === $k && (strpos($v, "\n") !== false || strpos($v, PHP_EOL) !== false)) {
                 // surround the description with CDATA if there is any '\n' in the description
                 $node = $xml->addChild($k);
                 $domNode = dom_import_simplexml($node);


### PR DESCRIPTION
There is a problem in using your API implementation in integration with Redmine.
When you create the entity Issue, text is transmitted in the field 'description', that Redmine API provides no restrictions on the data format and/or length. Thereafter, the text with any content should be transferred correctly.

However, there is a bug.
In case you create a XML request, and there is an ampersand symbol (&) in the field 'description' (or any other), the further text will be ignored. If this text is screened in CDATA, everything works fine.
Besides, your implementation does not take into account the platform-specific line terminators, so, for example, this rule does not work on CentOs.

This pull-request fixes the last problem. Also it would make sense to frame 'description' field in a CDATA every time.
