### PR TITLE
Fix filename of .php_cs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,6 @@ phpunit.xml.dist  export-ignore
 .gitattributes    export-ignore
 .gitignore        export-ignore
 .scrutinizer.yml  export-ignore
-php_cs            export-ignore
+.php_cs            export-ignore
 .editorconfig     export-ignore
 example.php       export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,6 @@ phpunit.xml.dist  export-ignore
 .gitattributes    export-ignore
 .gitignore        export-ignore
 .scrutinizer.yml  export-ignore
-.php_cs            export-ignore
+.php_cs           export-ignore
 .editorconfig     export-ignore
 example.php       export-ignore


### PR DESCRIPTION
I've noticed that the `.php_cs` filename was wrong in `.gitattributes`.