### PR TITLE
Assume all 2xx codes to be success.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/kbsali/php-redmine-api/compare/v2.0.1...v2.x)
 
+### Fixed
+
+- `lastCallFailed` method no longer returns `true` for 2xx status codes that are not 200 or 201
+
 ## [v2.0.1](https://github.com/kbsali/php-redmine-api/compare/v2.0.0...v2.0.1) - 2021-09-22
 
 ### Fixed

--- a/src/Redmine/Api/AbstractApi.php
+++ b/src/Redmine/Api/AbstractApi.php
@@ -33,7 +33,8 @@ abstract class AbstractApi implements Api
     {
         $code = $this->client->getLastResponseStatusCode();
 
-        return 200 !== $code && 201 !== $code;
+        // only assume 2xx codes to be success
+        return 200 > $code || 300 <= $code;
     }
 
     /**


### PR DESCRIPTION
This fixes `lastCallFailed` returning true for successful calls to the API
that actually return status codes such as 204 No Content.

Several API endpoints do the above since Redmine 4.1.0 (specifically this commit:
https://github.com/redmine/redmine/commit/29063283da5d333b990e2ce3a8c6221133f305c9),
including updates to issues.