### PR TITLE
Improve Xml- and JsonSerializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/kbsali/php-redmine-api/compare/v2.2.0...v2.x)
 
+### Deprecated
+
+- `Redmine\Api\AbstractApi::attachCustomFieldXML()` is deprecated
+- `Redmine\Api\Project::prepareParamsXml()` is deprecated
+
 ## [v2.2.0](https://github.com/kbsali/php-redmine-api/compare/v2.1.1...v2.2.0) - 2022-03-01
 
 ### Added

--- a/src/Redmine/Api/AbstractApi.php
+++ b/src/Redmine/Api/AbstractApi.php
@@ -253,6 +253,8 @@ abstract class AbstractApi implements Api
     /**
      * Attaches Custom Fields to a create/update query.
      *
+     * @deprecated the `attachCustomFieldXML()` method is deprecated.
+     *
      * @param SimpleXMLElement $xml    XML Element the custom fields are attached to
      * @param array            $fields array of fields to attach, each field needs name, id and value set
      *
@@ -262,6 +264,8 @@ abstract class AbstractApi implements Api
      */
     protected function attachCustomFieldXML(SimpleXMLElement $xml, array $fields)
     {
+        @trigger_error('The '.__METHOD__.' method is deprecated.', E_USER_DEPRECATED);
+
         $_fields = $xml->addChild('custom_fields');
         $_fields->addAttribute('type', 'array');
         foreach ($fields as $field) {

--- a/src/Redmine/Api/AbstractApi.php
+++ b/src/Redmine/Api/AbstractApi.php
@@ -186,7 +186,7 @@ abstract class AbstractApi implements Api
     }
 
     /**
-     * Retrieves all the elements of a given endpoint (even if the
+     * Retrieves as many elements as you want of a given endpoint (even if the
      * total number of elements is greater than 100).
      *
      * @param string $endpoint API end point

--- a/src/Redmine/Api/Group.php
+++ b/src/Redmine/Api/Group.php
@@ -5,6 +5,7 @@ namespace Redmine\Api;
 use Exception;
 use Redmine\Exception\MissingParameterException;
 use Redmine\Serializer\PathSerializer;
+use Redmine\Serializer\XmlSerializer;
 
 /**
  * Handling of groups.
@@ -78,9 +79,10 @@ class Group extends AbstractApi
             throw new MissingParameterException('Theses parameters are mandatory: `name`');
         }
 
-        $xml = $this->buildXML($params);
-
-        return $this->post('/groups.xml', $xml->asXML());
+        return $this->post(
+            '/groups.xml',
+            XmlSerializer::createFromArray(['group' => $params])->getEncoded()
+        );
     }
 
     /**
@@ -142,9 +144,10 @@ class Group extends AbstractApi
      */
     public function addUser($id, $userId)
     {
-        $xml = new \SimpleXMLElement('<?xml version="1.0"?><user_id>'.$userId.'</user_id>');
-
-        return $this->post('/groups/'.$id.'/users.xml', $xml->asXML());
+        return $this->post(
+            '/groups/'.$id.'/users.xml',
+            XmlSerializer::createFromArray(['user_id' => $userId])->getEncoded()
+        );
     }
 
     /**
@@ -160,30 +163,5 @@ class Group extends AbstractApi
     public function removeUser($id, $userId)
     {
         return $this->delete('/groups/'.$id.'/users/'.$userId.'.xml');
-    }
-
-    /**
-     * Build the XML for a group.
-     *
-     * @param array $params for the new/updated group data
-     *
-     * @return \SimpleXMLElement
-     */
-    private function buildXML(array $params = [])
-    {
-        $xml = new \SimpleXMLElement('<?xml version="1.0"?><group></group>');
-
-        foreach ($params as $k => $v) {
-            if ('user_ids' === $k && is_array($v)) {
-                $item = $xml->addChild($k);
-                foreach ($v as $role) {
-                    $item->addChild('user_id', $role);
-                }
-            } else {
-                $xml->addChild($k, $v);
-            }
-        }
-
-        return $xml;
     }
 }

--- a/src/Redmine/Api/Issue.php
+++ b/src/Redmine/Api/Issue.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Api;
 
+use Redmine\Serializer\JsonSerializer;
 use Redmine\Serializer\PathSerializer;
 use Redmine\Serializer\XmlSerializer;
 
