### PR TITLE
Add deprecation warnings in Redmine\Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Redmine\Client::getCheckSslHost()` always returns as boolean
 
+### Deprecated
+
+- `Redmine\Client` is deprecated, use `Redmine\Client\NativeCurlClient` or `Redmine\Client\Psr18Client` instead
+- Magic getter in `Redmine\Client` is deprecated, use `Redmine\Client::getApi()` instead
+- `Redmine\Client::api()` is deprecated, use `Redmine\Client::getApi()` instead
+- `Redmine\Client::get()` is deprecated, use `Redmine\Client::requestGet()` instead
+- `Redmine\Client::post()` is deprecated, use `Redmine\Client::requestPost()` instead
+- `Redmine\Client::put()` is deprecated, use `Redmine\Client::requestPut()` instead
+- `Redmine\Client::delete()` is deprecated, use `Redmine\Client::requestDelete()` instead
+- `Redmine\Client::setCheckSslCertificate()` is deprecated, use `Redmine\Client::setCurlOption()` instead
+- `Redmine\Client::setCheckSslHost()` is deprecated, use `Redmine\Client::setCurlOption()` instead
+- `Redmine\Client::setSslVersion()` is deprecated, use `Redmine\Client::setCurlOption()` instead
+- `Redmine\Client::setUseHttpAuth()` is deprecated, use `Redmine\Client::setCurlOption()` instead
+- `Redmine\Client::setPort()` is deprecated, use `Redmine\Client::setCurlOption()` instead
+- `Redmine\Client::getResponseCode()` is deprecated, use `Redmine\Client::getLastResponseStatusCode()` instead
+- `Redmine\Client::setImpersonateUser()` is deprecated, use `Redmine\Client::startImpersonateUser()` and `Redmine\Client::stopImpersonateUser()` instead
+- `Redmine\Client::setCustomHost()` is deprecated, use `Redmine\Client::setCurlOption()` instead
+- `Redmine\Client::getUrl()` is deprecated, you should stop using it
+- `Redmine\Client::decode()` is deprecated, you should stop using it
+- `Redmine\Client::getCheckSslCertificate()` is deprecated, you should stop using it
+- `Redmine\Client::getCheckSslHost()` is deprecated, you should stop using it
+- `Redmine\Client::getSslVersion()` is deprecated, you should stop using it
+- `Redmine\Client::getUseHttpAuth()` is deprecated, you should stop using it
+- `Redmine\Client::getPort()` is deprecated, you should stop using it
+- `Redmine\Client::getImpersonateUser()` is deprecated, you should stop using it
+- `Redmine\Client::getCustomHost()` is deprecated, you should stop using it
+- `Redmine\Client::getCurlOptions()` is deprecated, you should stop using it
+- `Redmine\Client::prepareRequest()` is deprecated, you should stop using it
+- `Redmine\Client::processCurlResponse()` is deprecated, you should stop using it
+- `Redmine\Client::runRequest()` is deprecated, you should stop using it
+
 ## [v1.7.0](https://github.com/kbsali/php-redmine-api/compare/v1.6.0...v1.7.0) - 2021-03-22
 
 ### Added

--- a/docs/migrate-to-nativecurlclient.md
+++ b/docs/migrate-to-nativecurlclient.md
@@ -107,7 +107,7 @@ This example shows how you can parse the response body of a DELETE request.
 
 ```diff
 -$dataAsString = $this->client->delete($path);
