### PR TITLE
JSON encoded post fields for relation creation

### DIFF
--- a/lib/Redmine/Api/IssueRelation.php
+++ b/lib/Redmine/Api/IssueRelation.php
@@ -83,7 +83,7 @@ class IssueRelation extends AbstractApi
 
         $params = $this->sanitizeParams($defaults, $params);
 
-        $params = ['relation' => $params];
+        $params = json_encode(['relation' => $params]);
 
         return json_decode($this->post('/issues/'.urlencode($issueId).'/relations.json', $params), true);
     }

--- a/test/Redmine/Tests/Api/IssueRelationTest.php
+++ b/test/Redmine/Tests/Api/IssueRelationTest.php
@@ -186,11 +186,11 @@ class IssueRelationTest extends \PHPUnit_Framework_TestCase
                ->method('post')
                ->with(
                    '/issues/1/relations.json',
-                   [
+                   json_encode([
                        'relation' => [
                            'relation_type' => 'relates',
                        ],
-                   ]
+                   ])
                )
                ->willReturn($postResponse);
 


### PR DESCRIPTION
Hi,

This is my first pull request so any advice is greatly appreciated!

I was getting an array to string conversion errors when attempting to create relations and this seems to be the problem.
I'm not sure whether this would be more appropriate in a 'asJson' function to make it more consistent with the asXML approach.

I haven't updated the test because I'm not completely sure what to change. If you point me in the right direction I'll give it a crack.