@@ -266,13 +267,15 @@ class Issue extends AbstractApi
      */
     public function attachMany($id, array $attachments)
     {
-        $request = [];
-        $request['issue'] = [
+        $params = [
             'id' => $id,
             'uploads' => $attachments,
         ];
 
-        return $this->put('/issues/'.$id.'.json', json_encode($request));
+        return $this->put(
+            '/issues/'.$id.'.json',
+            JsonSerializer::createFromArray(['issue' => $params])->getEncoded()
+        );
     }
 
     /**

--- a/src/Redmine/Api/Issue.php
+++ b/src/Redmine/Api/Issue.php
@@ -148,7 +148,10 @@ class Issue extends AbstractApi
      */
     public function addWatcher($id, $watcherUserId)
     {
-        return $this->post('/issues/'.$id.'/watchers.xml', '<user_id>'.$watcherUserId.'</user_id>');
+        return $this->post(
+            '/issues/'.$id.'/watchers.xml',
+            XmlSerializer::createFromArray(['user_id' => $watcherUserId])->getEncoded()
+        );
     }
 
     /**
@@ -171,10 +174,9 @@ class Issue extends AbstractApi
     public function setIssueStatus($id, $status)
     {
         $api = $this->client->getApi('issue_status');
-        $statusId = $api->getIdByName($status);
 
         return $this->update($id, [
-            'status_id' => $statusId,
+            'status_id' => $api->getIdByName($status),
         ]);
     }
 

--- a/src/Redmine/Api/IssueCategory.php
+++ b/src/Redmine/Api/IssueCategory.php
@@ -4,6 +4,7 @@ namespace Redmine\Api;
 
 use Redmine\Exception\MissingParameterException;
 use Redmine\Serializer\PathSerializer;
+use Redmine\Serializer\XmlSerializer;
 
 /**
  * Listing issue categories, creating, editing.
@@ -112,12 +113,10 @@ class IssueCategory extends AbstractApi
             throw new MissingParameterException('Theses parameters are mandatory: `name`');
         }
 
-        $xml = new \SimpleXMLElement('<?xml version="1.0"?><issue_category></issue_category>');
-        foreach ($params as $k => $v) {
-            $xml->addChild($k, $v);
-        }
-
-        return $this->post('/projects/'.$project.'/issue_categories.xml', $xml->asXML());
+        return $this->post(
+            '/projects/'.$project.'/issue_categories.xml',
+            XmlSerializer::createFromArray(['issue_category' => $params])->getEncoded()
+        );
     }
 
     /**
@@ -137,12 +136,10 @@ class IssueCategory extends AbstractApi
         ];
         $params = $this->sanitizeParams($defaults, $params);
 
-        $xml = new \SimpleXMLElement('<?xml version="1.0"?><issue_category></issue_category>');
-        foreach ($params as $k => $v) {
-            $xml->addChild($k, $v);
-        }
-
-        return $this->put('/issue_categories/'.$id.'.xml', $xml->asXML());
+        return $this->put(
+            '/issue_categories/'.$id.'.xml',
+            XmlSerializer::createFromArray(['issue_category' => $params])->getEncoded()
+        );
     }
 
     /**

--- a/src/Redmine/Api/IssueRelation.php
+++ b/src/Redmine/Api/IssueRelation.php
@@ -85,9 +85,10 @@ class IssueRelation extends AbstractApi
 
         $params = $this->sanitizeParams($defaults, $params);
 
-        $params = json_encode(['relation' => $params]);
-
-        $response = $this->post('/issues/'.urlencode($issueId).'/relations.json', $params);
+        $response = $this->post(
+            '/issues/'.urlencode($issueId).'/relations.json',
+            JsonSerializer::createFromArray(['relation' => $params])->getEncoded()
+        );
 
         return JsonSerializer::createFromString($response)->getNormalized();
     }

--- a/src/Redmine/Api/Membership.php
+++ b/src/Redmine/Api/Membership.php
@@ -3,6 +3,7 @@
 namespace Redmine\Api;
 
 use Redmine\Exception\MissingParameterException;
+use Redmine\Serializer\XmlSerializer;
 
 /**
  * Handling project memberships.
@@ -56,9 +57,10 @@ class Membership extends AbstractApi
             throw new MissingParameterException('Theses parameters are mandatory: `user_id`, `role_ids`');
         }
 
-        $xml = $this->buildXML($params);
-
-        return $this->post('/projects/'.$project.'/memberships.xml', $xml->asXML());
+        return $this->post(
+            '/projects/'.$project.'/memberships.xml',
+            XmlSerializer::createFromArray(['membership' => $params])->getEncoded()
+        );
     }
 
     /**
@@ -84,9 +86,10 @@ class Membership extends AbstractApi
             throw new MissingParameterException('Missing mandatory parameters');
         }
 
-        $xml = $this->buildXML($params);
-
-        return $this->put('/memberships/'.$id.'.xml', $xml->asXML());
+        return $this->put(
+            '/memberships/'.$id.'.xml',
+            XmlSerializer::createFromArray(['membership' => $params])->getEncoded()
+        );
     }
 
     /**
@@ -128,31 +131,5 @@ class Membership extends AbstractApi
         }
 
         return $removed;
-    }
-
-    /**
-     * Build the XML for a membership.
-     *
-     * @param array $params for the new/updated membership data
-     *
-     * @return \SimpleXMLElement
-     */
-    private function buildXML(array $params = [])
-    {
-        $xml = new \SimpleXMLElement('<?xml version="1.0"?><membership></membership>');
-
-        foreach ($params as $k => $v) {
-            if ('role_ids' === $k && is_array($v)) {
-                $item = $xml->addChild($k);
-                $item->addAttribute('type', 'array');
-                foreach ($v as $role) {
-                    $item->addChild('role_id', $role);
-                }
-            } else {
-                $xml->addChild($k, $v);
-            }
-        }
-
-        return $xml;
     }
 }