-+$this->client->requestDelte($path);
++$this->client->requestDelete($path);
 +$dataAsString = $this->client->getLastResponseBody();
 ```
 
@@ -237,7 +237,7 @@ test your code without errors and now simply switch the client.
 ```diff
 // Instantiate with ApiKey
 -$client = new \Redmine\Client(
-+$client = new \Redmine\Client\Prs18Client(
++$client = new \Redmine\Client\NativeCurlClient(
     'https://redmine.example.com',
     '1234567890abcdfgh'
 );

--- a/src/Redmine/Client.php
+++ b/src/Redmine/Client.php
@@ -99,7 +99,7 @@ class Client implements ClientInterface
     /**
      * PHP getter magic method.
      *
-     * @deprecated
+     * @deprecated use getApi() instead
      *
      * @param string $name
      *
@@ -109,13 +109,15 @@ class Client implements ClientInterface
      */
     public function __get($name)
     {
-        return $this->api($name);
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated, use getApi() instead.', E_USER_DEPRECATED);
+
+        return $this->getApi(strval($name));
     }
 
     /**
      * @param string $name
      *
-     * @deprecated
+     * @deprecated use getApi() instead
      *
      * @throws \InvalidArgumentException
      *
@@ -123,6 +125,8 @@ class Client implements ClientInterface
      */
     public function api($name)
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated, use getApi() instead.', E_USER_DEPRECATED);
+
         return $this->getApi(strval($name));
     }
 
@@ -135,6 +139,8 @@ class Client implements ClientInterface
      */
     public function getUrl()
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated. You should stop using it, as it will be removed in the future.', E_USER_DEPRECATED);
+
         return $this->url;
     }
 
@@ -205,7 +211,7 @@ class Client implements ClientInterface
     /**
      * HTTP GETs a json $path and tries to decode it.
      *
-     * @deprecated
+     * @deprecated use requestGet() instead
      *
      * @param string $path
      * @param bool   $decode
@@ -214,6 +220,8 @@ class Client implements ClientInterface
      */
     public function get($path, $decode = true)
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated, use requestGet() instead.', E_USER_DEPRECATED);
+
         if (false === $json = $this->runRequest($path, 'GET')) {
             return false;
         }
@@ -239,6 +247,8 @@ class Client implements ClientInterface
      */
     public function decode($json)
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated. You should stop using it, as it will be removed in the future.', E_USER_DEPRECATED);
+
         if (empty($json)) {
             return '';
         }
@@ -256,7 +266,7 @@ class Client implements ClientInterface
     /**
      * HTTP POSTs $params to $path.
      *
-     * @deprecated
+     * @deprecated use requestPost() instead
      *
      * @param string $path
      * @param string $data
@@ -265,13 +275,15 @@ class Client implements ClientInterface
      */
     public function post($path, $data)
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated, use requestPost() instead.', E_USER_DEPRECATED);
+
         return $this->runRequest($path, 'POST', $data);
     }
 
     /**
      * HTTP PUTs $params to $path.
      *
-     * @deprecated
+     * @deprecated use requestPut() instead
      *
      * @param string $path
      * @param string $data
@@ -280,13 +292,15 @@ class Client implements ClientInterface
      */
     public function put($path, $data)
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated, use requestPut() instead.', E_USER_DEPRECATED);
+
         return $this->runRequest($path, 'PUT', $data);
     }
 
     /**
      * HTTP PUTs $params to $path.
      *
-     * @deprecated
+     * @deprecated use requestDelete() instead
      *
      * @param string $path
      *
@@ -294,13 +308,15 @@ class Client implements ClientInterface
      */
     public function delete($path)
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated, use requestDelete() instead.', E_USER_DEPRECATED);
+
         return $this->runRequest($path, 'DELETE');
     }
 
     /**
      * Turns on/off ssl certificate check.
      *
-     * @deprecated
+     * @deprecated use setCurlOption() instead
      *
      * @param bool $check
      *
@@ -308,6 +324,8 @@ class Client implements ClientInterface
      */
     public function setCheckSslCertificate($check = false)
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated, use setCurlOption() instead.', E_USER_DEPRECATED);
+
         $this->checkSslCertificate = $check;
 
         return $this;
