### PR TITLE
Update to PHPUnit 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
 
 before_script:
   - composer install --dev --prefer-source

--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
+        "php": "^5.4 || ^7.0",
         "ext-curl": "*"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.0",
-        "phpunit/phpunit": "~4.0"
+        "phpunit/phpunit": "^4.8.35 || ^6.0"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -24,5 +24,11 @@
         "psr-0": {
             "Redmine": "lib/"
         }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Redmine\\Tests\\": "test/Redmine/Tests/",
+            "Redmine\\Fixtures\\": "test/Redmine/Fixtures/"
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
         "phpunit/phpunit": "^4.8.35 || ^6.0"
     },
     "autoload": {
-        "psr-0": {
-            "Redmine": "lib/"
+        "psr-4": {
+            "Redmine\\": "lib/Redmine/"
         }
     },
     "autoload-dev": {

--- a/lib/autoload.php
+++ b/lib/autoload.php
@@ -7,19 +7,8 @@ spl_autoload_register(function ($class) {
      */
     $class = str_replace('\\', '/', $class);
 
-    /* First, check under the current directory. It is important that
-     * we look here first, so that we don't waste time searching for
-     * test classes in the common case.
-     */
+    // Check under the current directory
     $path = dirname(__FILE__).'/'.$class.'.php';
-    if (file_exists($path)) {
-        require_once $path;
-    }
-
-    /* If we didn't find what we're looking for already, maybe it's
-     * a test class?
-     */
-    $path = dirname(__FILE__).'/../test/'.$class.'.php';
     if (file_exists($path)) {
         require_once $path;
     }

--- a/lib/autoload.php
+++ b/lib/autoload.php
@@ -7,8 +7,19 @@ spl_autoload_register(function ($class) {
      */
     $class = str_replace('\\', '/', $class);
 
-    // Check under the current directory
+    /* First, check under the current directory. It is important that
+     * we look here first, so that we don't waste time searching for
+     * test classes in the common case.
+     */
     $path = dirname(__FILE__).'/'.$class.'.php';
+    if (file_exists($path)) {
+        require_once $path;
+    }
+
+    /* If we didn't find what we're looking for already, maybe it's
+     * a test class?
+     */
+    $path = dirname(__FILE__).'/../test/'.$class.'.php';
     if (file_exists($path)) {
         require_once $path;
     }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,7 +9,7 @@
          processIsolation="false"
          stopOnFailure="false"
          syntaxCheck="false"
-         bootstrap="vendor/autoload.php"
+         bootstrap="lib/autoload.php"
 >
     <testsuites>
         <testsuite name="php-redmine-api Test Suite">

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,7 +9,7 @@
          processIsolation="false"
          stopOnFailure="false"
          syntaxCheck="false"
-         bootstrap="lib/autoload.php"
+         bootstrap="vendor/autoload.php"
 >
     <testsuites>
         <testsuite name="php-redmine-api Test Suite">

--- a/test/Redmine/Tests/Api/AttachmentTest.php
+++ b/test/Redmine/Tests/Api/AttachmentTest.php
@@ -9,7 +9,7 @@ use Redmine\Api\Attachment;
  *
  * @author     Malte Gerth <mail@malte-gerth.de>
  */
-class AttachmentTest extends \PHPUnit_Framework_TestCase
+class AttachmentTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test lastCallFailed().

--- a/test/Redmine/Tests/Api/CustomFieldTest.php
+++ b/test/Redmine/Tests/Api/CustomFieldTest.php
@@ -9,7 +9,7 @@ use Redmine\Api\CustomField;
  *
  * @author     Malte Gerth <mail@malte-gerth.de>
  */
-class CustomFieldTest extends \PHPUnit_Framework_TestCase
+class CustomFieldTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test all().

--- a/test/Redmine/Tests/Api/GroupTest.php
+++ b/test/Redmine/Tests/Api/GroupTest.php
@@ -9,7 +9,7 @@ use Redmine\Api\Group;
  *
  * @author     Malte Gerth <mail@malte-gerth.de>
  */
-class GroupTest extends \PHPUnit_Framework_TestCase
+class GroupTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test all().

--- a/test/Redmine/Tests/Api/IssueCategoryTest.php
+++ b/test/Redmine/Tests/Api/IssueCategoryTest.php
@@ -9,7 +9,7 @@ use Redmine\Api\IssueCategory;
  *
  * @author     Malte Gerth <mail@malte-gerth.de>
  */
-class IssueCategoryTest extends \PHPUnit_Framework_TestCase
+class IssueCategoryTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test all().

--- a/test/Redmine/Tests/Api/IssuePriorityTest.php
+++ b/test/Redmine/Tests/Api/IssuePriorityTest.php
@@ -9,7 +9,7 @@ use Redmine\Api\IssuePriority;
  *
  * @author     Malte Gerth <mail@malte-gerth.de>
  */
-class IssuePriorityTest extends \PHPUnit_Framework_TestCase
+class IssuePriorityTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test all().

--- a/test/Redmine/Tests/Api/IssueRelationTest.php
+++ b/test/Redmine/Tests/Api/IssueRelationTest.php
@@ -9,7 +9,7 @@ use Redmine\Api\IssueRelation;
  *
  * @author     Malte Gerth <mail@malte-gerth.de>
  */
-class IssueRelationTest extends \PHPUnit_Framework_TestCase
+class IssueRelationTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test all().

--- a/test/Redmine/Tests/Api/IssueStatusTest.php
+++ b/test/Redmine/Tests/Api/IssueStatusTest.php
@@ -9,7 +9,7 @@ use Redmine\Api\IssueStatus;
  *
  * @author     Malte Gerth <mail@malte-gerth.de>
  */
-class IssueStatusTest extends \PHPUnit_Framework_TestCase
+class IssueStatusTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test all().

--- a/test/Redmine/Tests/Api/IssueTest.php
+++ b/test/Redmine/Tests/Api/IssueTest.php
@@ -9,7 +9,7 @@ use Redmine\Api\Issue;
  *
  * @author     Malte Gerth <mail@malte-gerth.de>
  */
-class IssueTest extends \PHPUnit_Framework_TestCase
+class IssueTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test the constants.

--- a/test/Redmine/Tests/Api/MembershipTest.php
+++ b/test/Redmine/Tests/Api/MembershipTest.php
@@ -9,7 +9,7 @@ use Redmine\Api\Membership;
  *
  * @author     Malte Gerth <mail@malte-gerth.de>
  */
-class MembershipTest extends \PHPUnit_Framework_TestCase
+class MembershipTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test all().

--- a/test/Redmine/Tests/Api/NewsTest.php
+++ b/test/Redmine/Tests/Api/NewsTest.php
@@ -9,7 +9,7 @@ use Redmine\Api\News;
  *
  * @author     Malte Gerth <mail@malte-gerth.de>
  */
-class NewsTest extends \PHPUnit_Framework_TestCase
+class NewsTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test all().

--- a/test/Redmine/Tests/Api/ProjectTest.php
+++ b/test/Redmine/Tests/Api/ProjectTest.php
@@ -9,7 +9,7 @@ use Redmine\Api\Project;
  *
  * @author     Malte Gerth <mail@malte-gerth.de>
  */
-class ProjectTest extends \PHPUnit_Framework_TestCase
+class ProjectTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test all().

--- a/test/Redmine/Tests/Api/QueryTest.php
+++ b/test/Redmine/Tests/Api/QueryTest.php
@@ -9,7 +9,7 @@ use Redmine\Api\Query;
  *
  * @author     Malte Gerth <mail@malte-gerth.de>
  */
-class QueryTest extends \PHPUnit_Framework_TestCase
+class QueryTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test all().

--- a/test/Redmine/Tests/Api/RoleTest.php
+++ b/test/Redmine/Tests/Api/RoleTest.php
@@ -9,7 +9,7 @@ use Redmine\Api\Role;
  *
  * @author     Malte Gerth <mail@malte-gerth.de>
  */
-class RoleTest extends \PHPUnit_Framework_TestCase
+class RoleTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test all().

--- a/test/Redmine/Tests/Api/TimeEntryActivityTest.php
+++ b/test/Redmine/Tests/Api/TimeEntryActivityTest.php
@@ -9,7 +9,7 @@ use Redmine\Api\TimeEntryActivity;
  *
  * @author     Malte Gerth <mail@malte-gerth.de>
  */
-class TimeEntryActivityTest extends \PHPUnit_Framework_TestCase
+class TimeEntryActivityTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test all().

--- a/test/Redmine/Tests/Api/TimeEntryTest.php
+++ b/test/Redmine/Tests/Api/TimeEntryTest.php
@@ -9,7 +9,7 @@ use Redmine\Api\TimeEntry;
  *
  * @author     Malte Gerth <mail@malte-gerth.de>
  */
-class TimeEntryTest extends \PHPUnit_Framework_TestCase
+class TimeEntryTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test all().

--- a/test/Redmine/Tests/Api/TrackerTest.php
+++ b/test/Redmine/Tests/Api/TrackerTest.php
@@ -9,7 +9,7 @@ use Redmine\Api\Tracker;
  *
  * @author     Malte Gerth <mail@malte-gerth.de>
  */
-class TrackerTest extends \PHPUnit_Framework_TestCase
+class TrackerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test all().

--- a/test/Redmine/Tests/Api/UserTest.php
+++ b/test/Redmine/Tests/Api/UserTest.php
@@ -9,7 +9,7 @@ use Redmine\Api\User;
  *
  * @author     Malte Gerth <mail@malte-gerth.de>
  */
-class UserTest extends \PHPUnit_Framework_TestCase
+class UserTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test getCurrentUser().

--- a/test/Redmine/Tests/Api/VersionTest.php
+++ b/test/Redmine/Tests/Api/VersionTest.php
@@ -9,7 +9,7 @@ use Redmine\Api\Version;
  *
  * @author     Malte Gerth <mail@malte-gerth.de>
  */
-class VersionTest extends \PHPUnit_Framework_TestCase
+class VersionTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test all().

--- a/test/Redmine/Tests/Api/WikiTest.php
+++ b/test/Redmine/Tests/Api/WikiTest.php
@@ -9,7 +9,7 @@ use Redmine\Api\Wiki;
  *
  * @author     Malte Gerth <mail@malte-gerth.de>
  */
-class WikiTest extends \PHPUnit_Framework_TestCase
+class WikiTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test all().

--- a/test/Redmine/Tests/ClientTest.php
+++ b/test/Redmine/Tests/ClientTest.php
@@ -5,7 +5,7 @@ namespace Redmine\Tests;
 use Redmine\Client;
 use Redmine\Fixtures\MockClient;
 
-class ClientTest extends \PHPUnit_Framework_TestCase
+class ClientTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @covers \Redmine\Client

--- a/test/Redmine/Tests/GroupXmlTest.php
+++ b/test/Redmine/Tests/GroupXmlTest.php
@@ -4,7 +4,7 @@ namespace Redmine\Tests;
 
 use Redmine\Fixtures\MockClient as TestClient;
 
-class GroupXmlTest extends \PHPUnit_Framework_TestCase
+class GroupXmlTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var TestClient

--- a/test/Redmine/Tests/IssueCategoryXmlTest.php
+++ b/test/Redmine/Tests/IssueCategoryXmlTest.php
@@ -4,7 +4,7 @@ namespace Redmine\Tests;
 
 use Redmine\Fixtures\MockClient as TestClient;
 
-class IssueCategoryXmlTest extends \PHPUnit_Framework_TestCase
+class IssueCategoryXmlTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var TestClient

--- a/test/Redmine/Tests/IssueXmlTest.php
+++ b/test/Redmine/Tests/IssueXmlTest.php
@@ -4,7 +4,7 @@ namespace Redmine\Tests;
 
 use Redmine\Fixtures\MockClient as TestClient;
 
-class IssueXmlTest extends \PHPUnit_Framework_TestCase
+class IssueXmlTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var TestClient

--- a/test/Redmine/Tests/MembershipXmlTest.php
+++ b/test/Redmine/Tests/MembershipXmlTest.php
@@ -4,7 +4,7 @@ namespace Redmine\Tests;
 
 use Redmine\Fixtures\MockClient as TestClient;
 
-class MembershipXmlTest extends \PHPUnit_Framework_TestCase
+class MembershipXmlTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var TestClient

--- a/test/Redmine/Tests/ProjectXmlTest.php
+++ b/test/Redmine/Tests/ProjectXmlTest.php
@@ -4,7 +4,7 @@ namespace Redmine\Tests;
 
 use Redmine\Fixtures\MockClient as TestClient;
 
-class ProjectXmlTest extends \PHPUnit_Framework_TestCase
+class ProjectXmlTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var TestClient

--- a/test/Redmine/Tests/UrlTest.php
+++ b/test/Redmine/Tests/UrlTest.php
@@ -4,7 +4,7 @@ namespace Redmine\Tests;
 
 use Redmine\Fixtures\MockClient as TestUrlClient;
 
-class UrlTest extends \PHPUnit_Framework_TestCase
+class UrlTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var TestUrlClient

--- a/test/Redmine/Tests/UserXmlTest.php
+++ b/test/Redmine/Tests/UserXmlTest.php
@@ -4,7 +4,7 @@ namespace Redmine\Tests;
 
 use Redmine\Fixtures\MockClient as TestClient;
 
-class UserXmlTest extends \PHPUnit_Framework_TestCase
+class UserXmlTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var TestClient

--- a/test/Redmine/Tests/WikiXmlTest.php
+++ b/test/Redmine/Tests/WikiXmlTest.php
@@ -4,7 +4,7 @@ namespace Redmine\Tests;
 
 use Redmine\Fixtures\MockClient as TestClient;
 
-class WikiXmlTest extends \PHPUnit_Framework_TestCase
+class WikiXmlTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var TestClient


### PR DESCRIPTION
I've seen the broken tests and decided to take a look at them. So I've updated a few things in the testsuite. No production code were touched.

- Update composer requirements so <=PHP 5.6 uses PHPUnit 4.8.35 and PHP 7+ uses PHPUnit 6+
- Update the autoload from PSR-0 to PSR-4.
- Added autoload-dev with PSR-4, so the code for the tests in the `autoload.php` became unnecessary.
- Run tests with PHP 7.1

This PR will fix the broken tests.

To be honest: I have no idea how travis could load PHPUnit since last month. Imho the tests should have failed quiet earlier.