### PR TITLE
send data in json format

### DIFF
--- a/lib/Redmine/Api/IssueRelation.php
+++ b/lib/Redmine/Api/IssueRelation.php
@@ -85,6 +85,6 @@ class IssueRelation extends AbstractApi
 
         $params = ['relation' => $params];
 
-        return json_decode($this->post('/issues/'.urlencode($issueId).'/relations.json', $params), true);
+        return json_decode($this->post('/issues/'.urlencode($issueId).'/relations.json', json_encode($params)), true);
     }
 }


### PR DESCRIPTION
otherwise params would be encoded in form data format, which makes redmine return 400