--- a/src/Redmine/Api/Project.php
+++ b/src/Redmine/Api/Project.php
@@ -126,7 +126,6 @@ class Project extends AbstractApi
 
         return $this->post(
             '/projects.xml',
-            // $this->prepareParamsXml($params)->asXml()
             XmlSerializer::createFromArray(['project' => $params])->getEncoded()
         );
     }
@@ -152,7 +151,6 @@ class Project extends AbstractApi
 
         return $this->put(
             '/projects/'.$id.'.xml',
-            // $this->prepareParamsXml($params)->asXml()
             XmlSerializer::createFromArray(['project' => $params])->getEncoded()
         );
     }

--- a/src/Redmine/Api/TimeEntry.php
+++ b/src/Redmine/Api/TimeEntry.php
@@ -3,6 +3,7 @@
 namespace Redmine\Api;
 
 use Redmine\Exception\MissingParameterException;
+use Redmine\Serializer\XmlSerializer;
 
 /**
  * Listing time entries, creating, editing.
@@ -75,16 +76,10 @@ class TimeEntry extends AbstractApi
             throw new MissingParameterException('Theses parameters are mandatory: `issue_id` or `project_id`, `hours`');
         }
 
-        $xml = new \SimpleXMLElement('<?xml version="1.0"?><time_entry></time_entry>');
-        foreach ($params as $k => $v) {
-            if ('custom_fields' === $k && is_array($v)) {
-                $this->attachCustomFieldXML($xml, $v);
-            } else {
-                $xml->addChild($k, htmlspecialchars($v));
-            }
-        }
-
-        return $this->post('/time_entries.xml', $xml->asXML());
+        return $this->post(
+            '/time_entries.xml',
+            XmlSerializer::createFromArray(['time_entry' => $params])->getEncoded()
+        );
     }
 
     /**
@@ -109,16 +104,10 @@ class TimeEntry extends AbstractApi
         ];
         $params = $this->sanitizeParams($defaults, $params);
 
-        $xml = new \SimpleXMLElement('<?xml version="1.0"?><time_entry></time_entry>');
-        foreach ($params as $k => $v) {
-            if ('custom_fields' === $k && is_array($v)) {
-                $this->attachCustomFieldXML($xml, $v);
-            } else {
-                $xml->addChild($k, htmlspecialchars($v));
-            }
-        }
-
-        return $this->put('/time_entries/'.$id.'.xml', $xml->asXML());
+        return $this->put(
+            '/time_entries/'.$id.'.xml',
+            XmlSerializer::createFromArray(['time_entry' => $params])->getEncoded()
+        );
     }
 
     /**

--- a/src/Redmine/Api/User.php
+++ b/src/Redmine/Api/User.php
@@ -4,6 +4,7 @@ namespace Redmine\Api;
 
 use Redmine\Exception\MissingParameterException;
 use Redmine\Serializer\PathSerializer;
+use Redmine\Serializer\XmlSerializer;
 
 /**
  * Listing users, creating, editing.
@@ -153,16 +154,11 @@ class User extends AbstractApi
         ) {
             throw new MissingParameterException('Theses parameters are mandatory: `login`, `lastname`, `firstname`, `mail`');
         }
-        $xml = new \SimpleXMLElement('<?xml version="1.0"?><user></user>');
-        foreach ($params as $k => $v) {
-            if ('custom_fields' === $k) {
-                $this->attachCustomFieldXML($xml, $v);
-            } else {
-                $xml->addChild($k, $v);
-            }
-        }
 
-        return $this->post('/users.xml', $xml->asXML());
+        return $this->post(
+            '/users.xml',
+            XmlSerializer::createFromArray(['user' => $params])->getEncoded()
+        );
     }
 
     /**
@@ -186,16 +182,10 @@ class User extends AbstractApi
         ];
         $params = $this->sanitizeParams($defaults, $params);
 
-        $xml = new \SimpleXMLElement('<?xml version="1.0"?><user></user>');
-        foreach ($params as $k => $v) {
-            if ('custom_fields' === $k) {
-                $this->attachCustomFieldXML($xml, $v);
-            } else {
-                $xml->addChild($k, $v);
-            }
-        }
-
-        return $this->put('/users/'.$id.'.xml', $xml->asXML());
+        return $this->put(
+            '/users/'.$id.'.xml',
+            XmlSerializer::createFromArray(['user' => $params])->getEncoded()
+        );
     }
 
     /**

--- a/src/Redmine/Api/Version.php
+++ b/src/Redmine/Api/Version.php
@@ -4,6 +4,7 @@ namespace Redmine\Api;
 
 use Redmine\Exception\InvalidParameterException;
 use Redmine\Exception\MissingParameterException;
+use Redmine\Serializer\XmlSerializer;
 
 /**
  * Listing versions, creating, editing.
@@ -120,16 +121,10 @@ class Version extends AbstractApi
         $this->validateStatus($params);
         $this->validateSharing($params);
 
-        $xml = new \SimpleXMLElement('<?xml version="1.0"?><version></version>');
-        foreach ($params as $k => $v) {
-            if ('custom_fields' === $k && is_array($v)) {
-                $this->attachCustomFieldXML($xml, $v);
-            } else {
-                $xml->addChild($k, $v);
-            }
-        }
-
-        return $this->post('/projects/'.$project.'/versions.xml', $xml->asXML());
+        return $this->post(
+            '/projects/'.$project.'/versions.xml',
+            XmlSerializer::createFromArray(['version' => $params])->getEncoded()
+        );
     }
 
     /**
@@ -154,16 +149,10 @@ class Version extends AbstractApi
         $this->validateStatus($params);
         $this->validateSharing($params);
 
-        $xml = new \SimpleXMLElement('<?xml version="1.0"?><version></version>');
-        foreach ($params as $k => $v) {
-            if ('custom_fields' === $k && is_array($v)) {
-                $this->attachCustomFieldXML($xml, $v);
-            } else {
-                $xml->addChild($k, $v);
-            }
-        }
-
-        return $this->put('/versions/'.$id.'.xml', $xml->asXML());
+        return $this->put(
+            '/versions/'.$id.'.xml',
+            XmlSerializer::createFromArray(['version' => $params])->getEncoded()
+        );
     }
 
     private function validateStatus(array $params = [])

--- a/src/Redmine/Api/Wiki.php
+++ b/src/Redmine/Api/Wiki.php
@@ -3,6 +3,7 @@
 namespace Redmine\Api;
 
 use Redmine\Serializer\PathSerializer;
+use Redmine\Serializer\XmlSerializer;
 
 /**
  * Listing Wiki pages.
@@ -79,23 +80,10 @@ class Wiki extends AbstractApi
         ];
         $params = $this->sanitizeParams($defaults, $params);
 
-        $xml = new \SimpleXMLElement('<?xml version="1.0"?><wiki_page></wiki_page>');
-        foreach ($params as $k => $v) {
-            if ('uploads' === $k && is_array($v)) {
-                $item = $xml->addChild('uploads', '');
-                $item->addAttribute('type', 'array');
-                foreach ($v as $upload) {
-                    $uploadItem = $item->addChild('upload', '');
-                    foreach ($upload as $uploadK => $uploadV) {
-                        $uploadItem->addChild($uploadK, $uploadV);
-                    }
-                }
-            } else {
-                $xml->addChild($k, htmlspecialchars($v));
-            }
-        }
-
-        return $this->put('/projects/'.$project.'/wiki/'.$page.'.xml', $xml->asXML());
+        return $this->put(
+            '/projects/'.$project.'/wiki/'.$page.'.xml',
+            XmlSerializer::createFromArray(['wiki_page' => $params])->getEncoded()
+        );
     }
 
     /**

--- a/src/Redmine/Serializer/JsonSerializer.php
+++ b/src/Redmine/Serializer/JsonSerializer.php
@@ -23,6 +23,17 @@ final class JsonSerializer
         return $serializer;
     }
 
+    /**
+     * @throws SerializerException if $data could not be serialized to JSON
+     */
+    public static function createFromArray(array $data): self
+    {
+        $serializer = new self();
+        $serializer->encode($data);
+
+        return $serializer;
+    }
+
     private string $encoded;
 
     /** @var mixed */