@@ -322,13 +340,15 @@ class Client implements ClientInterface
      */
     public function getCheckSslCertificate()
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated. You should stop using it, as it will be removed in the future.', E_USER_DEPRECATED);
+
         return $this->checkSslCertificate;
     }
 
     /**
      * Turns on/off ssl host certificate check.
      *
-     * @deprecated
+     * @deprecated use setCurlOption() instead
      *
      * @param bool $check
      *
@@ -336,6 +356,8 @@ class Client implements ClientInterface
      */
     public function setCheckSslHost($check = false)
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated, use setCurlOption() instead.', E_USER_DEPRECATED);
+
         $this->checkSslHost = (bool) $check;
 
         return $this;
@@ -350,13 +372,15 @@ class Client implements ClientInterface
      */
     public function getCheckSslHost()
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated. You should stop using it, as it will be removed in the future.', E_USER_DEPRECATED);
+
         return $this->checkSslHost;
     }
 
     /**
      * Forces the SSL/TLS version to use.
      *
-     * @deprecated
+     * @deprecated use setCurlOption() instead
      * @see http://curl.haxx.se/libcurl/c/CURLOPT_SSLVERSION.html
      *
      * @param int $sslVersion
@@ -365,6 +389,8 @@ class Client implements ClientInterface
      */
     public function setSslVersion($sslVersion = 0)
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated, use setCurlOption() instead.', E_USER_DEPRECATED);
+
         $this->sslVersion = $sslVersion;
 
         return $this;
@@ -379,13 +405,15 @@ class Client implements ClientInterface
      */
     public function getSslVersion()
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated. You should stop using it, as it will be removed in the future.', E_USER_DEPRECATED);
+
         return $this->sslVersion;
     }
 
     /**
      * Turns on/off http auth.
      *
-     * @deprecated
+     * @deprecated use setCurlOption() instead
      *
      * @param bool $use
      *
@@ -393,6 +421,8 @@ class Client implements ClientInterface
      */
     public function setUseHttpAuth($use = true)
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated, use setCurlOption() instead.', E_USER_DEPRECATED);
+
         $this->useHttpAuth = $use;
 
         return $this;
@@ -407,13 +437,15 @@ class Client implements ClientInterface
      */
     public function getUseHttpAuth()
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated. You should stop using it, as it will be removed in the future.', E_USER_DEPRECATED);
+
         return $this->useHttpAuth;
     }
 
     /**
      * Set the port of the connection.
      *
-     * @deprecated
+     * @deprecated use setCurlOption() instead
      *
      * @param int $port
      *
@@ -421,6 +453,8 @@ class Client implements ClientInterface
      */
     public function setPort($port = null)
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated, use setCurlOption() instead.', E_USER_DEPRECATED);
+
         if (null !== $port) {
             $this->port = (int) $port;
         }
@@ -431,13 +465,15 @@ class Client implements ClientInterface
     /**
      * Returns Redmine response code.
      *
-     * @deprecated
+     * @deprecated use getLastResponseStatusCode() instead
      *
      * @return int
      */
     public function getResponseCode()
     {
-        return (int) $this->responseCode;
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated, use getLastResponseStatusCode() instead.', E_USER_DEPRECATED);
+
+        return (int) $this->getLastResponseStatusCode();
     }
 
     /**
@@ -451,11 +487,13 @@ class Client implements ClientInterface
      */
     public function getPort()
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated. You should stop using it, as it will be removed in the future.', E_USER_DEPRECATED);
+
         if (null !== $this->port) {
             return $this->port;
         }
 
