### PR TITLE
Escape all text values for any XML element properly

### DIFF
--- a/lib/Redmine/Api/Issue.php
+++ b/lib/Redmine/Api/Issue.php
@@ -91,14 +91,10 @@ class Issue extends AbstractApi
                         $upload_item->addChild($upload_k, $upload_v);
                     }
                 }
-            } elseif ('description' === $k && (strpos($v, "\n") !== false || strpos($v, PHP_EOL) !== false)) {
-                // surround the description with CDATA if there is any '\n' in the description
-                $node = $xml->addChild($k);
-                $domNode = dom_import_simplexml($node);
-                $no = $domNode->ownerDocument;
-                $domNode->appendChild($no->createCDATASection($v));
             } else {
-                $xml->addChild($k, $v);
+                // "addChild" does not escape text for XML value, but the setter does.
+                // http://stackoverflow.com/a/555039/99904
+                $xml->$k = $v;
             }
         }
 

--- a/test/Redmine/Tests/IssueXmlTest.php
+++ b/test/Redmine/Tests/IssueXmlTest.php
@@ -135,8 +135,8 @@ class IssueXmlTest extends \PHPUnit_Framework_TestCase
         $xml = '<?xml version="1.0"?>
 <issue>
     <subject>test api (xml) 3</subject>
-    <description><![CDATA[line1
-line2]]></description>
+    <description>line1
+line2</description>
     <project_id>test</project_id>
     <assigned_to_id>1</assigned_to_id>
     <custom_fields type="array">


### PR DESCRIPTION
Currently, only the "description" value gets escaped for XML. E.g., "subject" does not.

Even then, the "description" value is not escaped if it does not contain new line characters. E.g., if it contains "&", the API request loses the description value completely.

So, here is my offer how to fix it.