@@ -41,6 +52,11 @@ final class JsonSerializer
         return $this->normalized;
     }
 
+    public function getEncoded(): string
+    {
+        return $this->encoded;
+    }
+
     private function decode(string $encoded): void
     {
         $this->encoded = $encoded;
@@ -54,6 +70,25 @@ final class JsonSerializer
             );
         } catch (JsonException $e) {
             throw new SerializerException('Catched error "'.$e->getMessage().'" while decoding JSON: '.$encoded, $e->getCode(), $e);
+        }
+    }
+
+    private function encode(array $normalized): void
+    {
+        $this->normalized = $normalized;
+
+        try {
+            $this->encoded = json_encode(
+                $normalized,
+                \JSON_THROW_ON_ERROR,
+                512
+            );
+        } catch (JsonException $e) {
+            throw new SerializerException(
+                'Could not encode JSON from array: ' . $e->getMessage(),
+                $e->getCode(),
+                $e
+            );
         }
     }
 }

--- a/src/Redmine/Serializer/XmlSerializer.php
+++ b/src/Redmine/Serializer/XmlSerializer.php
@@ -128,6 +128,21 @@ final class XmlSerializer
 
         if ('custom_fields' === $k && is_array($v)) {
             $this->attachCustomFieldXML($xml, $v, 'custom_fields', 'custom_field');
+        } elseif ('watcher_user_ids' === $k && is_array($v)) {
+            $watcherUserIds = $xml->addChild('watcher_user_ids', '');
+            $watcherUserIds->addAttribute('type', 'array');
+            foreach ($v as $watcher) {
+                $watcherUserIds->addChild('watcher_user_id', (int) $watcher);
+            }
+        } elseif ('uploads' === $k && is_array($v)) {
+            $uploadsItem = $xml->addChild('uploads', '');
+            $uploadsItem->addAttribute('type', 'array');
+            foreach ($v as $upload) {
+                $upload_item = $uploadsItem->addChild('upload', '');
+                foreach ($upload as $upload_k => $upload_v) {
+                    $upload_item->addChild($upload_k, $upload_v);
+                }
+            }
         } elseif (isset($specialParams[$k]) && is_array($v)) {
             $array = $xml->addChild($k, '');
             $array->addAttribute('type', 'array');

--- a/src/Redmine/Serializer/XmlSerializer.php
+++ b/src/Redmine/Serializer/XmlSerializer.php
@@ -128,19 +128,16 @@ final class XmlSerializer
     private function addChildToXmlElement(SimpleXMLElement $xml, $k, $v): void
     {
         $specialParams = [
-            'tracker_ids' => 'tracker',
-            'issue_custom_field_ids' => 'issue_custom_field',
             'enabled_module_names' => 'enabled_module_names',
+            'issue_custom_field_ids' => 'issue_custom_field',
+            'role_ids' => 'role_id',
+            'tracker_ids' => 'tracker',
+            'user_ids' => 'user_id',
+            'watcher_user_ids' => 'watcher_user_id',
         ];
 
         if ('custom_fields' === $k && is_array($v)) {
             $this->attachCustomFieldXML($xml, $v, 'custom_fields', 'custom_field');
-        } elseif ('watcher_user_ids' === $k && is_array($v)) {
-            $watcherUserIds = $xml->addChild('watcher_user_ids', '');
-            $watcherUserIds->addAttribute('type', 'array');
-            foreach ($v as $watcher) {
-                $watcherUserIds->addChild('watcher_user_id', (int) $watcher);
-            }
         } elseif ('uploads' === $k && is_array($v)) {
             $uploadsItem = $xml->addChild('uploads', '');
             $uploadsItem->addAttribute('type', 'array');
@@ -149,11 +146,6 @@ final class XmlSerializer
                 foreach ($upload as $upload_k => $upload_v) {
                     $upload_item->addChild($upload_k, $upload_v);
                 }
-            }
-        } elseif ('user_ids' === $k && is_array($v)) {
-            $item = $xml->addChild($k);
-            foreach ($v as $role) {
-                $item->addChild('user_id', $role);
             }
         } elseif (isset($specialParams[$k]) && is_array($v)) {
             $array = $xml->addChild($k, '');

--- a/src/Redmine/Serializer/XmlSerializer.php
+++ b/src/Redmine/Serializer/XmlSerializer.php
@@ -22,6 +22,17 @@ final class XmlSerializer
         return $serializer;
     }
 
+    /**
+     * @throws SerializerException if $data could not be serialized to XML
+     */
+    public static function createFromArray(array $data): self
+    {
+        $serializer = new self();
+        $serializer->denormalize($data);
+
+        return $serializer;
+    }
+
     private string $encoded;
 
     /** @var mixed $normalized */
@@ -40,6 +51,11 @@ final class XmlSerializer
     public function getNormalized()
     {
         return $this->normalized;
+    }
+
+    public function getEncoded(): string
+    {
+        return $this->encoded;
     }
 
     private function deserialize(string $encoded): void
@@ -72,5 +88,27 @@ final class XmlSerializer
         }
 
         $this->normalized = JsonSerializer::createFromString($serialized)->getNormalized();
