### PR TITLE
Fix file uploads

### DIFF
--- a/lib/Redmine/Client.php
+++ b/lib/Redmine/Client.php
@@ -573,7 +573,17 @@ class Client
         switch ($method) {
             case 'POST':
                 $this->setCurlOption(CURLOPT_POST, 1);
-                if (isset($data)) {
+
+                if ('/uploads.json' === $path || '/uploads.xml' === $path && isset($data) && is_file($data)) {
+                    $file = fopen($data, 'r');
+                    $size = filesize($data);
+                    $filedata = fread($file, $size);
+
+                    $this->setCurlOption(CURLOPT_POSTFIELDS, $filedata);
+                    $this->setCurlOption(CURLOPT_INFILE, $file);
+                    $this->setCurlOption(CURLOPT_INFILESIZE, $size);
+                }
+                elseif (isset($data)) {
                     $this->setCurlOption(CURLOPT_POSTFIELDS, $data);
                 }
                 break;


### PR DESCRIPTION
Attaching files to an issue does not work. Before this fix, the file redmine would attach to an issue would be empty because the curl opts to add the file are missing.
The necessary curl opts have been added for the file to be read into the body of the request.