### PR TITLE
Deprecate attachment upload by file path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Switched from Travis-CI to Github Actions
 
+### Fixed
+
+- Avoid warning if path of uploaded file is longer than the maximum allowed path length
+
 ### Deprecated
 
 - `Redmine\Api\AbstractApi::lastCallFailed()` is deprecated, use `Redmine\Client\Client::getLastResponseStatusCode()` instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 - `Redmine\Api\AbstractApi::lastCallFailed()` is deprecated, use `Redmine\Client\Client::getLastResponseStatusCode()` instead
+- Uploading an attachment with method `Redmine\Api\Attachment::upload()` with filepath is deprectead, use `file_get_contents()` to upload the file content instead
 
 ## [v2.0.1](https://github.com/kbsali/php-redmine-api/compare/v2.0.0...v2.0.1) - 2021-09-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 - `Redmine\Api\AbstractApi::lastCallFailed()` is deprecated, use `Redmine\Client\Client::getLastResponseStatusCode()` instead
-- Uploading an attachment with method `Redmine\Api\Attachment::upload()` with filepath is deprectead, use `file_get_contents()` to upload the file content instead
+- Uploading an attachment using `Redmine\Api\Attachment::upload()` with filepath is deprectead, use `file_get_contents()` to upload the file content instead
 
 ## [v2.0.1](https://github.com/kbsali/php-redmine-api/compare/v2.0.0...v2.0.1) - 2021-09-22
 

--- a/src/Redmine/Client/ClientApiTrait.php
+++ b/src/Redmine/Client/ClientApiTrait.php
@@ -58,7 +58,7 @@ trait ClientApiTrait
     {
         $path = strtolower($path);
 
-        return (false !== strpos($path, '/uploads.json')) or (false !== strpos($path, '/uploads.xml'));
+        return (false !== strpos($path, '/uploads.json')) || (false !== strpos($path, '/uploads.xml'));
     }
 
     private function isUploadCallAndFilepath(string $path, string $body): bool

--- a/src/Redmine/Client/ClientApiTrait.php
+++ b/src/Redmine/Client/ClientApiTrait.php
@@ -53,4 +53,20 @@ trait ClientApiTrait
 
         return $this->apiInstances[$name];
     }
+
+    private function isUploadCall(string $path): bool
+    {
+        $path = strtolower($path);
+
+        return (false !== strpos($path, '/uploads.json')) or (false !== strpos($path, '/uploads.xml'));
+    }
+
+    private function isUploadCallAndFilepath(string $path, string $body): bool
+    {
+        return
+            $this->isUploadCall($path)
+            && '' !== $body
+            && is_file(strval(str_replace("\0", '', $body)))
+        ;
+    }
 }

--- a/src/Redmine/Client/ClientApiTrait.php
+++ b/src/Redmine/Client/ClientApiTrait.php
@@ -66,6 +66,7 @@ trait ClientApiTrait
         return
             $this->isUploadCall($path)
             && '' !== $body
+            && strlen($body) <= \PHP_MAXPATHLEN
             && is_file(strval(str_replace("\0", '', $body)))
         ;
     }

--- a/src/Redmine/Client/ClientApiTrait.php
+++ b/src/Redmine/Client/ClientApiTrait.php
@@ -61,11 +61,10 @@ trait ClientApiTrait
         return (false !== strpos($path, '/uploads.json')) || (false !== strpos($path, '/uploads.xml'));
     }
 