-        $tmp = parse_url($this->getUrl());
+        $tmp = parse_url($this->url);
         if (isset($tmp['port'])) {
             $this->setPort($tmp['port']);
         } elseif (isset($tmp['scheme'])) {
@@ -486,7 +524,7 @@ class Client implements ClientInterface
      * Sets to an existing username so api calls can be
      * impersonated to this user.
      *
-     * @deprecated
+     * @deprecated use startImpersonateUser() and stopImpersonateUser() instead
      *
      * @param string|null $username
      *
@@ -495,8 +533,12 @@ class Client implements ClientInterface
     public function setImpersonateUser($username = null)
     {
         if (null === $username) {
+            @trigger_error('The ' . __METHOD__ . ' method is deprecated, use stopImpersonateUser() instead.', E_USER_DEPRECATED);
+
             $this->stopImpersonateUser();
         } else {
+            @trigger_error('The ' . __METHOD__ . ' method is deprecated, use startImpersonateUser() instead.', E_USER_DEPRECATED);
+
             $this->startImpersonateUser($username);
         }
 
@@ -512,6 +554,8 @@ class Client implements ClientInterface
      */
     public function getImpersonateUser()
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated. You should stop using it, as it will be removed in the future.', E_USER_DEPRECATED);
+
         return $this->impersonateUser;
     }
 
@@ -524,6 +568,8 @@ class Client implements ClientInterface
      */
     public function setCustomHost($customHost = null)
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated, use setCurlOption() instead.', E_USER_DEPRECATED);
+
         $this->customHost = $customHost;
 
         return $this;
@@ -536,6 +582,8 @@ class Client implements ClientInterface
      */
     public function getCustomHost()
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated. You should stop using it, as it will be removed in the future.', E_USER_DEPRECATED);
+
         return $this->customHost;
     }
 
@@ -577,6 +625,8 @@ class Client implements ClientInterface
      */
     public function getCurlOptions()
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated. You should stop using it, as it will be removed in the future.', E_USER_DEPRECATED);
+
         return $this->curlOptions;
     }
 
@@ -593,6 +643,8 @@ class Client implements ClientInterface
      */
     public function prepareRequest($path, $method = 'GET', $data = '')
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated. You should stop using it, as it will be removed in the future.', E_USER_DEPRECATED);
+
         $this->responseCode = 0;
         $this->responseContentType = '';
         $this->responseBody = '';
