### PR TITLE
Fix custom field file type export

### DIFF
--- a/src/Redmine/Api/AbstractApi.php
+++ b/src/Redmine/Api/AbstractApi.php
@@ -195,11 +195,17 @@ abstract class AbstractApi
             }
             $_field->addAttribute('id', $field['id']);
             if (is_array($field['value'])) {
-                $_field->addAttribute('multiple', 'true');
                 $_values = $_field->addChild('value');
-                $_values->addAttribute('type', 'array');
-                foreach ($field['value'] as $val) {
-                    $_values->addChild('value', $val);
+                if (array_key_exists('token', $field['value'])) {
+                    foreach ($field['value'] as $key => $val) {
+                        $_values->addChild($key, $val);
+                    }
+                } else {
+                    $_field->addAttribute('multiple', 'true');
+                    $_values->addAttribute('type', 'array');
+                    foreach ($field['value'] as $val) {
+                        $_values->addChild('value', $val);
+                    }
                 }
             } else {
                 $_field->value = $field['value'];


### PR DESCRIPTION
Custom field of file type is not working properly because the XML generated require an array where value must contain an array like ['token'=>"xxxyyyzzzz.."], but the current code is treating as a multi values field