### PR TITLE
#195 add @params option to project->show() method

### DIFF
--- a/lib/Redmine/Api/Project.php
+++ b/lib/Redmine/Api/Project.php
@@ -70,15 +70,24 @@ class Project extends AbstractApi
     /**
      * Get extended information about a project (including memberships + groups).
      *
-     * @see http://www.redmine.org/projects/redmine/wiki/Rest_Projects
+     * @see http://www.redmine.org/projects/redmine/wiki/Rest_Projects#Showing-a-project
      *
      * @param string $id the project id
+     * @param array $params available parameters:
+     *        include: fetch associated data (optional). Possible values: trackers, issue_categories, enabled_modules (since 2.6.0)
      *
      * @return array information about the project
      */
-    public function show($id)
+    public function show($id, array $params = [])
     {
-        return $this->get('/projects/'.urlencode($id).'.json?include=trackers,issue_categories,attachments,relations');
+        if (isset($params['include']) && is_array($params['include'])) {
+            $params['include'] = implode(',', $params['include']);
+        }
+        else {
+            $params['include'] = 'trackers,issue_categories,attachments,relations';
+        }
+
+        return $this->get('/projects/'.urlencode($id).'.json?'.http_build_query($params));
     }
 
     /**

--- a/lib/Redmine/Api/Project.php
+++ b/lib/Redmine/Api/Project.php
@@ -82,8 +82,7 @@ class Project extends AbstractApi
     {
         if (isset($params['include']) && is_array($params['include'])) {
             $params['include'] = implode(',', $params['include']);
-        }
-        else {
+        } else {
             $params['include'] = 'trackers,issue_categories,attachments,relations';
         }
 

--- a/test/Redmine/Tests/Api/ProjectTest.php
+++ b/test/Redmine/Tests/Api/ProjectTest.php
@@ -90,8 +90,8 @@ class ProjectTest extends \PHPUnit_Framework_TestCase
         $client->expects($this->once())
             ->method('get')
             ->with(
-                '/projects/5.json?include=trackers,issue_categories,'
-                .'attachments,relations'
+                '/projects/5.json?'.
+                urlencode('include=trackers,issue_categories,attachments,relations')
             )
             ->willReturn($getResponse);
 
@@ -100,6 +100,40 @@ class ProjectTest extends \PHPUnit_Framework_TestCase
 
         // Perform the tests
         $this->assertSame($getResponse, $api->show(5));
+    }
+
+    /**
+     * Test show().
+     *
+     * @covers ::get
+     * @covers ::show
+     * @test
+     */
+    public function testShowReturnsClientGetResponseWithUniqueParameters()
+    {
+        // Test values
+        $parameters = ['include' => ['parameter1', 'parameter2', 'enabled_modules']];
+        $getResponse = 'API Response';
+
+        // Create the used mock objects
+        $client = $this->getMockBuilder('Redmine\Client')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $client->expects($this->once())
+            ->method('get')
+            ->with(
+                $this->logicalAnd(
+                    $this->stringStartsWith('/projects/5.json?'),
+                    $this->stringContains(urlencode('parameter1,parameter2,enabled_modules'))
+                )
+            )
+            ->willReturn($getResponse);
+
+        // Create the object under test
+        $api = new Project($client);
+
+        // Perform the tests
+        $this->assertSame($getResponse, $api->show(5, $parameters));
     }
 
     /**

--- a/test/Redmine/Tests/Api/ProjectTest.php
+++ b/test/Redmine/Tests/Api/ProjectTest.php
@@ -90,8 +90,8 @@ class ProjectTest extends \PHPUnit_Framework_TestCase
         $client->expects($this->once())
             ->method('get')
             ->with(
-                '/projects/5.json?'.
-                urlencode('include=trackers,issue_categories,attachments,relations')
+                '/projects/5.json?include='.
+                urlencode('trackers,issue_categories,attachments,relations')
             )
             ->willReturn($getResponse);
 
@@ -123,7 +123,7 @@ class ProjectTest extends \PHPUnit_Framework_TestCase
             ->method('get')
             ->with(
                 $this->logicalAnd(
-                    $this->stringStartsWith('/projects/5.json?'),
+                    $this->stringStartsWith('/projects/5.json?include='),
                     $this->stringContains(urlencode('parameter1,parameter2,enabled_modules'))
                 )
             )

--- a/test/Redmine/Tests/UrlTest.php
+++ b/test/Redmine/Tests/UrlTest.php
@@ -223,7 +223,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($res['method'], 'GET');
 
         $res = $api->show(1);
-        $this->assertEquals($res['path'], '/projects/1.json?include=trackers,issue_categories,attachments,relations');
+        $this->assertEquals($res['path'], '/projects/1.json?include='.urlencode('trackers,issue_categories,attachments,relations'));
         $this->assertEquals($res['method'], 'GET');
 
         $res = $api->remove(1);


### PR DESCRIPTION
Default is like before: 

`$params['include'] = 'trackers,issue_categories,attachments,relations'`

Redmine Rest API nethertheless only mentions: trackers, issue_categories, enabled_modules - but not: attachments, relations. 

But keeping 'em for backward compatibility.

Please, merge - thanx.