@@ -724,6 +776,8 @@ class Client implements ClientInterface
      */
     public function processCurlResponse($response, $contentType)
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated. You should stop using it, as it will be removed in the future.', E_USER_DEPRECATED);
+
         if ($response) {
             // if response is XML, return an SimpleXMLElement object
             if (0 === strpos($contentType, 'application/xml')) {
@@ -751,6 +805,8 @@ class Client implements ClientInterface
      */
     protected function runRequest($path, $method = 'GET', $data = '')
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated. You should stop using it, as it will be removed in the future.', E_USER_DEPRECATED);
+
         $curl = $this->prepareRequest($path, $method, $data);
 
         // use HTTP 1.1

--- a/src/Redmine/Client.php
+++ b/src/Redmine/Client.php
@@ -5,6 +5,16 @@ namespace Redmine;
 use Redmine\Client\Client as ClientInterface;
 use Redmine\Client\ClientApiTrait;
 
+@trigger_error(
+    sprintf(
+        'The "%s" class is deprecated, use "%s" or "%s" instead.',
+        'Redmine\Client',
+        'Redmine\Client\NativeCurlClient',
+        'Redmine\Client\Psr18Client'
+    ),
+    E_USER_DEPRECATED
+);
+
 /**
  * Simple PHP Redmine client.
  *
@@ -705,7 +715,7 @@ class Client implements ClientInterface
                 break;
         }
         // Set all cURL options to the current cURL resource
-        curl_setopt_array($curl, $this->getCurlOptions());
+        curl_setopt_array($curl, $this->curlOptions);
 
         return $curl;
     }

--- a/src/Redmine/Client.php
+++ b/src/Redmine/Client.php
@@ -18,6 +18,8 @@ use Redmine\Client\ClientApiTrait;
 /**
  * Simple PHP Redmine client.
  *
+ * @deprecated `Redmine\Client` is deprecated, use `Redmine\Client\NativeCurlClient` or `Redmine\Client\Psr18Client` instead
+ *
  * @author Kevin Saliou <kevin at saliou dot name>
  * Website: http://github.com/kbsali/php-redmine-api
  *
@@ -119,7 +121,7 @@ class Client implements ClientInterface
      */
     public function __get($name)
     {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated, use getApi() instead.', E_USER_DEPRECATED);
+        @trigger_error('The '.__METHOD__.' method is deprecated, use getApi() instead.', E_USER_DEPRECATED);
 
         return $this->getApi(strval($name));
     }
@@ -135,7 +137,7 @@ class Client implements ClientInterface
      */
     public function api($name)
     {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated, use getApi() instead.', E_USER_DEPRECATED);
+        @trigger_error('The '.__METHOD__.' method is deprecated, use getApi() instead.', E_USER_DEPRECATED);
 
         return $this->getApi(strval($name));
     }
@@ -149,7 +151,7 @@ class Client implements ClientInterface
      */
     public function getUrl()
     {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated. You should stop using it, as it will be removed in the future.', E_USER_DEPRECATED);
+        @trigger_error('The '.__METHOD__.' method is deprecated. You should stop using it, as it will be removed in the future.', E_USER_DEPRECATED);
 
         return $this->url;
     }
@@ -230,7 +232,7 @@ class Client implements ClientInterface
      */
     public function get($path, $decode = true)
     {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated, use requestGet() instead.', E_USER_DEPRECATED);
+        @trigger_error('The '.__METHOD__.' method is deprecated, use requestGet() instead.', E_USER_DEPRECATED);
 
         if (false === $json = $this->runRequest($path, 'GET')) {
             return false;
@@ -257,7 +259,7 @@ class Client implements ClientInterface
      */
     public function decode($json)
     {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated. You should stop using it, as it will be removed in the future.', E_USER_DEPRECATED);
+        @trigger_error('The '.__METHOD__.' method is deprecated. You should stop using it, as it will be removed in the future.', E_USER_DEPRECATED);
 
         if (empty($json)) {
             return '';
@@ -285,7 +287,7 @@ class Client implements ClientInterface
      */
     public function post($path, $data)
     {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated, use requestPost() instead.', E_USER_DEPRECATED);
+        @trigger_error('The '.__METHOD__.' method is deprecated, use requestPost() instead.', E_USER_DEPRECATED);
 
         return $this->runRequest($path, 'POST', $data);
     }
@@ -302,7 +304,7 @@ class Client implements ClientInterface
      */
     public function put($path, $data)
     {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated, use requestPut() instead.', E_USER_DEPRECATED);
+        @trigger_error('The '.__METHOD__.' method is deprecated, use requestPut() instead.', E_USER_DEPRECATED);
 
         return $this->runRequest($path, 'PUT', $data);
     }
@@ -318,7 +320,7 @@ class Client implements ClientInterface
      */
     public function delete($path)
     {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated, use requestDelete() instead.', E_USER_DEPRECATED);
+        @trigger_error('The '.__METHOD__.' method is deprecated, use requestDelete() instead.', E_USER_DEPRECATED);
 
         return $this->runRequest($path, 'DELETE');
     }
@@ -334,7 +336,7 @@ class Client implements ClientInterface
      */
     public function setCheckSslCertificate($check = false)
     {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated, use setCurlOption() instead.', E_USER_DEPRECATED);
+        @trigger_error('The '.__METHOD__.' method is deprecated, use setCurlOption() instead.', E_USER_DEPRECATED);
 
         $this->checkSslCertificate = $check;
 
@@ -350,7 +352,7 @@ class Client implements ClientInterface
      */
     public function getCheckSslCertificate()
     {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated. You should stop using it, as it will be removed in the future.', E_USER_DEPRECATED);
+        @trigger_error('The '.__METHOD__.' method is deprecated. You should stop using it, as it will be removed in the future.', E_USER_DEPRECATED);
 
         return $this->checkSslCertificate;
     }
@@ -366,7 +368,7 @@ class Client implements ClientInterface
      */
     public function setCheckSslHost($check = false)
     {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated, use setCurlOption() instead.', E_USER_DEPRECATED);
+        @trigger_error('The '.__METHOD__.' method is deprecated, use setCurlOption() instead.', E_USER_DEPRECATED);
 
         $this->checkSslHost = (bool) $check;
 
@@ -382,7 +384,7 @@ class Client implements ClientInterface
      */
     public function getCheckSslHost()
     {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated. You should stop using it, as it will be removed in the future.', E_USER_DEPRECATED);
+        @trigger_error('The '.__METHOD__.' method is deprecated. You should stop using it, as it will be removed in the future.', E_USER_DEPRECATED);
 
         return $this->checkSslHost;
     }
@@ -399,7 +401,7 @@ class Client implements ClientInterface
      */
     public function setSslVersion($sslVersion = 0)
     {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated, use setCurlOption() instead.', E_USER_DEPRECATED);
+        @trigger_error('The '.__METHOD__.' method is deprecated, use setCurlOption() instead.', E_USER_DEPRECATED);
 
         $this->sslVersion = $sslVersion;
 
@@ -415,7 +417,7 @@ class Client implements ClientInterface
      */
     public function getSslVersion()
     {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated. You should stop using it, as it will be removed in the future.', E_USER_DEPRECATED);
+        @trigger_error('The '.__METHOD__.' method is deprecated. You should stop using it, as it will be removed in the future.', E_USER_DEPRECATED);
 
         return $this->sslVersion;
     }
@@ -431,7 +433,7 @@ class Client implements ClientInterface
      */
     public function setUseHttpAuth($use = true)
     {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated, use setCurlOption() instead.', E_USER_DEPRECATED);
+        @trigger_error('The '.__METHOD__.' method is deprecated, use setCurlOption() instead.', E_USER_DEPRECATED);
 
         $this->useHttpAuth = $use;
 
@@ -447,7 +449,7 @@ class Client implements ClientInterface
      */
     public function getUseHttpAuth()
     {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated. You should stop using it, as it will be removed in the future.', E_USER_DEPRECATED);
+        @trigger_error('The '.__METHOD__.' method is deprecated. You should stop using it, as it will be removed in the future.', E_USER_DEPRECATED);
 
         return $this->useHttpAuth;
     }
@@ -463,7 +465,7 @@ class Client implements ClientInterface
      */
     public function setPort($port = null)
     {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated, use setCurlOption() instead.', E_USER_DEPRECATED);
+        @trigger_error('The '.__METHOD__.' method is deprecated, use setCurlOption() instead.', E_USER_DEPRECATED);
 
         if (null !== $port) {
             $this->port = (int) $port;
@@ -481,7 +483,7 @@ class Client implements ClientInterface
      */
     public function getResponseCode()
     {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated, use getLastResponseStatusCode() instead.', E_USER_DEPRECATED);
+        @trigger_error('The '.__METHOD__.' method is deprecated, use getLastResponseStatusCode() instead.', E_USER_DEPRECATED);
 
         return (int) $this->getLastResponseStatusCode();
     }
@@ -497,7 +499,7 @@ class Client implements ClientInterface
      */
     public function getPort()
     {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated. You should stop using it, as it will be removed in the future.', E_USER_DEPRECATED);
+        @trigger_error('The '.__METHOD__.' method is deprecated. You should stop using it, as it will be removed in the future.', E_USER_DEPRECATED);
 
         if (null !== $this->port) {
             return $this->port;
@@ -543,11 +545,11 @@ class Client implements ClientInterface
     public function setImpersonateUser($username = null)
     {
         if (null === $username) {
-            @trigger_error('The ' . __METHOD__ . ' method is deprecated, use stopImpersonateUser() instead.', E_USER_DEPRECATED);
+            @trigger_error('The '.__METHOD__.' method is deprecated, use stopImpersonateUser() instead.', E_USER_DEPRECATED);
 
             $this->stopImpersonateUser();
         } else {
-            @trigger_error('The ' . __METHOD__ . ' method is deprecated, use startImpersonateUser() instead.', E_USER_DEPRECATED);
+            @trigger_error('The '.__METHOD__.' method is deprecated, use startImpersonateUser() instead.', E_USER_DEPRECATED);
 
             $this->startImpersonateUser($username);
         }
@@ -564,7 +566,7 @@ class Client implements ClientInterface
      */
     public function getImpersonateUser()
     {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated. You should stop using it, as it will be removed in the future.', E_USER_DEPRECATED);
+        @trigger_error('The '.__METHOD__.' method is deprecated. You should stop using it, as it will be removed in the future.', E_USER_DEPRECATED);
 
         return $this->impersonateUser;
     }
@@ -578,7 +580,7 @@ class Client implements ClientInterface
      */
     public function setCustomHost($customHost = null)
     {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated, use setCurlOption() instead.', E_USER_DEPRECATED);
+        @trigger_error('The '.__METHOD__.' method is deprecated, use setCurlOption() instead.', E_USER_DEPRECATED);
 
         $this->customHost = $customHost;
 
@@ -592,7 +594,7 @@ class Client implements ClientInterface
      */
     public function getCustomHost()
     {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated. You should stop using it, as it will be removed in the future.', E_USER_DEPRECATED);
+        @trigger_error('The '.__METHOD__.' method is deprecated. You should stop using it, as it will be removed in the future.', E_USER_DEPRECATED);
 
         return $this->customHost;
     }
@@ -635,7 +637,7 @@ class Client implements ClientInterface
      */
     public function getCurlOptions()
     {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated. You should stop using it, as it will be removed in the future.', E_USER_DEPRECATED);
+        @trigger_error('The '.__METHOD__.' method is deprecated. You should stop using it, as it will be removed in the future.', E_USER_DEPRECATED);
 
         return $this->curlOptions;
     }
@@ -653,7 +655,7 @@ class Client implements ClientInterface
      */
     public function prepareRequest($path, $method = 'GET', $data = '')
     {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated. You should stop using it, as it will be removed in the future.', E_USER_DEPRECATED);
+        @trigger_error('The '.__METHOD__.' method is deprecated. You should stop using it, as it will be removed in the future.', E_USER_DEPRECATED);
 
         $this->responseCode = 0;
         $this->responseContentType = '';
@@ -786,7 +788,7 @@ class Client implements ClientInterface
      */
     public function processCurlResponse($response, $contentType)
     {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated. You should stop using it, as it will be removed in the future.', E_USER_DEPRECATED);
+        @trigger_error('The '.__METHOD__.' method is deprecated. You should stop using it, as it will be removed in the future.', E_USER_DEPRECATED);
 
         if ($response) {
             // if response is XML, return an SimpleXMLElement object
@@ -815,7 +817,7 @@ class Client implements ClientInterface
      */
     protected function runRequest($path, $method = 'GET', $data = '')
     {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated. You should stop using it, as it will be removed in the future.', E_USER_DEPRECATED);
+        @trigger_error('The '.__METHOD__.' method is deprecated. You should stop using it, as it will be removed in the future.', E_USER_DEPRECATED);
 
         $curl = $this->prepareRequest($path, $method, $data);
 


### PR DESCRIPTION
This PR will silently trigger errors if a the deprecated class `Redmine\Client` or one of the deprecated method is called. It refs https://github.com/kbsali/php-redmine-api/projects/2#card-58397341

The `trigger_error()` are silent so users can opt-in for getting the errors. To quote the symfony deprecating code convention:

> Without the @-silencing operator, users would need to opt-out from deprecation notices. Silencing swaps this behavior and allows users to opt-in when they are ready to cope with them (by adding a custom error handler like the one used by the Web Debug Toolbar or by the PHPUnit bridge).

https://symfony.com/doc/4.4/contributing/code/conventions.html#deprecating-code

A custom error handler could look like this:

```php
<?php

require 'vendor/autoload.php';

// Error Handler to show silent errors with PHPUnit
set_error_handler(function ($errno, $errstr, $errline, $errfile ) {
    if (0 === error_reporting()) {
        throw new \PHPUnit\Framework\Error\Error($errstr, $errno, $errfile, (int) $errline);
    }
});
```