### PR TITLE
Deprecate lastCallFailed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/kbsali/php-redmine-api/compare/v2.0.1...v2.x)
 
+### Deprecated
+
+- `Redmine\Api\AbstractApi::lastCallFailed()` is deprecated, use `Redmine\Client\Client::getLastResponseStatusCode()` instead
+
 ## [v2.0.1](https://github.com/kbsali/php-redmine-api/compare/v2.0.0...v2.0.1) - 2021-09-22
 
 ### Fixed

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -199,6 +199,8 @@ $client->stopImpersonateUser();
 
 You can now use the `getApi()` method to create and get a specific Redmine API.
 
+To check for failed requests you can afterwards check the status code via `$client->getLastResponseStatusCode()`.
+
 ```php
 // ----------------------------
 // Trackers

--- a/src/Redmine/Api/AbstractApi.php
+++ b/src/Redmine/Api/AbstractApi.php
@@ -28,9 +28,14 @@ abstract class AbstractApi implements Api
      * Returns whether or not the last api call failed.
      *
      * @return bool
+     *
+     * @deprecated This method does not correctly handle 2xx codes that are not 200 or 201, use \Redmine\Client\Client::getLastResponseStatusCode() instead
+     * @see Client::getLastResponseStatusCode() for checking the status code directly
      */
     public function lastCallFailed()
     {
+        @trigger_error('The '.__METHOD__.' method is deprecated, use \Redmine\Client\Client::getLastResponseStatusCode() instead.', E_USER_DEPRECATED);
+
         $code = $this->client->getLastResponseStatusCode();
 
         return 200 !== $code && 201 !== $code;


### PR DESCRIPTION
This PR is a result of discussion in #293.


`Redmine\Api\AbstractApi::lastCallFailed` fails to acknowledge 2xx codes that are not 200 or 201 as success, however changing that method may break old code relying on this behavior.

Redmine introduced a change to successful responses in 4.1.0 that leads to API calls such as issue updates leading to a yet undocumented 204 response, more details on that in the other issue.

We already have an alternative way to check for success, and that is to simply check the status code directly by calling `Redmine\Client\Client::getLastResponseStatusCode`. This PR will point users towards that method instead.

I am going to check whether this can be clarified in the documentation as well somehow before I mark this as ready to review.