-    private function isUploadCallAndFilepath(string $path, string $body): bool
+    private function isValidFilePath(string $body): bool
     {
         return
-            $this->isUploadCall($path)
-            && '' !== $body
+            '' !== $body
             && strlen($body) <= \PHP_MAXPATHLEN
             && is_file(strval(str_replace("\0", '', $body)))
         ;

--- a/src/Redmine/Client/NativeCurlClient.php
+++ b/src/Redmine/Client/NativeCurlClient.php
@@ -271,7 +271,7 @@ final class NativeCurlClient implements Client
         switch ($method) {
             case 'post':
                 $curlOptions[CURLOPT_POST] = 1;
-                if ($this->isUploadCallAndFilepath($path, $body)) {
+                if ($this->isUploadCall($path) && $this->isValidFilePath($body)) {
                     @trigger_error('Uploading an attachment by filepath is deprecated, use file_get_contents() to upload the file content instead.', E_USER_DEPRECATED);
 
                     $file = fopen($body, 'r');

--- a/src/Redmine/Client/NativeCurlClient.php
+++ b/src/Redmine/Client/NativeCurlClient.php
@@ -272,7 +272,7 @@ final class NativeCurlClient implements Client
             case 'post':
                 $curlOptions[CURLOPT_POST] = 1;
                 if ($this->isUploadCallAndFilepath($path, $body)) {
-                    @trigger_error('Upload an attachment by filepath is deprecated, use file_get_contents() to upload the file content instead.', E_USER_DEPRECATED);
+                    @trigger_error('Uploading an attachment by filepath is deprecated, use file_get_contents() to upload the file content instead.', E_USER_DEPRECATED);
 
                     $file = fopen($body, 'r');
                     $size = filesize($body);

--- a/src/Redmine/Client/NativeCurlClient.php
+++ b/src/Redmine/Client/NativeCurlClient.php
@@ -272,6 +272,8 @@ final class NativeCurlClient implements Client
             case 'post':
                 $curlOptions[CURLOPT_POST] = 1;
                 if ($this->isUploadCallAndFilepath($path, $body)) {
+                    @trigger_error('Upload an attachment by filepath is deprecated, use file_get_contents() to upload the file content instead.', E_USER_DEPRECATED);
+
                     $file = fopen($body, 'r');
                     $size = filesize($body);
                     $filedata = fread($file, $size);

--- a/src/Redmine/Client/NativeCurlClient.php
+++ b/src/Redmine/Client/NativeCurlClient.php
@@ -271,7 +271,7 @@ final class NativeCurlClient implements Client
         switch ($method) {
             case 'post':
                 $curlOptions[CURLOPT_POST] = 1;
-                if ($this->isUploadCall($path, $body)) {
+                if ($this->isUploadCallAndFilepath($path, $body)) {
                     $file = fopen($body, 'r');
                     $size = filesize($body);
                     $filedata = fread($file, $size);
@@ -309,15 +309,6 @@ final class NativeCurlClient implements Client
         curl_setopt_array($curl, $curlOptions);
 
         return $curl;
-    }
-
-    private function isUploadCall(string $path, string $body): bool
-    {
-        return
-            (preg_match('/\/uploads.(json|xml)/i', $path)) &&
-            '' !== $body &&
-            is_file(strval(str_replace("\0", '', $body)))
-        ;
     }
 
     private function createHttpHeader(string $path): array
@@ -360,7 +351,7 @@ final class NativeCurlClient implements Client
         // Content type headers
         $tmp = parse_url($this->url.$path);
 
-        if (preg_match('/\/uploads.(json|xml)/i', $path)) {
+        if ($this->isUploadCall($path)) {
             $httpHeaders[] = 'Content-Type: application/octet-stream';
         } elseif ('json' === substr($tmp['path'], -4)) {
             $httpHeaders[] = 'Content-Type: application/json';

--- a/src/Redmine/Client/Psr18Client.php
+++ b/src/Redmine/Client/Psr18Client.php
@@ -181,7 +181,7 @@ final class Psr18Client implements Client
 
         switch ($method) {
             case 'POST':
-                if ($this->isUploadCallAndFilepath($path, $body)) {
+                if ($this->isUploadCall($path) && $this->isValidFilePath($body)) {
                     @trigger_error('Uploading an attachment by filepath is deprecated, use file_get_contents() to upload the file content instead.', E_USER_DEPRECATED);
 
                     $request = $request->withBody(

--- a/src/Redmine/Client/Psr18Client.php
+++ b/src/Redmine/Client/Psr18Client.php
@@ -181,7 +181,7 @@ final class Psr18Client implements Client
 
         switch ($method) {
             case 'POST':
-                if ($this->isUploadCall($path, $body)) {
+                if ($this->isUploadCallAndFilepath($path, $body)) {
                     $request = $request->withBody(
                         $this->streamFactory->createStreamFromFile($body)
                     );
@@ -203,7 +203,7 @@ final class Psr18Client implements Client
         // set Content-Type header
         $tmp = parse_url($this->url.$path);
 
-        if (preg_match('/\/uploads.(json|xml)/i', $path)) {
+        if ($this->isUploadCall($path)) {
             $request = $request->withHeader('Content-Type', 'application/octet-stream');
         } elseif ('json' === substr($tmp['path'], -4)) {
             $request = $request->withHeader('Content-Type', 'application/json');
@@ -212,14 +212,5 @@ final class Psr18Client implements Client
         }
 
         return $request;
-    }
-
-    private function isUploadCall(string $path, string $body): bool
-    {
-        return
-            (preg_match('/\/uploads.(json|xml)/i', $path)) &&
-            '' !== $body &&
-            is_file(strval(str_replace("\0", '', $body)))
-        ;
     }
 }

--- a/src/Redmine/Client/Psr18Client.php
+++ b/src/Redmine/Client/Psr18Client.php
@@ -182,7 +182,7 @@ final class Psr18Client implements Client
         switch ($method) {
             case 'POST':
                 if ($this->isUploadCallAndFilepath($path, $body)) {
-                    @trigger_error('Upload an attachment by filepath is deprecated, use file_get_contents() to upload the file content instead.', E_USER_DEPRECATED);
+                    @trigger_error('Uploading an attachment by filepath is deprecated, use file_get_contents() to upload the file content instead.', E_USER_DEPRECATED);
 
                     $request = $request->withBody(
                         $this->streamFactory->createStreamFromFile($body)

--- a/src/Redmine/Client/Psr18Client.php
+++ b/src/Redmine/Client/Psr18Client.php
@@ -182,6 +182,8 @@ final class Psr18Client implements Client
         switch ($method) {
             case 'POST':
                 if ($this->isUploadCallAndFilepath($path, $body)) {
+                    @trigger_error('Upload an attachment by filepath is deprecated, use file_get_contents() to upload the file content instead.', E_USER_DEPRECATED);
+
                     $request = $request->withBody(
                         $this->streamFactory->createStreamFromFile($body)
                     );


### PR DESCRIPTION
Uploading an attachment could be made by `$client->getApi('attachment')->upload('file content');` as documented in the docs: https://github.com/kbsali/php-redmine-api/blob/v2.0.1/docs/usage.md

However in #222 a new way of uploading files via filepath was introduced as a "fix". This way has led to a number of problems like #235 and #264. 

This method can additionally lead to a potential security problem: Assume someone wants to upload the file `file.txt`, but the file contains the path to another file:

**file.txt**

```
/etc/passwd
```

If one now runs `$client->getApi('attachment')->upload(file_get_contents('./file.txt'));` the library will check with `is_file()` for the existence of the `/etc/passwd` file and will upload this file instead.

As a solution I would recommend to deprecate the attachment upload by filename and remove it in the next major version.

This PR will fix #264.

@kbsali Depending on how critical this issue is rated, I would also release version 3.0 very soon.