+    }
+
+    private function denormalize(array $normalized): void
+    {
+        $this->normalized = $normalized;
+
+        $key = array_key_first($this->normalized);
+
+        $this->deserialized = $this->createXmlElement($key, $this->normalized[$key]);
+
+        $this->encoded = $this->deserialized->asXml();
+    }
+
+    private function createXmlElement(string $key, array $params): SimpleXMLElement
+    {
+        $xml = new SimpleXMLElement('<?xml version="1.0"?><'.$key.'></'.$key.'>');
+
+        foreach ($params as $k => $v) {
+            $xml->$k = $v;
+        }
+
+        return $xml;
     }
 }

--- a/src/Redmine/Serializer/XmlSerializer.php
+++ b/src/Redmine/Serializer/XmlSerializer.php
@@ -96,7 +96,15 @@ final class XmlSerializer
 
         $key = array_key_first($this->normalized);
 
-        $this->deserialized = $this->createXmlElement($key, $this->normalized[$key]);
+        try {
+            $this->deserialized = $this->createXmlElement($key, $this->normalized[$key]);
+        } catch (Exception $e) {
+            throw new SerializerException(
+                'Could not create XML from array: ' . $e->getMessage(),
+                $e->getCode(),
+                $e
+            );
+        }
 
         $this->encoded = $this->deserialized->asXml();
     }

