### PR TITLE
Remote 'multiple' attribute set twice

### DIFF
--- a/src/Redmine/Api/AbstractApi.php
+++ b/src/Redmine/Api/AbstractApi.php
@@ -196,7 +196,6 @@ abstract class AbstractApi
                         $_values->addChild($key, $val);
                     }
                 } else {
-                    $_field->addAttribute('multiple', 'true');
                     $_values->addAttribute('type', 'array');
                     foreach ($field['value'] as $val) {
                         $_values->addChild('value', $val);


### PR DESCRIPTION
On recent PHP version,
we have an error 
> SimpleXMLElement::addAttribute(): Attribute already exists

because the "multiple" attribute is set at the line 192 and at the line 199.