### PR TITLE
Typed properties and bump to PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-   - 7.3
    - 7.4
    - 8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - This `CHANGELOG.md` file
 
+### Changed
+
+- Better type checking thanks to typed properties
+- Move `example.php` into new `docs` folder
+
+### Removed
+
+- Drop support for PHP 7.3
+
+### Fixed
+
+- `Redmine\Client::getCheckSslHost()` always returns as boolean
+
 ## [v1.7.0](https://github.com/kbsali/php-redmine-api/compare/v1.6.0...v1.7.0) - 2021-03-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed support for PHP 5.6, 7.0, 7.1 and 7.2
 
-## [v1.5.22](https://github.com/kbsali/php-redmine-api/compare/v1.5.21...v1.5.22) - 2021-01-02
+## [v1.5.22](https://github.com/kbsali/php-redmine-api/compare/v1.5.21...v1.5.22) - 2020-08-07
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ A possible solution to this would be to create an extra APIs implementing the mi
 
 ## Requirements
 
-* PHP ^7.3 || ^8.0
+* PHP ^7.4 || ^8.0
 * The PHP [cURL](http://php.net/manual/en/book.curl.php) extension
 * The PHP [SimpleXML](http://php.net/manual/en/book.simplexml.php) extension
 * The PHP [JSON](http://php.net/manual/en/book.json.php) extension

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "ext-curl": "*",
         "ext-simplexml": "*",
         "ext-json": "*",

--- a/src/Redmine/Api/AbstractApi.php
+++ b/src/Redmine/Api/AbstractApi.php
@@ -49,13 +49,14 @@ abstract class AbstractApi implements Api
         $this->client->requestGet($path);
 
         $body = $this->client->getLastResponseBody();
+        $contentType = $this->client->getLastResponseContentType();
 
         // if response is XML, return a SimpleXMLElement object
-        if ($body !== '' && 0 === strpos($this->client->getLastResponseContentType(), 'application/xml')) {
+        if ($body !== '' && 0 === strpos($contentType, 'application/xml')) {
             return new SimpleXMLElement($body);
         }
 
-        if ($decodeIfJson === true && $body !== '' && 0 === strpos($this->client->getLastResponseContentType(), 'application/json')) {
+        if ($decodeIfJson === true && $body !== '' && 0 === strpos($contentType, 'application/json')) {
             try {
                 return json_decode($body, true, 512, \JSON_THROW_ON_ERROR);
             } catch (JsonException $e) {

--- a/src/Redmine/Client/Client.php
+++ b/src/Redmine/Client/Client.php
@@ -11,7 +11,7 @@ use Redmine\Api;
 interface Client
 {
     /**
-     * @throws InvalidArgumentException
+     * @throws InvalidArgumentException if $name is not a valid api name
      */
     public function getApi(string $name): Api;
 

--- a/src/Redmine/Client/ClientApiTrait.php
+++ b/src/Redmine/Client/ClientApiTrait.php
@@ -12,12 +12,9 @@ use Redmine\Api;
  */
 trait ClientApiTrait
 {
-    /**
-     * @var array Api[]
-     */
-    private $apiInstances = [];
+    private array $apiInstances = [];
 
-    private $apiClassnames = [
+    private array $apiClassnames = [
         'attachment' => 'Attachment',
         'group' => 'Group',
         'custom_fields' => 'CustomField',

--- a/src/Redmine/Client/Psr18Client.php
+++ b/src/Redmine/Client/Psr18Client.php
@@ -22,11 +22,11 @@ final class Psr18Client implements Client
     private string $url;
     private string $apikeyOrUsername;
     private ?string $password;
-    private ?string $impersonateUser;
+    private ?string $impersonateUser = null;
     private ClientInterface $httpClient;
     private ServerRequestFactoryInterface $requestFactory;
     private StreamFactoryInterface $streamFactory;
-    private ?ResponseInterface $lastResponse;
+    private ?ResponseInterface $lastResponse = null;
 
     /**
      * $apikeyOrUsername should be your ApiKey, but it could also be your username.
@@ -46,8 +46,6 @@ final class Psr18Client implements Client
         $this->url = $url;
         $this->apikeyOrUsername = $apikeyOrUsername;
         $this->password = $password;
-        $this->impersonateUser = null;
-        $this->lastResponse = null;
     }
 
     /**

--- a/src/Redmine/Client/Psr18Client.php
+++ b/src/Redmine/Client/Psr18Client.php
@@ -19,49 +19,18 @@ final class Psr18Client implements Client
 {
     use ClientApiTrait;
 
-    /**
-     * @var string
-     */
-    private $url;
-
-    /**
-     * @var string
-     */
-    private $apikeyOrUsername;
-
-    /**
-     * @var string|null
-     */
-    private $pass;
-
-    /**
-     * @var string|null
-     */
-    private $impersonateUser;
-
-    /**
-     * @var ClientInterface
-     */
-    private $httpClient;
-
-    /**
-     * @var ServerRequestFactoryInterface
-     */
-    private $requestFactory;
-
-    /**
-     * @var StreamFactoryInterface
-     */
-    private $streamFactory;
-
-    /**
-     * @var ResponseInterface|null
-     */
-    private $lastResponse;
+    private string $url;
+    private string $apikeyOrUsername;
+    private ?string $password;
+    private ?string $impersonateUser;
+    private ClientInterface $httpClient;
+    private ServerRequestFactoryInterface $requestFactory;
+    private StreamFactoryInterface $streamFactory;
+    private ?ResponseInterface $lastResponse;
 
     /**
      * $apikeyOrUsername should be your ApiKey, but it could also be your username.
-     * $pass needs to be set if a username is given (not recommended).
+     * $password needs to be set if a username is given (not recommended).
      */
     public function __construct(
         ClientInterface $httpClient,
@@ -69,14 +38,16 @@ final class Psr18Client implements Client
         StreamFactoryInterface $streamFactory,
         string $url,
         string $apikeyOrUsername,
-        string $pass = null
+        string $password = null
     ) {
         $this->httpClient = $httpClient;
         $this->requestFactory = $requestFactory;
         $this->streamFactory = $streamFactory;
         $this->url = $url;
         $this->apikeyOrUsername = $apikeyOrUsername;
-        $this->pass = $pass;
+        $this->password = $password;
+        $this->impersonateUser = null;
+        $this->lastResponse = null;
     }
 
     /**
@@ -195,10 +166,10 @@ final class Psr18Client implements Client
 
         // Set Authentication header
         // @see https://www.redmine.org/projects/redmine/wiki/Rest_api#Authentication
-        if ($this->pass !== null) {
+        if ($this->password !== null) {
             $request = $request->withHeader(
                 'Authorization',
-                'Basic ' . base64_encode($this->apikeyOrUsername . ':' . $this->pass)
+                'Basic ' . base64_encode($this->apikeyOrUsername . ':' . $this->password)
             );
         } else {
             $request = $request->withHeader('X-Redmine-API-Key', $this->apikeyOrUsername);

--- a/tests/Integration/Psr18ClientRequestGenerationTest.php
+++ b/tests/Integration/Psr18ClientRequestGenerationTest.php
@@ -172,8 +172,8 @@ class Psr18ClientRequestGenerationTest extends TestCase
                 'X-Redmine-API-Key: access_token'.\PHP_EOL.
                 'Content-Type: application/octet-stream'.\PHP_EOL.
                 \PHP_EOL.
-                'This is a test file.'.\PHP_EOL.
-                'It will be needed for testing file uploads.'.\PHP_EOL
+                'This is a test file.'."\n".
+                'It will be needed for testing file uploads.'."\n"
             ],
             [
                 // Test fileupload with file path to image

--- a/tests/Unit/Api/CustomFieldTest.php
+++ b/tests/Unit/Api/CustomFieldTest.php
@@ -116,7 +116,7 @@ class CustomFieldTest extends TestCase
         $client->expects($this->exactly(3))
             ->method('getLastResponseBody')
             ->willReturn($response);
-        $client->expects($this->exactly(6))
+        $client->expects($this->exactly(3))
             ->method('getLastResponseContentType')
             ->willReturn('application/json');
 
@@ -164,7 +164,7 @@ class CustomFieldTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
-        $client->expects($this->exactly(2))
+        $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
             ->willReturn('application/json');
 
@@ -206,7 +206,7 @@ class CustomFieldTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
-        $client->expects($this->exactly(2))
+        $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
             ->willReturn('application/json');
 
@@ -245,7 +245,7 @@ class CustomFieldTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
-        $client->expects($this->exactly(2))
+        $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
             ->willReturn('application/json');
 
@@ -285,7 +285,7 @@ class CustomFieldTest extends TestCase
         $client->expects($this->exactly(2))
             ->method('getLastResponseBody')
             ->willReturn($response);
-        $client->expects($this->exactly(4))
+        $client->expects($this->exactly(2))
             ->method('getLastResponseContentType')
             ->willReturn('application/json');
 
@@ -321,7 +321,7 @@ class CustomFieldTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
-        $client->expects($this->exactly(2))
+        $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
             ->willReturn('application/json');
 

--- a/tests/Unit/Api/GroupTest.php
+++ b/tests/Unit/Api/GroupTest.php
@@ -110,7 +110,7 @@ class GroupTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
-        $client->expects($this->exactly(2))
+        $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
             ->willReturn('application/json');
 
@@ -149,7 +149,7 @@ class GroupTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
-        $client->expects($this->exactly(2))
+        $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
             ->willReturn('application/json');
 
@@ -189,7 +189,7 @@ class GroupTest extends TestCase
         $client->expects($this->exactly(2))
             ->method('getLastResponseBody')
             ->willReturn($response);
-        $client->expects($this->exactly(4))
+        $client->expects($this->exactly(2))
             ->method('getLastResponseContentType')
             ->willReturn('application/json');
 

--- a/tests/Unit/Api/IssueCategoryTest.php
+++ b/tests/Unit/Api/IssueCategoryTest.php
@@ -112,7 +112,7 @@ class IssueCategoryTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
-        $client->expects($this->exactly(2))
+        $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
             ->willReturn('application/json');
 
@@ -151,7 +151,7 @@ class IssueCategoryTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
-        $client->expects($this->exactly(2))
+        $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
             ->willReturn('application/json');
 
@@ -191,7 +191,7 @@ class IssueCategoryTest extends TestCase
         $client->expects($this->exactly(2))
             ->method('getLastResponseBody')
             ->willReturn($response);
-        $client->expects($this->exactly(4))
+        $client->expects($this->exactly(2))
             ->method('getLastResponseContentType')
             ->willReturn('application/json');
 
@@ -338,7 +338,7 @@ class IssueCategoryTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
-        $client->expects($this->exactly(2))
+        $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
             ->willReturn('application/json');
 

--- a/tests/Unit/Api/IssueRelationTest.php
+++ b/tests/Unit/Api/IssueRelationTest.php
@@ -107,7 +107,7 @@ class IssueRelationTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
-        $client->expects($this->exactly(2))
+        $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
             ->willReturn('application/json');
 

--- a/tests/Unit/Api/IssueStatusTest.php
+++ b/tests/Unit/Api/IssueStatusTest.php
@@ -109,7 +109,7 @@ class IssueStatusTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
-        $client->expects($this->exactly(2))
+        $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
             ->willReturn('application/json');
 
@@ -148,7 +148,7 @@ class IssueStatusTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
-        $client->expects($this->exactly(2))
+        $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
             ->willReturn('application/json');
 
@@ -188,7 +188,7 @@ class IssueStatusTest extends TestCase
         $client->expects($this->exactly(2))
             ->method('getLastResponseBody')
             ->willReturn($response);
-        $client->expects($this->exactly(4))
+        $client->expects($this->exactly(2))
             ->method('getLastResponseContentType')
             ->willReturn('application/json');
 
@@ -224,7 +224,7 @@ class IssueStatusTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
-        $client->expects($this->exactly(2))
+        $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
             ->willReturn('application/json');
 

--- a/tests/Unit/Api/ProjectTest.php
+++ b/tests/Unit/Api/ProjectTest.php
@@ -210,7 +210,7 @@ class ProjectTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
-        $client->expects($this->exactly(2))
+        $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
             ->willReturn('application/json');
 
@@ -249,7 +249,7 @@ class ProjectTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
-        $client->expects($this->exactly(2))
+        $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
             ->willReturn('application/json');
 
@@ -289,7 +289,7 @@ class ProjectTest extends TestCase
         $client->expects($this->exactly(2))
             ->method('getLastResponseBody')
             ->willReturn($response);
-        $client->expects($this->exactly(4))
+        $client->expects($this->exactly(2))
             ->method('getLastResponseContentType')
             ->willReturn('application/json');
 
@@ -325,7 +325,7 @@ class ProjectTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
-        $client->expects($this->exactly(2))
+        $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
             ->willReturn('application/json');
 

--- a/tests/Unit/Api/RoleTest.php
+++ b/tests/Unit/Api/RoleTest.php
@@ -109,7 +109,7 @@ class RoleTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
-        $client->expects($this->exactly(2))
+        $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
             ->willReturn('application/json');
 
@@ -148,7 +148,7 @@ class RoleTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
-        $client->expects($this->exactly(2))
+        $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
             ->willReturn('application/json');
 
@@ -188,7 +188,7 @@ class RoleTest extends TestCase
         $client->expects($this->exactly(2))
             ->method('getLastResponseBody')
             ->willReturn($response);
-        $client->expects($this->exactly(4))
+        $client->expects($this->exactly(2))
             ->method('getLastResponseContentType')
             ->willReturn('application/json');
 

--- a/tests/Unit/Api/TimeEntryActivityTest.php
+++ b/tests/Unit/Api/TimeEntryActivityTest.php
@@ -101,7 +101,7 @@ class TimeEntryActivityTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
-        $client->expects($this->exactly(2))
+        $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
             ->willReturn('application/json');
 
@@ -130,7 +130,7 @@ class TimeEntryActivityTest extends TestCase
         $client->expects($this->exactly(2))
             ->method('getLastResponseBody')
             ->willReturn($response);
-        $client->expects($this->exactly(4))
+        $client->expects($this->exactly(2))
             ->method('getLastResponseContentType')
             ->willReturn('application/json');
 
@@ -156,7 +156,7 @@ class TimeEntryActivityTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
-        $client->expects($this->exactly(2))
+        $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
             ->willReturn('application/json');
 

--- a/tests/Unit/Api/TrackerTest.php
+++ b/tests/Unit/Api/TrackerTest.php
@@ -109,7 +109,7 @@ class TrackerTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
-        $client->expects($this->exactly(2))
+        $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
             ->willReturn('application/json');
 
@@ -148,7 +148,7 @@ class TrackerTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
-        $client->expects($this->exactly(2))
+        $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
             ->willReturn('application/json');
 
@@ -188,7 +188,7 @@ class TrackerTest extends TestCase
         $client->expects($this->exactly(2))
             ->method('getLastResponseBody')
             ->willReturn($response);
-        $client->expects($this->exactly(4))
+        $client->expects($this->exactly(2))
             ->method('getLastResponseContentType')
             ->willReturn('application/json');
 
@@ -224,7 +224,7 @@ class TrackerTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
-        $client->expects($this->exactly(2))
+        $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
             ->willReturn('application/json');
 

--- a/tests/Unit/Api/UserTest.php
+++ b/tests/Unit/Api/UserTest.php
@@ -73,7 +73,7 @@ class UserTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
-        $client->expects($this->exactly(2))
+        $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
             ->willReturn('application/json');
 
@@ -590,7 +590,7 @@ class UserTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
-        $client->expects($this->exactly(2))
+        $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
             ->willReturn('application/json');
 
@@ -629,7 +629,7 @@ class UserTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
-        $client->expects($this->exactly(2))
+        $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
             ->willReturn('application/json');
 
@@ -669,7 +669,7 @@ class UserTest extends TestCase
         $client->expects($this->exactly(2))
             ->method('getLastResponseBody')
             ->willReturn($response);
-        $client->expects($this->exactly(4))
+        $client->expects($this->exactly(2))
             ->method('getLastResponseContentType')
             ->willReturn('application/json');
 

--- a/tests/Unit/Api/VersionTest.php
+++ b/tests/Unit/Api/VersionTest.php
@@ -516,10 +516,10 @@ class VersionTest extends TestCase
             ->method('requestGet')
             ->with('/projects/5/versions.json')
             ->willReturn(true);
-        $client->expects($this->once())
+        $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
-        $client->expects($this->exactly(2))
+        $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
             ->willReturn('application/json');
 
@@ -553,10 +553,10 @@ class VersionTest extends TestCase
             ->method('requestGet')
             ->with('/projects/5/versions.json')
             ->willReturn(true);
-        $client->expects($this->once())
+        $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
-        $client->expects($this->exactly(2))
+        $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
             ->willReturn('application/json');
 
@@ -590,10 +590,10 @@ class VersionTest extends TestCase
             ->method('requestGet')
             ->with('/projects/5/versions.json')
             ->willReturn(true);
-        $client->expects($this->once())
+        $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
-        $client->expects($this->exactly(2))
+        $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
             ->willReturn('application/json');
 
@@ -631,7 +631,7 @@ class VersionTest extends TestCase
         $client->expects($this->exactly(2))
             ->method('getLastResponseBody')
             ->willReturn($response);
-        $client->expects($this->exactly(4))
+        $client->expects($this->exactly(2))
             ->method('getLastResponseContentType')
             ->willReturn('application/json');
 
@@ -664,10 +664,10 @@ class VersionTest extends TestCase
                 $this->stringStartsWith('/projects/5/versions.json')
             )
             ->willReturn(true);
-        $client->expects($this->once())
+        $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
-        $client->expects($this->exactly(2))
+        $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
             ->willReturn('application/json');
 

--- a/tests/Unit/ClientTest.php
+++ b/tests/Unit/ClientTest.php
@@ -178,7 +178,7 @@ class ClientTest extends TestCase
         $this->assertInstanceOf('Redmine\Client', $client->setCheckSslHost());
         $this->assertFalse($client->getCheckSslHost());
         $this->assertInstanceOf('Redmine\Client', $client->setCheckSslHost(true));
-        $this->assertSame(2, $client->getCheckSslHost());
+        $this->assertSame(true, $client->getCheckSslHost());
         $this->assertInstanceOf('Redmine\Client', $client->setCheckSslHost(false));
         $this->assertFalse($client->getCheckSslHost());
     }


### PR DESCRIPTION
This PR will introduces typed properties wherever possible. This way I found and fixed a small inconsistency in `Redmine\Client::getCheckSslHost()`.

Most API classes also have private properties but they could have multiple types like array, string or SimpleXMLElement. I've left protected properties out for BC reasons. 

Typed properties were added with PHP 7.4, so I've also bumped the required PHP version.

This refs:
- https://github.com/kbsali/php-redmine-api/projects/2#card-57585718
- https://github.com/kbsali/php-redmine-api/projects/2#card-57585764