--- a/tests/Integration/GroupXmlTest.php
+++ b/tests/Integration/GroupXmlTest.php
@@ -43,7 +43,7 @@ class GroupXmlTest extends TestCase
         $xml = '<?xml version="1.0"?>
 <group>
     <name>Developers</name>
-    <user_ids>
+    <user_ids type="array">
         <user_id>3</user_id>
         <user_id>5</user_id>
     </user_ids>

--- a/tests/Unit/Api/IssueTest.php
+++ b/tests/Unit/Api/IssueTest.php
@@ -320,7 +320,7 @@ class IssueTest extends TestCase
             ->method('requestPost')
             ->with(
                 $this->stringStartsWith('/issues/5/watchers.xml'),
-                $this->stringEndsWith('<user_id>10</user_id>')
+                $this->stringEndsWith('<user_id>10</user_id>'."\n")
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))

--- a/tests/Unit/Serializer/JsonSerializerTest.php
+++ b/tests/Unit/Serializer/JsonSerializerTest.php
@@ -94,4 +94,127 @@ class JsonSerializerTest extends TestCase
 
         $serializer = JsonSerializer::createFromString($data);
     }
+
+    public function getNormalizedToEncodedData()
+    {
+        return [
+            [
+                [
+                    'issue' => [
+                        'project_id' => 1,
+                        'subject' => 'Example',
+                        'priority_id' => 4,
+                    ],
+                ],
+                <<< JSON
+                {
+                    "issue": {
+                        "project_id": 1,
+                        "subject": "Example",
+                        "priority_id": 4
+                    }
+                }
+                JSON,
+            ],
+            [
+                [
+                    'issue' => [
+                        'project_id' => 1,
+                        'subject' => 'Example',
+                        'priority_id' => 4,
+                    ],
+                    'ignored' => [
+                        'only the first element of the array will be used',
+                    ],
+                ],
+                <<< JSON
+                {
+                    "issue": {
+                        "project_id": 1,
+                        "subject": "Example",
+                        "priority_id": 4
+                    },
+                    "ignored": [
+                        "only the first element of the array will be used"
+                    ]
+                }
+                JSON,
+            ],
+            [
+                [
+                    'project' => [
+                        'name' => 'some name',
+                        'identifier' => 'the_identifier',
+                        'custom_fields' => [
+                            [
+                                'id' => 123,
+                                'name' => 'cf_name',
+                                'field_format' => 'string',
+                                'value' => [1, 2, 3],
+                            ],
+                        ],
+                    ],
+                ],
+                <<< JSON
+                {
+                    "project": {
+                        "name": "some name",
+                        "identifier": "the_identifier",
+                        "custom_fields": [
+                            {
+                                "id": 123,
+                                "name": "cf_name",
+                                "field_format": "string",
+                                "value": [
+                                    1,
+                                    2,
+                                    3
+                                ]
+                            }
+                        ]
+                    }
+                }
+                JSON,
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider getNormalizedToEncodedData
+     */
+    public function createFromArrayDecodesToExpectedString(array $data, $expected)
+    {
+        $serializer = JsonSerializer::createFromArray($data);
+
+        // decode the result, so we encode again with JSON_PRETTY_PRINT to compare the formated output
+        $encoded = json_encode(
+            json_decode($serializer->getEncoded(), true, 512, \JSON_THROW_ON_ERROR),
+            \JSON_THROW_ON_ERROR | \JSON_PRETTY_PRINT
+        );
+
+        $this->assertSame($expected, $encoded);
+    }
+
+    public function getInvalidSerializedData()
+    {
+        yield [
+            'Could not encode JSON from array: Type is not supported',
+            [fopen('php://temp', 'r+')],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider getInvalidSerializedData
+     */
+    public function createFromArrayWithInvalidDataThrowsException(string $message, array $data)
+    {
+        $this->expectException(SerializerException::class);
+        $this->expectExceptionMessage($message);
+
+        $serializer = JsonSerializer::createFromArray($data);
+    }
 }

--- a/tests/Unit/Serializer/JsonSerializerTest.php
+++ b/tests/Unit/Serializer/JsonSerializerTest.php
@@ -10,7 +10,7 @@ use Redmine\Serializer\JsonSerializer;
 
 class JsonSerializerTest extends TestCase
 {
-    public function getNormalizedAndEncodedData()
+    public function getEncodedToNormalizedData()
     {
         return [
             [
@@ -59,7 +59,7 @@ class JsonSerializerTest extends TestCase
     /**
      * @test
      *
-     * @dataProvider getNormalizedAndEncodedData
+     * @dataProvider getEncodedToNormalizedData
      */
     public function createFromStringDecodesToExpectedNormalizedData(string $data, $expected)
     {
@@ -71,8 +71,14 @@ class JsonSerializerTest extends TestCase
     public function getInvalidEncodedData()
     {
         return [
-            [''],
-            ['["foo":"bar"]'],
+            [
+                'Catched error "Syntax error" while decoding JSON: ',
+                '',
+            ],
+            [
+                'Catched error "Syntax error" while decoding JSON: ["foo":"bar"]',
+                '["foo":"bar"]',
+            ],
         ];
     }
 
@@ -81,9 +87,10 @@ class JsonSerializerTest extends TestCase
      *
      * @dataProvider getInvalidEncodedData
      */
-    public function createFromStringWithInvalidStringThrowsException(string $data)
+    public function createFromStringWithInvalidStringThrowsException(string $message, string $data)
     {
         $this->expectException(SerializerException::class);
+        $this->expectExceptionMessage($message);
 
         $serializer = JsonSerializer::createFromString($data);
     }

--- a/tests/Unit/Serializer/XmlSerializerTest.php
+++ b/tests/Unit/Serializer/XmlSerializerTest.php
@@ -30,7 +30,7 @@ class XmlSerializerTest extends TestCase
                 ['1'],
             ],
             [
-                <<< END
+                <<< XML
                 <?xml version="1.0" encoding="UTF-8"?>
                 <issues type="array" count="1640">
                   <issue>
@@ -40,7 +40,7 @@ class XmlSerializerTest extends TestCase
                     <id>4325</id>
                   </issue>
                 </issues>
-                END,
+                XML,
                 [
                     '@attributes' => [
                         'type' => 'array',
@@ -121,14 +121,14 @@ class XmlSerializerTest extends TestCase
                         'priority_id' => 4,
                     ],
                 ],
-                <<< END
+                <<< XML
                 <?xml version="1.0"?>
                 <issue>
                   <project_id>1</project_id>
                   <subject>Example</subject>
                   <priority_id>4</priority_id>
                 </issue>
-                END,
+                XML,
             ],
             [
                 [
@@ -141,14 +141,14 @@ class XmlSerializerTest extends TestCase
                         'only the first element of the array will be used',
                     ],
                 ],
-                <<< END
+                <<< XML
                 <?xml version="1.0"?>
                 <issue>
                   <project_id>1</project_id>
                   <subject>Example</subject>
                   <priority_id>4</priority_id>
                 </issue>
-                END,
+                XML,
             ],
             [
                 [
@@ -165,7 +165,7 @@ class XmlSerializerTest extends TestCase
                         ],
                     ],
                 ],
-                <<< END
+                <<< XML
                 <?xml version="1.0"?>
                 <project>
                   <name>some name</name>
@@ -180,7 +180,7 @@ class XmlSerializerTest extends TestCase
                     </custom_field>
                   </custom_fields>
                 </project>
-                END,
+                XML,
             ],
         ];
     }

--- a/tests/Unit/Serializer/XmlSerializerTest.php
+++ b/tests/Unit/Serializer/XmlSerializerTest.php
@@ -150,6 +150,38 @@ class XmlSerializerTest extends TestCase
                 </issue>
                 END,
             ],
+            [
+                [
+                    'project' => [
+                        'name' => 'some name',
+                        'identifier' => 'the_identifier',
+                        'custom_fields' => [
+                            [
+                                'id' => 123,
+                                'name' => 'cf_name',
+                                'field_format' => 'string',
+                                'value' => [1, 2, 3],
+                            ],
+                        ],
+                    ],
+                ],
+                <<< END
+                <?xml version="1.0"?>
+                <project>
+                  <name>some name</name>
+                  <identifier>the_identifier</identifier>
+                  <custom_fields type="array">
+                    <custom_field name="cf_name" field_format="string" id="123" multiple="true">
+                      <value type="array">
+                        <value>1</value>
+                        <value>2</value>
+                        <value>3</value>
+                      </value>
+                    </custom_field>
+                  </custom_fields>
+                </project>
+                END,
+            ],
         ];
     }
 

