### PR TITLE
Improve retrieveAll()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/kbsali/php-redmine-api/compare/v2.1.0...v2.x)
 
+### Added
+
+- New method `Redmine\Client\AbstractApi::retrieveData()` to retrieve as many elements as you want as array (even if the total number of elements is greater than 100).
+- New exception `Redmine\Client\SerializerException` for JSON/XML serializer related exceptions
+
+### Deprecated
+
+- `Redmine\Api\AbstractApi::retrieveAll()` is deprecated, use `Redmine\Api\AbstractApi::retrieveData()` instead
+
 ## [v2.1.1](https://github.com/kbsali/php-redmine-api/compare/v2.1.0...v2.1.1) - 2022-01-15
 
 ### Fixed

--- a/src/Redmine/Api/AbstractApi.php
+++ b/src/Redmine/Api/AbstractApi.php
@@ -8,6 +8,7 @@ use Redmine\Client\Client;
 use Redmine\Exception\SerializerException;
 use Redmine\Serializer\JsonSerializer;
 use Redmine\Serializer\PathSerializer;
+use Redmine\Serializer\XmlSerializer;
 use SimpleXMLElement;
 
 /**
@@ -316,17 +317,7 @@ abstract class AbstractApi implements Api
 
         // parse XML
         if (0 === strpos($contentType, 'application/xml')) {
-            try {
-                $returnData = new SimpleXMLElement($body);
-            } catch (\Exception $e) {
-                throw new SerializerException(
-                    'Catched error "' . $e->getMessage() . '" while decoding body as XML: ' . $body,
-                    $e->getCode(),
-                    $e
-                );
-            }
-
-            $returnData = JsonSerializer::createFromString(json_encode($returnData, \JSON_THROW_ON_ERROR))->getNormalized();
+            $returnData = XmlSerializer::createFromString($body)->getNormalized();
         } else if (0 === strpos($contentType, 'application/json')) {
             $returnData = JsonSerializer::createFromString($body)->getNormalized();
         }

--- a/src/Redmine/Api/AbstractApi.php
+++ b/src/Redmine/Api/AbstractApi.php
@@ -304,16 +304,8 @@ abstract class AbstractApi implements Api
     private function getLastResponseBodyAsArray(): array
     {
         $body = $this->client->getLastResponseBody();
-        $returnData = null;
-
-        // if body is empty
-        if ($body === '') {
-            throw new SerializerException(
-                'Could not convert empty response body into array'
-            );
-        }
-
         $contentType = $this->client->getLastResponseContentType();
+        $returnData = null;
 
         // parse XML
         if (0 === strpos($contentType, 'application/xml')) {

--- a/src/Redmine/Api/AbstractApi.php
+++ b/src/Redmine/Api/AbstractApi.php
@@ -6,6 +6,7 @@ use JsonException;
 use Redmine\Api;
 use Redmine\Client\Client;
 use Redmine\Exception\ConversionException;
+use Redmine\Serializer\PathSerializer;
 use SimpleXMLElement;
 
 /**
@@ -226,11 +227,9 @@ abstract class AbstractApi implements Api
             $params['limit'] = $_limit;
             $params['offset'] = $offset;
 
-            $queryString = http_build_query($params);
-            // replace every encoded array (`foo[0]=`, `foo[1]=`, `foo[2]=`, etc => `foo[]=`)
-            $queryString = preg_replace('/%5B[0-9]+%5D/simU', '%5B%5D', $queryString);
-
-            $this->client->requestGet($endpoint.'?'.$queryString);
+            $this->client->requestGet(
+                PathSerializer::create($endpoint, $params)->getPath()
+            );
 
             $newDataSet = $this->getLastResponseBodyAsArray();
 

--- a/src/Redmine/Api/AbstractApi.php
+++ b/src/Redmine/Api/AbstractApi.php
@@ -176,13 +176,13 @@ abstract class AbstractApi implements Api
     {
         @trigger_error('The '.__METHOD__.' method is deprecated, use `retrieveData()` instead.', E_USER_DEPRECATED);
 
-        $data = $this->retrieveData(strval($endpoint), $params);
-
-        if (! array_key_exists('response', $data)) {
-            return $data;
+        try {
+            $data = $this->retrieveData(strval($endpoint), $params);
+        } catch (SerializerException $e) {
+            $data = false;
         }
 
-        return ('' === $data['response']) ? false : $data['response'];
+        return $data;
     }
 
     /**

--- a/src/Redmine/Api/AbstractApi.php
+++ b/src/Redmine/Api/AbstractApi.php
@@ -170,7 +170,7 @@ abstract class AbstractApi implements Api
      * @param string $endpoint API end point
      * @param array  $params   optional parameters to be passed to the api (offset, limit, ...)
      *
-     * @return array elements found
+     * @return array|false elements found
      */
     protected function retrieveAll($endpoint, array $params = [])
     {

--- a/src/Redmine/Api/AbstractApi.php
+++ b/src/Redmine/Api/AbstractApi.php
@@ -5,7 +5,7 @@ namespace Redmine\Api;
 use JsonException;
 use Redmine\Api;
 use Redmine\Client\Client;
-use Redmine\Exception\ConversionException;
+use Redmine\Exception\SerializerException;
 use Redmine\Serializer\PathSerializer;
 use SimpleXMLElement;
 
@@ -191,7 +191,7 @@ abstract class AbstractApi implements Api
      * @param string $endpoint API end point
      * @param array  $params   optional query parameters to be passed to the api (offset, limit, ...)
      *
-     * @throws ConversionException if response body could not be converted into array
+     * @throws SerializerException if response body could not be converted into array
      *
      * @return array elements found
      */
@@ -298,7 +298,7 @@ abstract class AbstractApi implements Api
     /**
      * returns the last response body as array
      *
-     * @throws ConversionException if response body could not be converted into array
+     * @throws SerializerException if response body could not be converted into array
      */
     private function getLastResponseBodyAsArray(): array
     {
@@ -307,7 +307,7 @@ abstract class AbstractApi implements Api
 
         // if body is empty
         if ($body === '') {
-            throw new ConversionException(
+            throw new SerializerException(
                 'Could not convert empty response body into array'
             );
         }
@@ -319,7 +319,7 @@ abstract class AbstractApi implements Api
             try {
                 $returnData = new SimpleXMLElement($body);
             } catch (\Exception $e) {
-                throw new ConversionException(
+                throw new SerializerException(
                     'Catched error "' . $e->getMessage() . '" while decoding body as XML: ' . $body,
                     $e->getCode(),
                     $e
@@ -334,7 +334,7 @@ abstract class AbstractApi implements Api
                     \JSON_THROW_ON_ERROR
                 );
             } catch (JsonException $e) {
-                throw new ConversionException(
+                throw new SerializerException(
                     'Catched error "' . $e->getMessage() . '" while en- and decoding body as JSON: ' . $body,
                     $e->getCode(),
                     $e
@@ -349,7 +349,7 @@ abstract class AbstractApi implements Api
                     \JSON_THROW_ON_ERROR
                 );
             } catch (JsonException $e) {
-                throw new ConversionException(
+                throw new SerializerException(
                     'Catched error "' . $e->getMessage() . '" while decoding body as JSON: ' . $body,
                     $e->getCode(),
                     $e
@@ -358,7 +358,7 @@ abstract class AbstractApi implements Api
         }
 
         if (! is_array($returnData)) {
-            throw new ConversionException(
+            throw new SerializerException(
                 'Could not convert response body into array: ' . $body
             );
         }

--- a/src/Redmine/Api/Attachment.php
+++ b/src/Redmine/Api/Attachment.php
@@ -2,6 +2,8 @@
 
 namespace Redmine\Api;
 
+use Redmine\Serializer\PathSerializer;
+
 /**
  * Attachment details.
  *
@@ -51,7 +53,10 @@ class Attachment extends AbstractApi
      */
     public function upload($attachment, $params = [])
     {
-        return $this->post('/uploads.json?'.http_build_query($params), $attachment);
+        return $this->post(
+            PathSerializer::create('/uploads.json', $params)->getPath(),
+            $attachment
+        );
     }
 
     /**

--- a/src/Redmine/Api/CustomField.php
+++ b/src/Redmine/Api/CustomField.php
@@ -24,7 +24,7 @@ class CustomField extends AbstractApi
      */
     public function all(array $params = [])
     {
-        $this->customFields = $this->retrieveAll('/custom_fields.json', $params);
+        $this->customFields = $this->retrieveData('/custom_fields.json', $params);
 
         return $this->customFields;
     }

--- a/src/Redmine/Api/Group.php
+++ b/src/Redmine/Api/Group.php
@@ -28,7 +28,7 @@ class Group extends AbstractApi
      */
     public function all(array $params = [])
     {
-        $this->groups = $this->retrieveAll('/groups.json', $params);
+        $this->groups = $this->retrieveData('/groups.json', $params);
 
         return $this->groups;
     }

--- a/src/Redmine/Api/Group.php
+++ b/src/Redmine/Api/Group.php
@@ -4,6 +4,7 @@ namespace Redmine\Api;
 
 use Exception;
 use Redmine\Exception\MissingParameterException;
+use Redmine\Serializer\PathSerializer;
 
 /**
  * Handling of groups.
@@ -110,7 +111,9 @@ class Group extends AbstractApi
      */
     public function show($id, array $params = [])
     {
-        return $this->get('/groups/'.urlencode($id).'.json?'.http_build_query($params));
+        return $this->get(
+            PathSerializer::create('/groups/'.urlencode($id).'.json', $params)->getPath()
+        );
     }
 
     /**

--- a/src/Redmine/Api/Issue.php
+++ b/src/Redmine/Api/Issue.php
@@ -2,6 +2,8 @@
 
 namespace Redmine\Api;
 
+use Redmine\Serializer\PathSerializer;
+
 /**
  * Listing issues, searching, editing and closing your projects issues.
  *
@@ -59,7 +61,9 @@ class Issue extends AbstractApi
             $params['include'] = implode(',', $params['include']);
         }
 
-        return $this->get('/issues/'.urlencode($id).'.json?'.http_build_query($params));
+        return $this->get(
+            PathSerializer::create('/issues/'.urlencode($id).'.json', $params)->getPath()
+        );
     }
 
     /**

--- a/src/Redmine/Api/Issue.php
+++ b/src/Redmine/Api/Issue.php
@@ -40,7 +40,7 @@ class Issue extends AbstractApi
      */
     public function all(array $params = [])
     {
-        return $this->retrieveAll('/issues.json', $params);
+        return $this->retrieveData('/issues.json', $params);
     }
 
     /**

--- a/src/Redmine/Api/IssueCategory.php
+++ b/src/Redmine/Api/IssueCategory.php
@@ -3,6 +3,7 @@
 namespace Redmine\Api;
 
 use Redmine\Exception\MissingParameterException;
+use Redmine\Serializer\PathSerializer;
 
 /**
  * Listing issue categories, creating, editing.
@@ -158,6 +159,8 @@ class IssueCategory extends AbstractApi
      */
     public function remove($id, array $params = [])
     {
-        return $this->delete('/issue_categories/'.$id.'.xml?'.http_build_query($params));
+        return $this->delete(
+            PathSerializer::create('/issue_categories/'.$id.'.xml', $params)->getPath()
+        );
     }
 }

--- a/src/Redmine/Api/IssueCategory.php
+++ b/src/Redmine/Api/IssueCategory.php
@@ -28,7 +28,7 @@ class IssueCategory extends AbstractApi
      */
     public function all($project, array $params = [])
     {
-        $this->issueCategories = $this->retrieveAll('/projects/'.$project.'/issue_categories.json', $params);
+        $this->issueCategories = $this->retrieveData('/projects/'.$project.'/issue_categories.json', $params);
 
         return $this->issueCategories;
     }

--- a/src/Redmine/Api/IssuePriority.php
+++ b/src/Redmine/Api/IssuePriority.php
@@ -24,7 +24,7 @@ class IssuePriority extends AbstractApi
      */
     public function all(array $params = [])
     {
-        $this->issuePriorities = $this->retrieveAll('/enumerations/issue_priorities.json', $params);
+        $this->issuePriorities = $this->retrieveData('/enumerations/issue_priorities.json', $params);
 
         return $this->issuePriorities;
     }

--- a/src/Redmine/Api/IssueRelation.php
+++ b/src/Redmine/Api/IssueRelation.php
@@ -27,7 +27,7 @@ class IssueRelation extends AbstractApi
      */
     public function all($issueId, array $params = [])
     {
-        $this->relations = $this->retrieveAll('/issues/'.urlencode($issueId).'/relations.json', $params);
+        $this->relations = $this->retrieveData('/issues/'.urlencode($issueId).'/relations.json', $params);
 
         return $this->relations;
     }

--- a/src/Redmine/Api/IssueRelation.php
+++ b/src/Redmine/Api/IssueRelation.php
@@ -2,6 +2,8 @@
 
 namespace Redmine\Api;
 
+use Redmine\Serializer\JsonSerializer;
+
 /**
  * Handling issue relations.
  *
@@ -85,6 +87,8 @@ class IssueRelation extends AbstractApi
 
         $params = json_encode(['relation' => $params]);
 
-        return json_decode($this->post('/issues/'.urlencode($issueId).'/relations.json', $params), true);
+        $response = $this->post('/issues/'.urlencode($issueId).'/relations.json', $params);
+
+        return JsonSerializer::createFromString($response)->getNormalized();
     }
 }

--- a/src/Redmine/Api/IssueStatus.php
+++ b/src/Redmine/Api/IssueStatus.php
@@ -24,7 +24,7 @@ class IssueStatus extends AbstractApi
      */
     public function all(array $params = [])
     {
-        $this->issueStatuses = $this->retrieveAll('/issue_statuses.json', $params);
+        $this->issueStatuses = $this->retrieveData('/issue_statuses.json', $params);
 
         return $this->issueStatuses;
     }

--- a/src/Redmine/Api/Membership.php
+++ b/src/Redmine/Api/Membership.php
@@ -27,7 +27,7 @@ class Membership extends AbstractApi
      */
     public function all($project, array $params = [])
     {
-        $this->memberships = $this->retrieveAll('/projects/'.$project.'/memberships.json', $params);
+        $this->memberships = $this->retrieveData('/projects/'.$project.'/memberships.json', $params);
 
         return $this->memberships;
     }

--- a/src/Redmine/Api/News.php
+++ b/src/Redmine/Api/News.php
@@ -24,7 +24,7 @@ class News extends AbstractApi
     public function all($project = null, array $params = [])
     {
         $path = null === $project ? '/news.json' : '/projects/'.$project.'/news.json';
-        $this->news = $this->retrieveAll($path, $params);
+        $this->news = $this->retrieveData($path, $params);
 
         return $this->news;
     }

--- a/src/Redmine/Api/Project.php
+++ b/src/Redmine/Api/Project.php
@@ -27,7 +27,7 @@ class Project extends AbstractApi
      */
     public function all(array $params = [])
     {
-        $this->projects = $this->retrieveAll('/projects.json', $params);
+        $this->projects = $this->retrieveData('/projects.json', $params);
 
         return $this->projects;
     }

--- a/src/Redmine/Api/Project.php
+++ b/src/Redmine/Api/Project.php
@@ -3,6 +3,7 @@
 namespace Redmine\Api;
 
 use Redmine\Exception\MissingParameterException;
+use Redmine\Serializer\PathSerializer;
 
 /**
  * Listing projects, creating, editing.
@@ -90,7 +91,9 @@ class Project extends AbstractApi
             $params['include'] = 'trackers,issue_categories,attachments,relations';
         }
 
-        return $this->get('/projects/'.urlencode($id).'.json?'.http_build_query($params));
+        return $this->get(
+            PathSerializer::create('/projects/'.urlencode($id).'.json', $params)->getPath()
+        );
     }
 
     /**

--- a/src/Redmine/Api/Query.php
+++ b/src/Redmine/Api/Query.php
@@ -24,7 +24,7 @@ class Query extends AbstractApi
      */
     public function all(array $params = [])
     {
-        $this->query = $this->retrieveAll('/queries.json', $params);
+        $this->query = $this->retrieveData('/queries.json', $params);
 
         return $this->query;
     }

--- a/src/Redmine/Api/Role.php
+++ b/src/Redmine/Api/Role.php
@@ -24,7 +24,7 @@ class Role extends AbstractApi
      */
     public function all(array $params = [])
     {
-        $this->roles = $this->retrieveAll('/roles.json', $params);
+        $this->roles = $this->retrieveData('/roles.json', $params);
 
         return $this->roles;
     }

--- a/src/Redmine/Api/Search.php
+++ b/src/Redmine/Api/Search.php
@@ -22,7 +22,7 @@ class Search extends AbstractApi
     public function search($query, array $params = [])
     {
         $params['q'] = $query;
-        $this->results = $this->retrieveAll('/search.json', $params);
+        $this->results = $this->retrieveData('/search.json', $params);
 
         return $this->results;
     }

--- a/src/Redmine/Api/TimeEntry.php
+++ b/src/Redmine/Api/TimeEntry.php
@@ -26,7 +26,7 @@ class TimeEntry extends AbstractApi
      */
     public function all(array $params = [])
     {
-        $this->timeEntries = $this->retrieveAll('/time_entries.json', $params);
+        $this->timeEntries = $this->retrieveData('/time_entries.json', $params);
 
         return $this->timeEntries;
     }

--- a/src/Redmine/Api/TimeEntryActivity.php
+++ b/src/Redmine/Api/TimeEntryActivity.php
@@ -22,7 +22,7 @@ class TimeEntryActivity extends AbstractApi
      */
     public function all(array $params = [])
     {
-        $this->timeEntryActivities = $this->retrieveAll('/enumerations/time_entry_activities.json', $params);
+        $this->timeEntryActivities = $this->retrieveData('/enumerations/time_entry_activities.json', $params);
 
         return $this->timeEntryActivities;
     }

--- a/src/Redmine/Api/Tracker.php
+++ b/src/Redmine/Api/Tracker.php
@@ -24,7 +24,7 @@ class Tracker extends AbstractApi
      */
     public function all(array $params = [])
     {
-        $this->trackers = $this->retrieveAll('/trackers.json', $params);
+        $this->trackers = $this->retrieveData('/trackers.json', $params);
 
         return $this->trackers;
     }

--- a/src/Redmine/Api/User.php
+++ b/src/Redmine/Api/User.php
@@ -27,7 +27,7 @@ class User extends AbstractApi
      */
     public function all(array $params = [])
     {
-        $this->users = $this->retrieveAll('/users.json', $params);
+        $this->users = $this->retrieveData('/users.json', $params);
 
         return $this->users;
     }

--- a/src/Redmine/Api/User.php
+++ b/src/Redmine/Api/User.php
@@ -3,6 +3,7 @@
 namespace Redmine\Api;
 
 use Redmine\Exception\MissingParameterException;
+use Redmine\Serializer\PathSerializer;
 
 /**
  * Listing users, creating, editing.
@@ -117,11 +118,9 @@ class User extends AbstractApi
         );
         $params['include'] = implode(',', $params['include']);
 
-        return $this->get(sprintf(
-            '/users/%s.json?%s',
-            urlencode($id),
-            http_build_query($params)
-        ));
+        return $this->get(
+            PathSerializer::create('/users/'.urlencode($id).'.json', $params)->getPath()
+        );
     }
 
     /**

--- a/src/Redmine/Api/Version.php
+++ b/src/Redmine/Api/Version.php
@@ -28,7 +28,7 @@ class Version extends AbstractApi
      */
     public function all($project, array $params = [])
     {
-        $this->versions = $this->retrieveAll('/projects/'.$project.'/versions.json', $params);
+        $this->versions = $this->retrieveData('/projects/'.$project.'/versions.json', $params);
 
         return $this->versions;
     }

--- a/src/Redmine/Api/Wiki.php
+++ b/src/Redmine/Api/Wiki.php
@@ -2,6 +2,8 @@
 
 namespace Redmine\Api;
 
+use Redmine\Serializer\PathSerializer;
+
 /**
  * Listing Wiki pages.
  *
@@ -44,11 +46,19 @@ class Wiki extends AbstractApi
      */
     public function show($project, $page, $version = null)
     {
-        $path = null === $version
-            ? '/projects/'.$project.'/wiki/'.$page.'.json?include=attachments'
-            : '/projects/'.$project.'/wiki/'.$page.'/'.$version.'.json?include=attachments';
+        $params = [
+            'include' => 'attachments',
+        ];
 
-        return $this->get($path);
+        if ($version === null) {
+            $path = '/projects/'.$project.'/wiki/'.$page.'.json';
+        } else {
+            $path = '/projects/'.$project.'/wiki/'.$page.'/'.$version.'.json';
+        }
+
+        return $this->get(
+            PathSerializer::create($path, $params)->getPath()
+        );
     }
 
     /**

--- a/src/Redmine/Api/Wiki.php
+++ b/src/Redmine/Api/Wiki.php
@@ -27,7 +27,7 @@ class Wiki extends AbstractApi
      */
     public function all($project, array $params = [])
     {
-        $this->wikiPages = $this->retrieveAll('/projects/'.$project.'/wiki/index.json', $params);
+        $this->wikiPages = $this->retrieveData('/projects/'.$project.'/wiki/index.json', $params);
 
         return $this->wikiPages;
     }

--- a/src/Redmine/Exception/ConversionException.php
+++ b/src/Redmine/Exception/ConversionException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Redmine\Exception;
+
+use RuntimeException;
+use Redmine\Exception as RedmineException;
+
+class ConversionException extends RuntimeException implements RedmineException
+{
+}

--- a/src/Redmine/Exception/SerializerException.php
+++ b/src/Redmine/Exception/SerializerException.php
@@ -5,6 +5,6 @@ namespace Redmine\Exception;
 use RuntimeException;
 use Redmine\Exception as RedmineException;
 
-class ConversionException extends RuntimeException implements RedmineException
+class SerializerException extends RuntimeException implements RedmineException
 {
 }

--- a/src/Redmine/Serializer/JsonSerializer.php
+++ b/src/Redmine/Serializer/JsonSerializer.php
@@ -39,7 +39,7 @@ final class JsonSerializer
         return $this->normalized;
     }
 
-    private function decode(string $encoded)
+    private function decode(string $encoded): void
     {
         $this->encoded = $encoded;
 

--- a/src/Redmine/Serializer/JsonSerializer.php
+++ b/src/Redmine/Serializer/JsonSerializer.php
@@ -10,6 +10,9 @@ use Redmine\Exception\SerializerException;
  */
 final class JsonSerializer
 {
+    /**
+     * @throws SerializerException if $data is not valid JSON
+     */
     public static function createFromString(string $data): self
     {
         $serializer = new self();

--- a/src/Redmine/Serializer/JsonSerializer.php
+++ b/src/Redmine/Serializer/JsonSerializer.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Redmine\Serializer;
+
+use JsonException;
+use Redmine\Exception\SerializerException;
+
+/**
+ * JsonSerializer
+ */
+final class JsonSerializer
+{
+    public static function createFromString(string $data): self
+    {
+        $serializer = new self();
+        $serializer->decode($data);
+
+        return $serializer;
+    }
+
+    private string $encoded;
+
+    /** @var mixed $normalized */
+    private $normalized;
+
+    private function __construct()
+    {
+        // use factory method instead
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getNormalized()
+    {
+        return $this->normalized;
+    }
+
+    private function decode(string $encoded)
+    {
+        $this->encoded = $encoded;
+
+        try {
+            $this->normalized = json_decode(
+                $encoded,
+                true,
+                512,
+                \JSON_THROW_ON_ERROR
+            );
+        } catch (JsonException $e) {
+            throw new SerializerException(
+                'Catched error "' . $e->getMessage() . '" while decoding JSON: ' . $encoded,
+                $e->getCode(),
+                $e
+            );
+        }
+    }
+}

--- a/src/Redmine/Serializer/JsonSerializer.php
+++ b/src/Redmine/Serializer/JsonSerializer.php
@@ -7,6 +7,8 @@ use Redmine\Exception\SerializerException;
 
 /**
  * JsonSerializer
+ *
+ * @internal
  */
 final class JsonSerializer
 {

--- a/src/Redmine/Serializer/PathSerializer.php
+++ b/src/Redmine/Serializer/PathSerializer.php
@@ -31,6 +31,9 @@ final class PathSerializer
 
         if (! empty($this->queryParams)) {
             $queryString = '?' . \http_build_query($this->queryParams);
+
+            // @see #154: replace every encoded array (`foo[0]=`, `foo[1]=`, etc with `foo[]=`)
+            $queryString = preg_replace('/%5B[0-9]+%5D/simU', '%5B%5D', $queryString);
         }
 
         return $this->path . $queryString;

--- a/src/Redmine/Serializer/PathSerializer.php
+++ b/src/Redmine/Serializer/PathSerializer.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Redmine\Serializer;
+
+/**
+ * PathSerializer
+ */
+final class PathSerializer
+{
+    public static function create(string $path, array $queryParams = []): self
+    {
+        $serializer = new self();
+        $serializer->path = $path;
+        $serializer->queryParams = $queryParams;
+
+        return $serializer;
+    }
+
+    private string $path;
+
+    private array $queryParams;
+
+    private function __construct()
+    {
+        // use factory method instead
+    }
+
+    public function getPath(): string
+    {
+        $queryString = '';
+
+        if (! empty($this->queryParams)) {
+            $queryString = '?' . \http_build_query($this->queryParams);
+        }
+
+        return $this->path . $queryString;
+    }
+}

--- a/src/Redmine/Serializer/PathSerializer.php
+++ b/src/Redmine/Serializer/PathSerializer.php
@@ -4,6 +4,8 @@ namespace Redmine\Serializer;
 
 /**
  * PathSerializer
+ *
+ * @internal
  */
 final class PathSerializer
 {

--- a/src/Redmine/Serializer/XmlSerializer.php
+++ b/src/Redmine/Serializer/XmlSerializer.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Redmine\Serializer;
+
+use Exception;
+use Redmine\Exception\SerializerException;
+use SimpleXMLElement;
+
+/**
+ * XmlSerializer
+ */
+final class XmlSerializer
+{
+    /**
+     * @throws SerializerException if $data is not valid XML
+     */
+    public static function createFromString(string $data): self
+    {
+        $serializer = new self();
+        $serializer->deserialize($data);
+
+        return $serializer;
+    }
+
+    private string $encoded;
+
+    /** @var mixed $normalized */
+    private $normalized;
+
+    private SimpleXMLElement $deserialized;
+
+    private function __construct()
+    {
+        // use factory method instead
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getNormalized()
+    {
+        return $this->normalized;
+    }
+
+    private function deserialize(string $encoded)
+    {
+        $this->encoded = $encoded;
+
+        try {
+            $this->deserialized = new SimpleXMLElement($encoded);
+        } catch (Exception $e) {
+            throw new SerializerException(
+                'Catched error "' . $e->getMessage() . '" while decoding XML: ' . $encoded,
+                $e->getCode(),
+                $e
+            );
+        }
+
+        $this->normalize($this->deserialized);
+    }
+
+    private function normalize(SimpleXMLElement $deserialized)
+    {
+        try {
+            $serialized = json_encode($deserialized, \JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw new SerializerException(
+                'Catched error "' . $e->getMessage() . '" while encoding SimpleXMLElement',
+                $e->getCode(),
+                $e
+            );
+        }
+
+        $this->normalized = JsonSerializer::createFromString($serialized)->getNormalized();
+    }
+}

--- a/src/Redmine/Serializer/XmlSerializer.php
+++ b/src/Redmine/Serializer/XmlSerializer.php
@@ -42,7 +42,7 @@ final class XmlSerializer
         return $this->normalized;
     }
 
-    private function deserialize(string $encoded)
+    private function deserialize(string $encoded): void
     {
         $this->encoded = $encoded;
 
@@ -59,7 +59,7 @@ final class XmlSerializer
         $this->normalize($this->deserialized);
     }
 
-    private function normalize(SimpleXMLElement $deserialized)
+    private function normalize(SimpleXMLElement $deserialized): void
     {
         try {
             $serialized = json_encode($deserialized, \JSON_THROW_ON_ERROR);

--- a/src/Redmine/Serializer/XmlSerializer.php
+++ b/src/Redmine/Serializer/XmlSerializer.php
@@ -8,6 +8,8 @@ use SimpleXMLElement;
 
 /**
  * XmlSerializer
+ *
+ * @internal
  */
 final class XmlSerializer
 {

--- a/tests/Fixtures/MockClient.php
+++ b/tests/Fixtures/MockClient.php
@@ -139,7 +139,7 @@ class MockClient implements Client
 
         $this->responseBodyMock = json_encode($return);
         $this->responseCodeMock = 200;
-        $this->responseContentType = 'application/json';
+        $this->responseContentTypeMock = 'application/json';
 
         return true;
     }

--- a/tests/Integration/UrlTest.php
+++ b/tests/Integration/UrlTest.php
@@ -169,7 +169,13 @@ class UrlTest extends TestCase
         $res = $api->remove(1);
         $res = json_decode($res, true);
 
-        $this->assertEquals('/issue_categories/1.xml?', $res['path']);
+        $this->assertEquals('/issue_categories/1.xml', $res['path']);
+        $this->assertEquals('DELETE', $res['method']);
+
+        $res = $api->remove(1, ['reassign_to_id' => 16]);
+        $res = json_decode($res, true);
+
+        $this->assertEquals('/issue_categories/1.xml?reassign_to_id=16', $res['path']);
         $this->assertEquals('DELETE', $res['method']);
     }
 

--- a/tests/Integration/UrlTest.php
+++ b/tests/Integration/UrlTest.php
@@ -105,6 +105,11 @@ class UrlTest extends TestCase
         $this->assertEquals('/issues.json', $res['path']);
         $this->assertEquals('GET', $res['method']);
 
+        $res = $api->all(['limit' => 250]);
+
+        $this->assertEquals('/issues.json?limit=100&offset=0', $res['path']);
+        $this->assertEquals('GET', $res['method']);
+
         $res = $api->show(1);
 
         $this->assertEquals('/issues/1.json?', $res['path']);
@@ -332,6 +337,20 @@ class UrlTest extends TestCase
         $res = $api->all();
 
         $this->assertEquals('/time_entries.json', $res['path']);
+        $this->assertEquals('GET', $res['method']);
+
+        // Test for #154: fix http_build_query encoding array values with numeric keys
+        $res = $api->all([
+            "f"  => ["spent_on"],
+            "op" => ["spent_on" => "><"],
+            "v"  => [
+                "spent_on" => [
+                    "2016-01-18",
+                    "2016-01-22"
+                ]
+            ],
+        ]);
+        $this->assertEquals('/time_entries.json?limit=25&offset=0&f%5B%5D=spent_on&op%5Bspent_on%5D=%3E%3C&v%5Bspent_on%5D%5B%5D=2016-01-18&v%5Bspent_on%5D%5B%5D=2016-01-22', $res['path']);
         $this->assertEquals('GET', $res['method']);
 
         $res = $api->show(1);

--- a/tests/Integration/UrlTest.php
+++ b/tests/Integration/UrlTest.php
@@ -21,7 +21,6 @@ class UrlTest extends TestCase
     {
         $api = $this->client->getApi('attachment');
         $res = $api->show(1);
-        $res = json_decode($res, true);
 
         $this->assertEquals('/attachments/1.json', $res['path']);
         $this->assertEquals('GET', $res['method']);
@@ -37,7 +36,6 @@ class UrlTest extends TestCase
     {
         $api = $this->client->getApi('custom_fields');
         $res = $api->all();
-        $res = json_decode($res, true);
 
         $this->assertEquals('/custom_fields.json', $res['path']);
         $this->assertEquals('GET', $res['method']);
@@ -55,13 +53,11 @@ class UrlTest extends TestCase
         $this->assertEquals('POST', $res['method']);
 
         $res = $api->all();
-        $res = json_decode($res, true);
 
         $this->assertEquals('/groups.json', $res['path']);
         $this->assertEquals('GET', $res['method']);
 
         $res = $api->show(1);
-        $res = json_decode($res, true);
 
         $this->assertEquals('/groups/1.json?', $res['path']);
         $this->assertEquals('GET', $res['method']);
@@ -105,13 +101,11 @@ class UrlTest extends TestCase
         $this->assertEquals('PUT', $res['method']);
 
         $res = $api->all();
-        $res = json_decode($res, true);
 
         $this->assertEquals('/issues.json', $res['path']);
         $this->assertEquals('GET', $res['method']);
 
         $res = $api->show(1);
-        $res = json_decode($res, true);
 
         $this->assertEquals('/issues/1.json?', $res['path']);
         $this->assertEquals('GET', $res['method']);
@@ -158,13 +152,11 @@ class UrlTest extends TestCase
         $this->assertEquals('PUT', $res['method']);
 
         $res = $api->all('testProject');
-        $res = json_decode($res, true);
 
         $this->assertEquals('/projects/testProject/issue_categories.json', $res['path']);
         $this->assertEquals('GET', $res['method']);
 
         $res = $api->show(1);
-        $res = json_decode($res, true);
 
         $this->assertEquals('/issue_categories/1.json', $res['path']);
         $this->assertEquals('GET', $res['method']);
@@ -180,7 +172,6 @@ class UrlTest extends TestCase
     {
         $api = $this->client->getApi('issue_priority');
         $res = $api->all();
-        $res = json_decode($res, true);
 
         $this->assertEquals('/enumerations/issue_priorities.json', $res['path']);
         $this->assertEquals('GET', $res['method']);
@@ -190,7 +181,6 @@ class UrlTest extends TestCase
     {
         $api = $this->client->getApi('issue_relation');
         $res = $api->all(1);
-        $res = json_decode($res, true);
 
         $this->assertEquals('/issues/1/relations.json', $res['path']);
         $this->assertEquals('GET', $res['method']);
@@ -209,7 +199,6 @@ class UrlTest extends TestCase
     {
         $api = $this->client->getApi('issue_status');
         $res = $api->all();
-        $res = json_decode($res, true);
 
         $this->assertEquals('/issue_statuses.json', $res['path']);
         $this->assertEquals('GET', $res['method']);
@@ -237,7 +226,6 @@ class UrlTest extends TestCase
         $this->assertEquals('PUT', $res['method']);
 
         $res = $api->all('testProject');
-        $res = json_decode($res, true);
 
         $this->assertEquals('/projects/testProject/memberships.json', $res['path']);
         $this->assertEquals('GET', $res['method']);
@@ -253,13 +241,11 @@ class UrlTest extends TestCase
     {
         $api = $this->client->getApi('news');
         $res = $api->all();
-        $res = json_decode($res, true);
 
         $this->assertEquals('/news.json', $res['path']);
         $this->assertEquals('GET', $res['method']);
 
         $res = $api->all('testProject');
-        $res = json_decode($res, true);
 
         $this->assertEquals('/projects/testProject/news.json', $res['path']);
         $this->assertEquals('GET', $res['method']);
@@ -286,13 +272,11 @@ class UrlTest extends TestCase
         $this->assertEquals('PUT', $res['method']);
 
         $res = $api->all();
-        $res = json_decode($res, true);
 
         $this->assertEquals('/projects.json', $res['path']);
         $this->assertEquals('GET', $res['method']);
 
         $res = $api->show(1);
-        $res = json_decode($res, true);
 
         $this->assertEquals($res['path'], '/projects/1.json?include='.urlencode('trackers,issue_categories,attachments,relations'));
         $this->assertEquals('GET', $res['method']);
@@ -308,7 +292,6 @@ class UrlTest extends TestCase
     {
         $api = $this->client->getApi('query');
         $res = $api->all();
-        $res = json_decode($res, true);
 
         $this->assertEquals('/queries.json', $res['path']);
         $this->assertEquals('GET', $res['method']);
@@ -318,13 +301,11 @@ class UrlTest extends TestCase
     {
         $api = $this->client->getApi('role');
         $res = $api->all();
-        $res = json_decode($res, true);
 
         $this->assertEquals('/roles.json', $res['path']);
         $this->assertEquals('GET', $res['method']);
 
         $res = $api->show(1);
-        $res = json_decode($res, true);
 
         $this->assertEquals('/roles/1.json', $res['path']);
         $this->assertEquals('GET', $res['method']);
@@ -349,13 +330,11 @@ class UrlTest extends TestCase
         $this->assertEquals('PUT', $res['method']);
 
         $res = $api->all();
-        $res = json_decode($res, true);
 
         $this->assertEquals('/time_entries.json', $res['path']);
         $this->assertEquals('GET', $res['method']);
 
         $res = $api->show(1);
-        $res = json_decode($res, true);
 
         $this->assertEquals('/time_entries/1.json', $res['path']);
         $this->assertEquals('GET', $res['method']);
@@ -371,7 +350,6 @@ class UrlTest extends TestCase
     {
         $api = $this->client->getApi('time_entry_activity');
         $res = $api->all();
-        $res = json_decode($res, true);
 
         $this->assertEquals('/enumerations/time_entry_activities.json', $res['path']);
         $this->assertEquals('GET', $res['method']);
@@ -381,7 +359,6 @@ class UrlTest extends TestCase
     {
         $api = $this->client->getApi('tracker');
         $res = $api->all();
-        $res = json_decode($res, true);
 
         $this->assertEquals('/trackers.json', $res['path']);
         $this->assertEquals('GET', $res['method']);
@@ -408,31 +385,26 @@ class UrlTest extends TestCase
         $this->assertEquals('PUT', $res['method']);
 
         $res = $api->all();
-        $res = json_decode($res, true);
 
         $this->assertEquals('/users.json', $res['path']);
         $this->assertEquals('GET', $res['method']);
 
         $res = $api->show(1);
-        $res = json_decode($res, true);
 
         $this->assertEquals($res['path'], '/users/1.json?include='.urlencode('memberships,groups'));
         $this->assertEquals('GET', $res['method']);
 
         $res = $api->show(1, ['include' => ['memberships', 'groups']]);
-        $res = json_decode($res, true);
 
         $this->assertEquals($res['path'], '/users/1.json?include='.urlencode('memberships,groups'));
         $this->assertEquals('GET', $res['method']);
 
         $res = $api->show(1, ['include' => ['memberships', 'groups', 'parameter1']]);
-        $res = json_decode($res, true);
 
         $this->assertEquals($res['path'], '/users/1.json?include='.urlencode('memberships,groups,parameter1'));
         $this->assertEquals('GET', $res['method']);
 
         $res = $api->show(1, ['include' => ['parameter1', 'memberships', 'groups']]);
-        $res = json_decode($res, true);
 
         $this->assertEquals($res['path'], '/users/1.json?include='.urlencode('parameter1,memberships,groups'));
         $this->assertEquals('GET', $res['method']);
@@ -462,13 +434,11 @@ class UrlTest extends TestCase
         $this->assertEquals('PUT', $res['method']);
 
         $res = $api->all('testProject');
-        $res = json_decode($res, true);
 
         $this->assertEquals('/projects/testProject/versions.json', $res['path']);
         $this->assertEquals('GET', $res['method']);
 
         $res = $api->show(1);
-        $res = json_decode($res, true);
 
         $this->assertEquals('/versions/1.json', $res['path']);
         $this->assertEquals('GET', $res['method']);
@@ -504,19 +474,16 @@ class UrlTest extends TestCase
         $this->assertEquals('PUT', $res['method']);
 
         $res = $api->all('testProject');
-        $res = json_decode($res, true);
 
         $this->assertEquals('/projects/testProject/wiki/index.json', $res['path']);
         $this->assertEquals('GET', $res['method']);
 
         $res = $api->show('testProject', 'about');
-        $res = json_decode($res, true);
 
         $this->assertEquals('/projects/testProject/wiki/about.json?include=attachments', $res['path']);
         $this->assertEquals('GET', $res['method']);
 
         $res = $api->show('testProject', 'about', 'v1');
-        $res = json_decode($res, true);
 
         $this->assertEquals('/projects/testProject/wiki/about/v1.json?include=attachments', $res['path']);
         $this->assertEquals('GET', $res['method']);

--- a/tests/Integration/UrlTest.php
+++ b/tests/Integration/UrlTest.php
@@ -28,7 +28,7 @@ class UrlTest extends TestCase
         $res = $api->upload('asdf');
         $res = json_decode($res, true);
 
-        $this->assertEquals('/uploads.json?', $res['path']);
+        $this->assertEquals('/uploads.json', $res['path']);
         $this->assertEquals('POST', $res['method']);
     }
 
@@ -59,7 +59,7 @@ class UrlTest extends TestCase
 
         $res = $api->show(1);
 
-        $this->assertEquals('/groups/1.json?', $res['path']);
+        $this->assertEquals('/groups/1.json', $res['path']);
         $this->assertEquals('GET', $res['method']);
 
         $res = $api->remove(1);
@@ -112,7 +112,7 @@ class UrlTest extends TestCase
 
         $res = $api->show(1);
 
-        $this->assertEquals('/issues/1.json?', $res['path']);
+        $this->assertEquals('/issues/1.json', $res['path']);
         $this->assertEquals('GET', $res['method']);
 
         $res = $api->remove(1);

--- a/tests/Unit/Api/CustomFieldTest.php
+++ b/tests/Unit/Api/CustomFieldTest.php
@@ -25,7 +25,8 @@ class CustomFieldTest extends TestCase
     public function testAllReturnsClientGetResponse()
     {
         // Test values
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedResponse = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -38,12 +39,15 @@ class CustomFieldTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new CustomField($client);
 
         // Perform the tests
-        $this->assertSame($response, $api->all());
+        $this->assertSame($expectedResponse, $api->all());
     }
 
     /**
@@ -59,7 +63,8 @@ class CustomFieldTest extends TestCase
     {
         // Test values
         $allParameters = ['not-used'];
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedResponse = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -72,12 +77,15 @@ class CustomFieldTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new CustomField($client);
 
         // Perform the tests
-        $this->assertSame([$response], $api->all($allParameters));
+        $this->assertSame($expectedResponse, $api->all($allParameters));
     }
 
     /**
@@ -94,8 +102,8 @@ class CustomFieldTest extends TestCase
         // Test values
         $response = '{"limit":"100","items":[]}';
         $allParameters = ['limit' => 250];
-        $returnDataSet = [
-            'limit' => '100',
+        $expectedResponse = [
+            'limit' => ['100', '100', '100'], // TODO: Check response created by array_merge_recursive()
             'items' => [],
         ];
 
@@ -118,10 +126,7 @@ class CustomFieldTest extends TestCase
         $api = new CustomField($client);
 
         // Perform the tests
-        $retrievedDataSet = $api->all($allParameters);
-        $this->assertTrue(is_array($retrievedDataSet));
-        $this->assertArrayHasKey('limit', $retrievedDataSet);
-        $this->assertArrayHasKey('items', $retrievedDataSet);
+        $this->assertSame($expectedResponse, $api->all($allParameters));
     }
 
     /**

--- a/tests/Unit/Api/GroupTest.php
+++ b/tests/Unit/Api/GroupTest.php
@@ -24,7 +24,8 @@ class GroupTest extends TestCase
     public function testAllReturnsClientGetResponse()
     {
         // Test values
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -37,12 +38,15 @@ class GroupTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new Group($client);
 
         // Perform the tests
-        $this->assertSame($response, $api->all());
+        $this->assertSame($expectedReturn, $api->all());
     }
 
     /**
@@ -55,7 +59,8 @@ class GroupTest extends TestCase
     {
         // Test values
         $parameters = ['not-used'];
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -71,12 +76,15 @@ class GroupTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new Group($client);
 
         // Perform the tests
-        $this->assertSame([$response], $api->all($parameters));
+        $this->assertSame($expectedReturn, $api->all($parameters));
     }
 
     /**
@@ -202,7 +210,8 @@ class GroupTest extends TestCase
     public function testShowReturnsClientGetResponse()
     {
         // Test values
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -213,12 +222,15 @@ class GroupTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new Group($client);
 
         // Perform the tests
-        $this->assertSame($response, $api->show(5));
+        $this->assertSame($expectedReturn, $api->show(5));
     }
 
     /**
@@ -231,8 +243,9 @@ class GroupTest extends TestCase
     public function testShowCallsGetUrlWithParameters()
     {
         // Test values
-        $response = 'API Response';
         $allParameters = ['not-used'];
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -248,12 +261,15 @@ class GroupTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new Group($client);
 
         // Perform the tests
-        $this->assertSame($response, $api->show(5, $allParameters));
+        $this->assertSame($expectedReturn, $api->show(5, $allParameters));
     }
 
     /**
@@ -266,7 +282,8 @@ class GroupTest extends TestCase
     public function testRemoveCallsDelete()
     {
         // Test values
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = $response;
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -285,12 +302,15 @@ class GroupTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(0))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new Group($client);
 
         // Perform the tests
-        $this->assertSame($response, $api->remove(5));
+        $this->assertSame($expectedReturn, $api->remove(5));
     }
 
     /**

--- a/tests/Unit/Api/IssueCategoryTest.php
+++ b/tests/Unit/Api/IssueCategoryTest.php
@@ -25,7 +25,8 @@ class IssueCategoryTest extends TestCase
     {
         // Test values
         $projectId = 5;
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -38,12 +39,15 @@ class IssueCategoryTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new IssueCategory($client);
 
         // Perform the tests
-        $this->assertSame($response, $api->all($projectId));
+        $this->assertSame($expectedReturn, $api->all($projectId));
     }
 
     /**

--- a/tests/Unit/Api/IssueCategoryTest.php
+++ b/tests/Unit/Api/IssueCategoryTest.php
@@ -57,7 +57,8 @@ class IssueCategoryTest extends TestCase
         // Test values
         $projectId = 5;
         $parameters = ['not-used'];
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -73,12 +74,15 @@ class IssueCategoryTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new IssueCategory($client);
 
         // Perform the tests
-        $this->assertSame([$response], $api->all($projectId, $parameters));
+        $this->assertSame($expectedReturn, $api->all($projectId, $parameters));
     }
 
     /**

--- a/tests/Unit/Api/IssueCategoryTest.php
+++ b/tests/Unit/Api/IssueCategoryTest.php
@@ -248,12 +248,9 @@ class IssueCategoryTest extends TestCase
         $client->expects($this->once())
             ->method('requestDelete')
             ->with(
-                $this->logicalAnd(
-                    $this->stringStartsWith('/issue_categories/5'),
-                    $this->logicalXor(
-                        $this->stringContains('.json?'),
-                        $this->stringContains('.xml?')
-                    )
+                $this->logicalXor(
+                    $this->stringStartsWith('/issue_categories/5.json'),
+                    $this->stringStartsWith('/issue_categories/5.xml')
                 )
             )
             ->willReturn(true);

--- a/tests/Unit/Api/IssuePriorityTest.php
+++ b/tests/Unit/Api/IssuePriorityTest.php
@@ -22,7 +22,8 @@ class IssuePriorityTest extends TestCase
     public function testAllReturnsClientGetResponse()
     {
         // Test values
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -35,12 +36,15 @@ class IssuePriorityTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new IssuePriority($client);
 
         // Perform the tests
-        $this->assertSame($response, $api->all());
+        $this->assertSame($expectedReturn, $api->all());
     }
 
     /**
@@ -53,7 +57,8 @@ class IssuePriorityTest extends TestCase
     {
         // Test values
         $allParameters = ['not-used'];
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -66,11 +71,14 @@ class IssuePriorityTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new IssuePriority($client);
 
         // Perform the tests
-        $this->assertSame([$response], $api->all($allParameters));
+        $this->assertSame($expectedReturn, $api->all($allParameters));
     }
 }

--- a/tests/Unit/Api/IssueRelationTest.php
+++ b/tests/Unit/Api/IssueRelationTest.php
@@ -22,7 +22,8 @@ class IssueRelationTest extends TestCase
     public function testAllReturnsClientGetResponseWithProject()
     {
         // Test values
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -35,12 +36,15 @@ class IssueRelationTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new IssueRelation($client);
 
         // Perform the tests
-        $this->assertSame($response, $api->all(5));
+        $this->assertSame($expectedReturn, $api->all(5));
     }
 
     /**
@@ -53,7 +57,8 @@ class IssueRelationTest extends TestCase
     {
         // Test values
         $parameters = ['not-used'];
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -69,12 +74,15 @@ class IssueRelationTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new IssueRelation($client);
 
         // Perform the tests
-        $this->assertSame([$response], $api->all(5, $parameters));
+        $this->assertSame($expectedReturn, $api->all(5, $parameters));
     }
 
     /**
@@ -121,6 +129,9 @@ class IssueRelationTest extends TestCase
      */
     public function testShowReturnsArrayIfNull()
     {
+        $response = '';
+        $expectedReturn = [];
+
         // Create the used mock objects
         $client = $this->createMock(Client::class);
         $client->expects($this->once())
@@ -129,13 +140,16 @@ class IssueRelationTest extends TestCase
             ->willReturn(false);
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
-            ->willReturn('');
+            ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new IssueRelation($client);
 
         // Perform the tests
-        $this->assertSame([], $api->show(5));
+        $this->assertSame($expectedReturn, $api->show(5));
     }
 
     /**
@@ -148,7 +162,8 @@ class IssueRelationTest extends TestCase
     public function testRemoveCallsDelete()
     {
         // Test values
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = '["API Response"]';
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -167,12 +182,15 @@ class IssueRelationTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(0))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new IssueRelation($client);
 
         // Perform the tests
-        $this->assertSame($response, $api->remove(5));
+        $this->assertSame($expectedReturn, $api->remove(5));
     }
 
     /**
@@ -185,31 +203,34 @@ class IssueRelationTest extends TestCase
     public function testCreateCallsPost()
     {
         // Test values
-        $response = '{"test":"response"}';
-        $responseArray = ['test' => 'response'];
         $parameters = [];
+        $response = '{"test":"response"}';
+        $expectedReturn = ['test' => 'response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
         $client->expects($this->once())
-                ->method('requestPost')
-                ->with(
-                    '/issues/1/relations.json',
-                    json_encode([
-                        'relation' => [
-                            'relation_type' => 'relates',
-                        ],
-                    ])
-                )
-                ->willReturn(true);
+            ->method('requestPost')
+            ->with(
+                '/issues/1/relations.json',
+                json_encode([
+                    'relation' => [
+                        'relation_type' => 'relates',
+                    ],
+                ])
+            )
+            ->willReturn(true);
         $client->expects($this->exactly(1))
-                ->method('getLastResponseBody')
-                ->willReturn($response);
+            ->method('getLastResponseBody')
+            ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new IssueRelation($client);
 
         // Perform the tests
-        $this->assertSame($responseArray, $api->create(1, $parameters));
+        $this->assertSame($expectedReturn, $api->create(1, $parameters));
     }
 }

--- a/tests/Unit/Api/IssueStatusTest.php
+++ b/tests/Unit/Api/IssueStatusTest.php
@@ -22,7 +22,8 @@ class IssueStatusTest extends TestCase
     public function testAllReturnsClientGetResponse()
     {
         // Test values
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -35,12 +36,15 @@ class IssueStatusTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new IssueStatus($client);
 
         // Perform the tests
-        $this->assertSame($response, $api->all());
+        $this->assertSame($expectedReturn, $api->all());
     }
 
     /**
@@ -53,7 +57,8 @@ class IssueStatusTest extends TestCase
     {
         // Test values
         $parameters = ['not-used'];
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -69,12 +74,15 @@ class IssueStatusTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new IssueStatus($client);
 
         // Perform the tests
-        $this->assertSame([$response], $api->all($parameters));
+        $this->assertSame($expectedReturn, $api->all($parameters));
     }
 
     /**

--- a/tests/Unit/Api/IssueTest.php
+++ b/tests/Unit/Api/IssueTest.php
@@ -13,18 +13,26 @@ use Redmine\Client\Client;
  */
 class IssueTest extends TestCase
 {
+    public function getPriorityConstantsData()
+    {
+        return [
+            [1, Issue::PRIO_LOW],
+            [2, Issue::PRIO_NORMAL],
+            [3, Issue::PRIO_HIGH],
+            [4, Issue::PRIO_URGENT],
+            [5, Issue::PRIO_IMMEDIATE],
+        ];
+    }
     /**
      * Test the constants.
      *
+     * @dataProvider getPriorityConstantsData
+     *
      * @test
      */
-    public function testPriorityConstants()
+    public function testPriorityConstants($expected, $value)
     {
-        $this->assertSame(1, Issue::PRIO_LOW);
-        $this->assertSame(2, Issue::PRIO_NORMAL);
-        $this->assertSame(3, Issue::PRIO_HIGH);
-        $this->assertSame(4, Issue::PRIO_URGENT);
-        $this->assertSame(5, Issue::PRIO_IMMEDIATE);
+        $this->assertSame($expected, $value);
     }
 
     /**
@@ -36,7 +44,8 @@ class IssueTest extends TestCase
     public function testAllReturnsClientGetResponse()
     {
         // Test values
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -49,12 +58,15 @@ class IssueTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new Issue($client);
 
         // Perform the tests
-        $this->assertSame($response, $api->all());
+        $this->assertSame($expectedReturn, $api->all());
     }
 
     /**
@@ -67,7 +79,8 @@ class IssueTest extends TestCase
     {
         // Test values
         $parameters = ['not-used'];
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -83,12 +96,15 @@ class IssueTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new Issue($client);
 
         // Perform the tests
-        $this->assertSame([$response], $api->all($parameters));
+        $this->assertSame($expectedReturn, $api->all($parameters));
     }
 
     /**
@@ -101,7 +117,8 @@ class IssueTest extends TestCase
     public function testShowReturnsClientGetResponse()
     {
         // Test values
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -112,12 +129,15 @@ class IssueTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new Issue($client);
 
         // Perform the tests
-        $this->assertSame($response, $api->show(5));
+        $this->assertSame($expectedReturn, $api->show(5));
     }
 
     /**
@@ -130,8 +150,9 @@ class IssueTest extends TestCase
     public function testShowCallsGetUrlWithParameters()
     {
         // Test values
-        $response = 'API Response';
         $allParameters = ['not-used'];
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -147,12 +168,15 @@ class IssueTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new Issue($client);
 
         // Perform the tests
-        $this->assertSame($response, $api->show(5, $allParameters));
+        $this->assertSame($expectedReturn, $api->show(5, $allParameters));
     }
 
     /**
@@ -165,7 +189,8 @@ class IssueTest extends TestCase
     {
         // Test values
         $parameters = ['include' => ['parameter1', 'parameter2']];
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -181,12 +206,15 @@ class IssueTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new Issue($client);
 
         // Perform the tests
-        $this->assertSame($response, $api->show(5, $parameters));
+        $this->assertSame($expectedReturn, $api->show(5, $parameters));
     }
 
     /**

--- a/tests/Unit/Api/MembershipTest.php
+++ b/tests/Unit/Api/MembershipTest.php
@@ -24,7 +24,8 @@ class MembershipTest extends TestCase
     public function testAllReturnsClientGetResponseWithProject()
     {
         // Test values
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -37,12 +38,15 @@ class MembershipTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new Membership($client);
 
         // Perform the tests
-        $this->assertSame($response, $api->all(5));
+        $this->assertSame($expectedReturn, $api->all(5));
     }
 
     /**
@@ -55,7 +59,8 @@ class MembershipTest extends TestCase
     {
         // Test values
         $parameters = ['not-used'];
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -71,12 +76,15 @@ class MembershipTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new Membership($client);
 
         // Perform the tests
-        $this->assertSame([$response], $api->all(5, $parameters));
+        $this->assertSame($expectedReturn, $api->all(5, $parameters));
     }
 
     /**

--- a/tests/Unit/Api/NewsTest.php
+++ b/tests/Unit/Api/NewsTest.php
@@ -22,7 +22,8 @@ class NewsTest extends TestCase
     public function testAllReturnsClientGetResponse()
     {
         // Test values
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -35,12 +36,15 @@ class NewsTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new News($client);
 
         // Perform the tests
-        $this->assertSame($response, $api->all());
+        $this->assertSame($expectedReturn, $api->all());
     }
 
     /**
@@ -53,7 +57,8 @@ class NewsTest extends TestCase
     {
         // Test values
         $projectId = 5;
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -66,12 +71,15 @@ class NewsTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new News($client);
 
         // Perform the tests
-        $this->assertSame($response, $api->all($projectId));
+        $this->assertSame($expectedReturn, $api->all($projectId));
     }
 
     /**
@@ -85,7 +93,8 @@ class NewsTest extends TestCase
         // Test values
         $projectId = 5;
         $parameters = ['not-used'];
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -98,11 +107,14 @@ class NewsTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new News($client);
 
         // Perform the tests
-        $this->assertSame([$response], $api->all($projectId, $parameters));
+        $this->assertSame($expectedReturn, $api->all($projectId, $parameters));
     }
 }

--- a/tests/Unit/Api/ProjectTest.php
+++ b/tests/Unit/Api/ProjectTest.php
@@ -24,7 +24,8 @@ class ProjectTest extends TestCase
     public function testAllReturnsClientGetResponse()
     {
         // Test values
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -35,12 +36,15 @@ class ProjectTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new Project($client);
 
         // Perform the tests
-        $this->assertSame($response, $api->all());
+        $this->assertSame($expectedReturn, $api->all());
     }
 
     /**
@@ -53,7 +57,8 @@ class ProjectTest extends TestCase
     {
         // Test values
         $parameters = ['not-used'];
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -69,12 +74,15 @@ class ProjectTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new Project($client);
 
         // Perform the tests
-        $this->assertSame([$response], $api->all($parameters));
+        $this->assertSame($expectedReturn, $api->all($parameters));
     }
 
     /**
@@ -87,7 +95,8 @@ class ProjectTest extends TestCase
     public function testShowReturnsClientGetResponse()
     {
         // Test values
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -101,12 +110,15 @@ class ProjectTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new Project($client);
 
         // Perform the tests
-        $this->assertSame($response, $api->show(5));
+        $this->assertSame($expectedReturn, $api->show(5));
     }
 
     /**
@@ -120,7 +132,8 @@ class ProjectTest extends TestCase
     {
         // Test values
         $parameters = ['include' => ['parameter1', 'parameter2', 'enabled_modules']];
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -136,12 +149,15 @@ class ProjectTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new Project($client);
 
         // Perform the tests
-        $this->assertSame($response, $api->show(5, $parameters));
+        $this->assertSame($expectedReturn, $api->show(5, $parameters));
     }
 
     /**

--- a/tests/Unit/Api/QueryTest.php
+++ b/tests/Unit/Api/QueryTest.php
@@ -22,7 +22,8 @@ class QueryTest extends TestCase
     public function testAllReturnsClientGetResponse()
     {
         // Test values
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -35,12 +36,15 @@ class QueryTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new Query($client);
 
         // Perform the tests
-        $this->assertSame($response, $api->all());
+        $this->assertSame($expectedReturn, $api->all());
     }
 
     /**
@@ -53,7 +57,8 @@ class QueryTest extends TestCase
     {
         // Test values
         $parameters = ['not-used'];
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -69,11 +74,14 @@ class QueryTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new Query($client);
 
         // Perform the tests
-        $this->assertSame([$response], $api->all($parameters));
+        $this->assertSame($expectedReturn, $api->all($parameters));
     }
 }

--- a/tests/Unit/Api/RoleTest.php
+++ b/tests/Unit/Api/RoleTest.php
@@ -22,7 +22,8 @@ class RoleTest extends TestCase
     public function testAllReturnsClientGetResponse()
     {
         // Test values
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -35,12 +36,15 @@ class RoleTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new Role($client);
 
         // Perform the tests
-        $this->assertSame($response, $api->all());
+        $this->assertSame($expectedReturn, $api->all());
     }
 
     /**
@@ -53,7 +57,8 @@ class RoleTest extends TestCase
     {
         // Test values
         $parameters = ['not-used'];
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -69,12 +74,15 @@ class RoleTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new Role($client);
 
         // Perform the tests
-        $this->assertSame([$response], $api->all($parameters));
+        $this->assertSame($expectedReturn, $api->all($parameters));
     }
 
     /**
@@ -200,7 +208,8 @@ class RoleTest extends TestCase
     public function testShowReturnsClientGetResponse()
     {
         // Test values
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);

--- a/tests/Unit/Api/TimeEntryActivityTest.php
+++ b/tests/Unit/Api/TimeEntryActivityTest.php
@@ -22,7 +22,8 @@ class TimeEntryActivityTest extends TestCase
     public function testAllReturnsClientGetResponse()
     {
         // Test values
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -35,12 +36,15 @@ class TimeEntryActivityTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new TimeEntryActivity($client);
 
         // Perform the tests
-        $this->assertSame($response, $api->all());
+        $this->assertSame($expectedReturn, $api->all());
     }
 
     /**
@@ -53,7 +57,8 @@ class TimeEntryActivityTest extends TestCase
     {
         // Test values
         $parameters = ['not-used'];
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -69,12 +74,15 @@ class TimeEntryActivityTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new TimeEntryActivity($client);
 
         // Perform the tests
-        $this->assertSame([$response], $api->all($parameters));
+        $this->assertSame($expectedReturn, $api->all($parameters));
     }
 
     public function testListingReturnsNameIdArray()

--- a/tests/Unit/Api/TimeEntryTest.php
+++ b/tests/Unit/Api/TimeEntryTest.php
@@ -24,7 +24,8 @@ class TimeEntryTest extends TestCase
     public function testAllReturnsClientGetResponse()
     {
         // Test values
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -35,12 +36,15 @@ class TimeEntryTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new TimeEntry($client);
 
         // Perform the tests
-        $this->assertSame($response, $api->all());
+        $this->assertSame($expectedReturn, $api->all());
     }
 
     /**
@@ -57,7 +61,8 @@ class TimeEntryTest extends TestCase
             'user_id' => 10,
             'limit' => 2,
         ];
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -75,12 +80,15 @@ class TimeEntryTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new TimeEntry($client);
 
         // Perform the tests
-        $this->assertSame([$response], $api->all($parameters));
+        $this->assertSame($expectedReturn, $api->all($parameters));
     }
 
     /**
@@ -93,7 +101,8 @@ class TimeEntryTest extends TestCase
     public function testShowReturnsClientGetResponse()
     {
         // Test values
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -104,12 +113,15 @@ class TimeEntryTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new TimeEntry($client);
 
         // Perform the tests
-        $this->assertSame($response, $api->show(5));
+        $this->assertSame($expectedReturn, $api->show(5));
     }
 
     /**

--- a/tests/Unit/Api/TrackerTest.php
+++ b/tests/Unit/Api/TrackerTest.php
@@ -22,7 +22,8 @@ class TrackerTest extends TestCase
     public function testAllReturnsClientGetResponse()
     {
         // Test values
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -35,12 +36,15 @@ class TrackerTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new Tracker($client);
 
         // Perform the tests
-        $this->assertSame($response, $api->all());
+        $this->assertSame($expectedReturn, $api->all());
     }
 
     /**
@@ -53,7 +57,8 @@ class TrackerTest extends TestCase
     {
         // Test values
         $parameters = ['not-used'];
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -69,12 +74,15 @@ class TrackerTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new Tracker($client);
 
         // Perform the tests
-        $this->assertSame([$response], $api->all($parameters));
+        $this->assertSame($expectedReturn, $api->all($parameters));
     }
 
     /**

--- a/tests/Unit/Api/UserTest.php
+++ b/tests/Unit/Api/UserTest.php
@@ -24,7 +24,8 @@ class UserTest extends TestCase
     public function testGetCurrentUserReturnsClientGetResponse()
     {
         // Test values
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -40,12 +41,15 @@ class UserTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new User($client);
 
         // Perform the tests
-        $this->assertSame($response, $api->getCurrentUser());
+        $this->assertSame($expectedReturn, $api->getCurrentUser());
     }
 
     /**
@@ -73,6 +77,9 @@ class UserTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
             ->willReturn('application/json');
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new User($client);
@@ -91,7 +98,8 @@ class UserTest extends TestCase
     public function testAllReturnsClientGetResponse()
     {
         // Test values
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -102,12 +110,15 @@ class UserTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new User($client);
 
         // Perform the tests
-        $this->assertSame($response, $api->all());
+        $this->assertSame($expectedReturn, $api->all());
     }
 
     /**
@@ -123,7 +134,8 @@ class UserTest extends TestCase
             'offset' => 10,
             'limit' => 2,
         ];
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -140,12 +152,15 @@ class UserTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new User($client);
 
         // Perform the tests
-        $this->assertSame([$response], $api->all($parameters));
+        $this->assertSame($expectedReturn, $api->all($parameters));
     }
 
     /**
@@ -158,7 +173,8 @@ class UserTest extends TestCase
     public function testShowReturnsClientGetResponse()
     {
         // Test values
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -174,12 +190,15 @@ class UserTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new User($client);
 
         // Perform the tests
-        $this->assertSame($response, $api->show(5));
+        $this->assertSame($expectedReturn, $api->show(5));
     }
 
     /**
@@ -193,7 +212,8 @@ class UserTest extends TestCase
     {
         // Test values
         $parameters = ['include' => ['parameter1', 'parameter2', 'memberships']];
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -209,12 +229,15 @@ class UserTest extends TestCase
         $client->expects($this->exactly(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new User($client);
 
         // Perform the tests
-        $this->assertSame($response, $api->show(5, $parameters));
+        $this->assertSame($expectedReturn, $api->show(5, $parameters));
     }
 
     /**

--- a/tests/Unit/Api/VersionTest.php
+++ b/tests/Unit/Api/VersionTest.php
@@ -25,7 +25,8 @@ class VersionTest extends TestCase
     public function testAllReturnsClientGetResponse()
     {
         // Test values
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -36,12 +37,15 @@ class VersionTest extends TestCase
         $client->expects($this->once())
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new Version($client);
 
         // Perform the tests
-        $this->assertSame($response, $api->all(5));
+        $this->assertSame($expectedReturn, $api->all(5));
     }
 
     /**
@@ -57,7 +61,8 @@ class VersionTest extends TestCase
             'offset' => 10,
             'limit' => 2,
         ];
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -74,12 +79,15 @@ class VersionTest extends TestCase
         $client->expects($this->once())
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new Version($client);
 
         // Perform the tests
-        $this->assertSame([$response], $api->all(5, $parameters));
+        $this->assertSame($expectedReturn, $api->all(5, $parameters));
     }
 
     /**
@@ -92,7 +100,8 @@ class VersionTest extends TestCase
     public function testShowWithNumericIdReturnsClientGetResponse()
     {
         // Test values
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -103,12 +112,15 @@ class VersionTest extends TestCase
         $client->expects($this->once())
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new Version($client);
 
         // Perform the tests
-        $this->assertSame($response, $api->show(5));
+        $this->assertSame($expectedReturn, $api->show(5));
     }
 
     /**
@@ -121,7 +133,8 @@ class VersionTest extends TestCase
     public function testShowWithStringReturnsClientGetResponse()
     {
         // Test values
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -132,12 +145,15 @@ class VersionTest extends TestCase
         $client->expects($this->once())
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new Version($client);
 
         // Perform the tests
-        $this->assertSame($response, $api->show('test'));
+        $this->assertSame($expectedReturn, $api->show('test'));
     }
 
     /**

--- a/tests/Unit/Api/WikiTest.php
+++ b/tests/Unit/Api/WikiTest.php
@@ -54,7 +54,8 @@ class WikiTest extends TestCase
             'offset' => 10,
             'limit' => 2,
         ];
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -71,12 +72,15 @@ class WikiTest extends TestCase
         $client->expects($this->once())
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new Wiki($client);
 
         // Perform the tests
-        $this->assertSame([$response], $api->all(5, $parameters));
+        $this->assertSame($expectedReturn, $api->all(5, $parameters));
     }
 
     /**

--- a/tests/Unit/Api/WikiTest.php
+++ b/tests/Unit/Api/WikiTest.php
@@ -22,7 +22,8 @@ class WikiTest extends TestCase
     public function testAllReturnsClientGetResponse()
     {
         // Test values
-        $response = 'API Response';
+        $response = '["API Response"]';
+        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -33,12 +34,15 @@ class WikiTest extends TestCase
         $client->expects($this->once())
             ->method('getLastResponseBody')
             ->willReturn($response);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
 
         // Create the object under test
         $api = new Wiki($client);
 
         // Perform the tests
-        $this->assertSame($response, $api->all(5));
+        $this->assertSame($expectedReturn, $api->all(5));
     }
 
     /**

--- a/tests/Unit/Serializer/JsonSerializerTest.php
+++ b/tests/Unit/Serializer/JsonSerializerTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Redmine\Tests\Unit\Serializer;
+
+use PHPUnit\Framework\TestCase;
+use Redmine\Exception\SerializerException;
+use Redmine\Serializer\JsonSerializer;
+
+class JsonSerializerTest extends TestCase
+{
+    public function getNormalizedAndEncodedData()
+    {
+        return [
+            [
+                'null',
+                null,
+            ],
+            [
+                'true',
+                true,
+            ],
+            [
+                'false',
+                false,
+            ],
+            [
+                '0',
+                0,
+            ],
+            [
+                '""',
+                '',
+            ],
+            [
+                '"foobar"',
+                'foobar',
+            ],
+            [
+                '[]',
+                [],
+            ],
+            [
+                '{}',
+                [],
+            ],
+            [
+                '["foo","bar"]',
+                ['foo','bar'],
+            ],
+            [
+                '{"foo":"bar"}',
+                ['foo' => 'bar'],
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider getNormalizedAndEncodedData
+     */
+    public function createFromStringDecodesToExpectedNormalizedData(string $data, $expected)
+    {
+        $serializer = JsonSerializer::createFromString($data);
+
+        $this->assertSame($expected, $serializer->getNormalized());
+    }
+
+    public function getInvalidEncodedData()
+    {
+        return [
+            [''],
+            ['["foo":"bar"]'],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider getInvalidEncodedData
+     */
+    public function createFromStringWithInvalidStringThrowsException(string $data)
+    {
+        $this->expectException(SerializerException::class);
+
+        $serializer = JsonSerializer::createFromString($data);
+    }
+}

--- a/tests/Unit/Serializer/PathSerializerTest.php
+++ b/tests/Unit/Serializer/PathSerializerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Redmine\Tests\Unit\Serializer;
+
+use PHPUnit\Framework\TestCase;
+use Redmine\Serializer\PathSerializer;
+
+class PathSerializerTest extends TestCase
+{
+    public function getPathData()
+    {
+        return [
+            [
+                'foo.json',
+                [],
+                'foo.json'
+            ],
+            [
+                'foo.xml?format=xml',
+                [],
+                'foo.xml?format=xml'
+            ],
+            [
+                'foo.xml',
+                [
+                    'format' => 'xml',
+                ],
+                'foo.xml?format=xml'
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider getPathData
+     */
+    public function getPathShouldReturn(string $path, array $params, string $expected)
+    {
+        $serializer = PathSerializer::create($path, $params);
+
+        $this->assertSame($expected, $serializer->getPath());
+    }
+}

--- a/tests/Unit/Serializer/PathSerializerTest.php
+++ b/tests/Unit/Serializer/PathSerializerTest.php
@@ -15,19 +15,34 @@ class PathSerializerTest extends TestCase
             [
                 'foo.json',
                 [],
-                'foo.json'
+                'foo.json',
             ],
             [
                 'foo.xml?format=xml',
                 [],
-                'foo.xml?format=xml'
+                'foo.xml?format=xml',
             ],
             [
                 'foo.xml',
                 [
                     'format' => 'xml',
                 ],
-                'foo.xml?format=xml'
+                'foo.xml?format=xml',
+            ],
+            // Test for #154: fix http_build_query encoding array values with numeric keys
+            [
+                '/time_entries.json',
+                [
+                    'f'  => ['spent_on'],
+                    'op' => ['spent_on' => '><'],
+                    'v'  => [
+                        'spent_on' => [
+                            '2016-01-18',
+                            '2016-01-22'
+                        ],
+                    ],
+                ],
+                '/time_entries.json?f%5B%5D=spent_on&op%5Bspent_on%5D=%3E%3C&v%5Bspent_on%5D%5B%5D=2016-01-18&v%5Bspent_on%5D%5B%5D=2016-01-22',
             ],
         ];
     }
@@ -37,7 +52,7 @@ class PathSerializerTest extends TestCase
      *
      * @dataProvider getPathData
      */
-    public function getPathShouldReturn(string $path, array $params, string $expected)
+    public function getPathShouldReturnExpectedString(string $path, array $params, string $expected)
     {
         $serializer = PathSerializer::create($path, $params);
 

--- a/tests/Unit/Serializer/XmlSerializerTest.php
+++ b/tests/Unit/Serializer/XmlSerializerTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Redmine\Tests\Unit\Serializer;
+
+use PHPUnit\Framework\TestCase;
+use Redmine\Exception\SerializerException;
+use Redmine\Serializer\XmlSerializer;
+
+class XmlSerializerTest extends TestCase
+{
+    public function getNormalizedAndEncodedData()
+    {
+        return [
+            [
+                '<a/>',
+                [],
+            ],
+            [
+                '<?xml version="1.0"?><issue/>',
+                [],
+            ],
+            [
+                '<?xml version="1.0"?><issue></issue>',
+                [],
+            ],
+            [
+                '<?xml version="1.0"?><issue>1</issue>',
+                ['1'],
+            ],
+            [
+                <<< END
+                <?xml version="1.0" encoding="UTF-8"?>
+                <issues type="array" count="1640">
+                  <issue>
+                    <id>4326</id>
+                  </issue>
+                  <issue>
+                    <id>4325</id>
+                  </issue>
+                </issues>
+                END,
+                [
+                    '@attributes' => [
+                        'type' => 'array',
+                        'count' => '1640',
+                    ],
+                    'issue' => [
+                        [
+                            'id' => '4326',
+                        ],
+                        [
+                            'id' => '4325',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider getNormalizedAndEncodedData
+     */
+    public function createFromStringDecodesToExpectedNormalizedData(string $data, $expected)
+    {
+        $serializer = XmlSerializer::createFromString($data);
+
+        $this->assertSame($expected, $serializer->getNormalized());
+    }
+
+    public function getInvalidEncodedData()
+    {
+        return [
+            [''],
+            ['<?xml version="1.0" encoding="UTF-8"?>'],
+            ['<?xml version="1.0" encoding="UTF-8"?><>'],
+            ['<?xml version="1.0" encoding="UTF-8"?><a>'],
+            ['<?xml version="1.0" encoding="UTF-8"?></>'],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider getInvalidEncodedData
+     */
+    public function createFromStringWithInvalidStringThrowsException(string $data)
+    {
+        $this->expectException(SerializerException::class);
+
+        $serializer = XmlSerializer::createFromString($data);
+    }
+}


### PR DESCRIPTION
Hey :wave: 

The method `Redmine\Client\AbstractApi::retrieveData()` returns many elements of an endpoint as an array. During the conversion of the response, errors may occur under certain circumstances. In this case the method would return `false`, or throw an `Throwable`.

To better guarantee that only an array is returned (and not false) I created a new method `retrieveData()`. In case of errors in the response a new `SerializerException` is thrown.

The method `retrieveAll()` also uses 3 new internal serializers, in which I have outsourced the logic for decoding and encoding XML, JSON and URL paths. I am already working on a next PR where these serializers will be used to bundle the serialization of request/response bodies for XML and JSON. This will be a next step to be able to dynamically switch the format in the request/response between XML and JSON, see #146.
