### PR TITLE
Update AbstractApi autoescaping values

### DIFF
--- a/lib/Redmine/Api/AbstractApi.php
+++ b/lib/Redmine/Api/AbstractApi.php
@@ -204,9 +204,6 @@ abstract class AbstractApi
                     $_values->addChild('value', $val);
                 }
             } else {
-                // as in Issue::buildXML method
-                // "addChild" does not escape text for XML value, but the setter does.
-                // http://stackoverflow.com/a/555039/99904
                 $_field->value = $field['value'];
             }
         }

--- a/lib/Redmine/Api/AbstractApi.php
+++ b/lib/Redmine/Api/AbstractApi.php
@@ -204,7 +204,10 @@ abstract class AbstractApi
                     $_values->addChild('value', $val);
                 }
             } else {
-                $_field->addChild('value', $field['value']);
+                // as in Issue::buildXML method
+                // "addChild" does not escape text for XML value, but the setter does.
+                // http://stackoverflow.com/a/555039/99904
+                $_field->value = $field['value'];
             }
         }
 

--- a/tests/Unit/Api/IssueTest.php
+++ b/tests/Unit/Api/IssueTest.php
@@ -687,6 +687,7 @@ class IssueTest extends \PHPUnit\Framework\TestCase
             'custom_fields' => [
                 ['id' => 225, 'value' => 'One Custom Field'],
                 ['id' => 25, 'value' => 'Second Custom Field'],
+                ['id' => 321, 'value' => 'http://test.local/?one=first&two=second'],
             ],
         ];
 
@@ -704,7 +705,8 @@ class IssueTest extends \PHPUnit\Framework\TestCase
                     $this->stringContains('<custom_fields type="array">'),
                     $this->stringContains('</custom_fields>'),
                     $this->stringContains('<custom_field id="225"><value>One Custom Field</value></custom_field>'),
-                    $this->stringContains('<custom_field id="25"><value>Second Custom Field</value></custom_field>')
+                    $this->stringContains('<custom_field id="25"><value>Second Custom Field</value></custom_field>'),
+                    $this->stringContains('<custom_field id="321"><value>http://test.local/?one=first&amp;two=second</value></custom_field>')
                 )
             );
 


### PR DESCRIPTION
While setting value for custom a custom field, "addChild" does not escape text for XML value, but the setter does.
Only when value is not multiple.