--- a/tests/Unit/Serializer/XmlSerializerTest.php
+++ b/tests/Unit/Serializer/XmlSerializerTest.php
@@ -10,7 +10,7 @@ use Redmine\Serializer\XmlSerializer;
 
 class XmlSerializerTest extends TestCase
 {
-    public function getNormalizedAndEncodedData()
+    public function getEncodedToNormalizedData()
     {
         return [
             [
@@ -62,13 +62,53 @@ class XmlSerializerTest extends TestCase
     /**
      * @test
      *
-     * @dataProvider getNormalizedAndEncodedData
+     * @dataProvider getEncodedToNormalizedData
      */
     public function createFromStringDecodesToExpectedNormalizedData(string $data, $expected)
     {
         $serializer = XmlSerializer::createFromString($data);
 
         $this->assertSame($expected, $serializer->getNormalized());
+    }
+
+    public function getNormalizedToEncodedData()
+    {
+        return [
+            [
+                [
+                    'issue' => [
+                        'project_id' => 1,
+                        'subject' => 'Example',
+                        'priority_id' => 4,
+                    ],
+                ],
+                <<< END
+                <?xml version="1.0"?>
+                <issue>
+                  <project_id>1</project_id>
+                  <subject>Example</subject>
+                  <priority_id>4</priority_id>
+                </issue>
+
+                END,
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider getNormalizedToEncodedData
+     */
+    public function createFromArrayDecodesToExpectedString(array $data, $expected)
+    {
+        $serializer = XmlSerializer::createFromArray($data);
+
+        // Load the encoded string into a DOMDocument, so we can compare the formated output
+        $dom = dom_import_simplexml(new \SimpleXMLElement($serializer->getEncoded()))->ownerDocument;
+        $dom->formatOutput = true;
+
+        $this->assertSame($expected, $dom->saveXML());
     }
 
     public function getInvalidEncodedData()

--- a/tests/Unit/Serializer/XmlSerializerTest.php
+++ b/tests/Unit/Serializer/XmlSerializerTest.php
@@ -128,7 +128,6 @@ class XmlSerializerTest extends TestCase
                   <subject>Example</subject>
                   <priority_id>4</priority_id>
                 </issue>
-
                 END,
             ],
             [
@@ -149,7 +148,6 @@ class XmlSerializerTest extends TestCase
                   <subject>Example</subject>
                   <priority_id>4</priority_id>
                 </issue>
-
                 END,
             ],
         ];
@@ -168,20 +166,27 @@ class XmlSerializerTest extends TestCase
         $dom = dom_import_simplexml(new \SimpleXMLElement($serializer->getEncoded()))->ownerDocument;
         $dom->formatOutput = true;
 
-        $this->assertSame($expected, $dom->saveXML());
+        $this->assertSame($expected, trim($dom->saveXML()));
     }
 
     public function getInvalidSerializedData()
     {
-        return [
-            [
+        if (version_compare(\PHP_VERSION, '8.0.0', '<')) {
+            // old Exception message for PHP 7.4
+            yield [
+                'Could not create XML from array: Undefined index: ',
+                [],
+            ];
+        } else {
+            // new Exeption message for PHP 8.0
+            yield [
                 'Could not create XML from array: Undefined array key ""',
                 [],
-            ],
-            [
-                'Could not create XML from array: String could not be parsed as XML',
-                ['0' => ['foobar']],
-            ],
+            ];
+        }
+        yield [
+            'Could not create XML from array: String could not be parsed as XML',
+            ['0' => ['foobar']],
         ];
     }
 


### PR DESCRIPTION
This PR improves the `JsonSerializer` and `XmlSerializer` introduced in #310. The serializers have been extended to encode JSON or XML from an array for a request body. The methods `Redmine\Api\AbstractApi::attachCustomFieldXML()` and `Redmine\Api\Project::prepareParamsXml()` that generated XML are thus deprecated.

The next step is to replace the `get()`, `post()`, `put()` and `delete()` methods in `AbstractApi` by using only the serializer and `Client` classes in the API classes. This will then be the final preparation to be able to dynamically switch the format in the request/response between XML and JSON, see #146.