### PR TITLE
fix is_file() input data have \0 issue

### DIFF
--- a/src/Redmine/Client.php
+++ b/src/Redmine/Client.php
@@ -602,7 +602,7 @@ class Client
         return
             (preg_match('/\/uploads.(json|xml)/i', $path)) &&
             isset($data) &&
-            is_file($data)
+            is_file(strval(str_replace("\0", "", $data))
         ;
     }
 


### PR DESCRIPTION
When $data is attachment content, maybe have \0 char in content, it will cause is_file() got warning message, maybe it's related with #227 

```
Warning: is_file() expects parameter 1 to be a valid path, string given in vendor/kbsali/redmine-api/src/Redmine/Client.php on line 605
```

So, I try to fix this issue.