### PR TITLE
Fix $lastResponseContentType of type string

### DIFF
--- a/src/Redmine/Client/NativeCurlClient.php
+++ b/src/Redmine/Client/NativeCurlClient.php
@@ -232,9 +232,10 @@ final class NativeCurlClient implements Client
 
         $this->lastResponseBody = (false === $response) ? '' : $response;
         $this->lastResponseStatusCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
-        $result = curl_getinfo($curl, CURLINFO_CONTENT_TYPE);
-        if(is_string($result)){    
-            $this->lastResponseContentType =  $result;
+        $possibleContentType = curl_getinfo($curl, CURLINFO_CONTENT_TYPE);
+
+        if (is_string($possibleContentType)) {
+            $this->lastResponseContentType = $possibleContentType;
         }
 
         curl_close($curl);

--- a/src/Redmine/Client/NativeCurlClient.php
+++ b/src/Redmine/Client/NativeCurlClient.php
@@ -232,7 +232,10 @@ final class NativeCurlClient implements Client
 
         $this->lastResponseBody = (false === $response) ? '' : $response;
         $this->lastResponseStatusCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
-        $this->lastResponseContentType = curl_getinfo($curl, CURLINFO_CONTENT_TYPE);
+        $result = curl_getinfo($curl, CURLINFO_CONTENT_TYPE);
+        if(is_string($result)){    
+            $this->lastResponseContentType =  $result;
+        }
 
         curl_close($curl);
 


### PR DESCRIPTION
Fatal error: Uncaught TypeError: Cannot assign int to property Redmine\Client\NativeCurlClient::$lastResponseContentType of type string in D:\xampp-v8\htdocs\wordpress\wp-content\plugins\wordpress-cloodo-plugins\libs\Redmine\Client\NativeCurlClient.php:235 Stack trace: #0 D:\xampp-v8\htdocs\wordpress\wp-content\plugins\wordpress-cloodo-plugins\libs\Redmine\Client\NativeCurlClient.php(81): Redmine\Client\NativeCurlClient->request('get', '/users/current....') #1 D:\xampp-v8\htdocs\wordpress\wp-content\plugins\wordpress-cloodo-plugins\libs\Redmine\Api\AbstractApi.php(49): Redmine\Client\NativeCurlClient->requestGet('/users/current....') #2 D:\xampp-v8\htdocs\wordpress\wp-content\plugins\wordpress-cloodo-plugins\libs\Redmine\Api\User.php(121): Redmine\Api\AbstractApi->get('/users/current....') #3 D:\xampp-v8\htdocs\wordpress\wp-content\plugins\wordpress-cloodo-plugins\libs\Redmine\Api\User.php(66): Redmine\Api\User->show('current', Array) #4 D:\xampp-v8\htdocs\wordpress\wp-content\plugins\wordpress-cloodo-plugins\cloodo.php(27): Redmine\Api\User->getCurrentUser(Array) #5 D:\xampp-v8\htdocs\wordpress\wp-settings.php(391): include_once('D:\\xampp-v8\\htd...') #6 D:\xampp-v8\htdocs\wordpress\wp-config.php(90): require_once('D:\\xampp-v8\\htd...') #7 D:\xampp-v8\htdocs\wordpress\wp-load.php(37): require_once('D:\\xampp-v8\\htd...') #8 D:\xampp-v8\htdocs\wordpress\wp-admin\admin.php(34): require_once('D:\\xampp-v8\\htd...') #9 {main} thrown in D:\xampp-v8\htdocs\wordpress\wp-content\plugins\wordpress-cloodo-plugins\libs\Redmine\Client\NativeCurlClient.php on line 235