### PR TITLE
Add PHP 8.2 support and PHPUnit 10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,11 +14,11 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: ['ubuntu-latest']
-        php-versions: ['7.4', '8.0', '8.1']
+        php-versions: ['7.4', '8.0', '8.1', '8.2']
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
 
@@ -32,21 +32,10 @@ jobs:
           extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite
           coverage: xdebug
 
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Cache composer dependencies
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          # Use composer.json for key, if composer.lock is not committed.
-          # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
-
-      - name: Install Composer dependencies
-        run: composer install --no-progress --prefer-dist --optimize-autoloader
+      # Install composer dependencies and handle caching in one go.
+      # @link https://github.com/marketplace/actions/install-composer-dependencies
+      - name: "Install Composer dependencies"
+        uses: "ramsey/composer-install@v2"
 
       - name: Run tests
         run: vendor/bin/phpunit --coverage-text

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .php-cs-fixer.cache
-.phpunit.result.cache
+.phpunit.cache
 composer.lock
 composer.phar
-coverage.clover
 phpunit.xml
 vendor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/kbsali/php-redmine-api/compare/v2.2.0...v2.x)
 
+### Added
+
+- Added support for PHP 8.2
+
 ### Deprecated
 
 - `Redmine\Api\AbstractApi::attachCustomFieldXML()` is deprecated
@@ -37,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added support for PHP 8.1
 - New interface `Redmine\Exception` that is implemented by every library-related exception
 - New exception `Redmine\Exception\ClientException` for client related exceptions
 - New exception `Redmine\Exception\InvalidApiNameException` if an invalid API instance is requested

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
         }
     },
     "scripts": {
+        "coverage": "phpunit --coverage-html=\".phpunit.cache/code-coverage\"",
         "test": "phpunit"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -38,5 +38,8 @@
         "psr-4": {
             "Redmine\\Tests\\": "tests/"
         }
+    },
+    "scripts": {
+        "test": "phpunit"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3",
-        "phpunit/phpunit": "^9",
+        "phpunit/phpunit": "^9 || 10.2.*",
         "guzzlehttp/psr7": "^2",
         "php-mock/php-mock-phpunit": "^2.6"
     },

--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,10 @@
         "psr/http-factory": "^1.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "3.11.0",
-        "phpunit/phpunit": "9.5.10",
-        "guzzlehttp/psr7": "2.1.0",
-        "php-mock/php-mock-phpunit": "2.6.0"
+        "friendsofphp/php-cs-fixer": "^3",
+        "phpunit/phpunit": "^9",
+        "guzzlehttp/psr7": "^2",
+        "php-mock/php-mock-phpunit": "^2.6"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" bootstrap="vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage>
-    <include>
-      <directory suffix=".php">src/Redmine/</directory>
-    </include>
-    <report>
-      <clover outputFile="coverage.clover"/>
-    </report>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" bootstrap="vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <coverage />
   <testsuites>
     <testsuite name="all">
       <directory suffix="Test.php">tests/Unit/</directory>
@@ -20,4 +13,9 @@
     </exclude>
   </groups>
   <logging/>
+  <source>
+    <include>
+      <directory suffix=".php">src/Redmine/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" bootstrap="vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         cacheDirectory=".phpunit.cache"
+         colors="true"
+         beStrictAboutCoverageMetadata="false"
+         beStrictAboutOutputDuringTests="true"
+         displayDetailsOnIncompleteTests="true"
+         displayDetailsOnSkippedTests="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerWarnings="true"
+>
   <coverage />
   <testsuites>
     <testsuite name="all">

--- a/src/Redmine/Serializer/XmlSerializer.php
+++ b/src/Redmine/Serializer/XmlSerializer.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Serializer;
 
+use JsonException;
 use Redmine\Exception\SerializerException;
 use SimpleXMLElement;
 use Throwable;

--- a/tests/Integration/Psr18ClientRequestGenerationTest.php
+++ b/tests/Integration/Psr18ClientRequestGenerationTest.php
@@ -107,7 +107,7 @@ class Psr18ClientRequestGenerationTest extends TestCase
         $client->$method($path, $data);
     }
 
-    public function createdGetRequestsData()
+    public static function createdGetRequestsData(): array
     {
         return [
             [

--- a/tests/Unit/Api/AbstractApiTest.php
+++ b/tests/Unit/Api/AbstractApiTest.php
@@ -30,7 +30,7 @@ class AbstractApiTest extends TestCase
         $this->assertSame($expected, $method->invoke($api, $value));
     }
 
-    public function getIsNotNullReturnsCorrectBooleanData()
+    public static function getIsNotNullReturnsCorrectBooleanData(): array
     {
         return [
             [false, null],
@@ -67,7 +67,7 @@ class AbstractApiTest extends TestCase
         $this->assertSame($expectedBoolean, $api->lastCallFailed());
     }
 
-    public function getLastCallFailedData()
+    public static function getLastCallFailedData(): array
     {
         return [
             [100, true],
@@ -161,7 +161,7 @@ class AbstractApiTest extends TestCase
         }
     }
 
-    public function getJsonDecodingFromGetMethodData()
+    public static function getJsonDecodingFromGetMethodData(): array
     {
         return [
             ['{"foo_bar": 12345}', null, ['foo_bar' => 12345]], // test decode by default
@@ -217,7 +217,7 @@ class AbstractApiTest extends TestCase
         }
     }
 
-    public function getXmlDecodingFromGetMethodData()
+    public static function getXmlDecodingFromGetMethodData(): array
     {
         return [
             ['get', '<?xml version="1.0"?><issue/>', null, '<?xml version="1.0"?><issue/>'], // test decode by default

--- a/tests/Unit/Api/AttachmentTest.php
+++ b/tests/Unit/Api/AttachmentTest.php
@@ -44,7 +44,7 @@ class AttachmentTest extends TestCase
      *
      * @return array[]
      */
-    public function responseCodeProvider()
+    public static function responseCodeProvider(): array
     {
         return [
             [199, true],

--- a/tests/Unit/Api/IssueTest.php
+++ b/tests/Unit/Api/IssueTest.php
@@ -475,7 +475,6 @@ class IssueTest extends TestCase
      * Test create() and buildXML().
      *
      * @covers ::create
-     * @covers ::buildXML
      * @covers ::attachCustomFieldXML
      * @test
      */
@@ -719,7 +718,6 @@ class IssueTest extends TestCase
     /**
      * Test buildXML().
      *
-     * @covers ::buildXML
      * @test
      */
     public function testBuildXmlWithCustomFields()
@@ -760,7 +758,6 @@ class IssueTest extends TestCase
     /**
      * Test buildXML().
      *
-     * @covers ::buildXML
      * @test
      */
     public function testBuildXmlWithWatchers()
@@ -796,7 +793,6 @@ class IssueTest extends TestCase
     /**
      * Test buildXML().
      *
-     * @covers ::buildXML
      * @test
      */
     public function testBuildXmlWithUploads()
@@ -857,7 +853,6 @@ class IssueTest extends TestCase
     /**
      * Test buildXML().
      *
-     * @covers ::buildXML
      * @test
      */
     public function testBuildXmlWithWatcherAndUploadAndCustomFieldAndStandard()

--- a/tests/Unit/Api/IssueTest.php
+++ b/tests/Unit/Api/IssueTest.php
@@ -13,7 +13,7 @@ use Redmine\Client\Client;
  */
 class IssueTest extends TestCase
 {
-    public function getPriorityConstantsData()
+    public static function getPriorityConstantsData(): array
     {
         return [
             [1, Issue::PRIO_LOW],

--- a/tests/Unit/Api/MembershipTest.php
+++ b/tests/Unit/Api/MembershipTest.php
@@ -220,7 +220,6 @@ class MembershipTest extends TestCase
      * Test create().
      *
      * @covers ::create
-     * @covers ::buildXML
      * @test
      */
     public function testCreateBuildsXml()

--- a/tests/Unit/Api/UserTest.php
+++ b/tests/Unit/Api/UserTest.php
@@ -323,7 +323,7 @@ class UserTest extends TestCase
      *
      * @return array[]
      */
-    public function incompleteCreateParameterProvider()
+    public static function incompleteCreateParameterProvider(): array
     {
         return [
             // Missing Login

--- a/tests/Unit/Api/VersionTest.php
+++ b/tests/Unit/Api/VersionTest.php
@@ -909,7 +909,7 @@ class VersionTest extends TestCase
      *
      * @return array[]
      */
-    public function validSharingProvider()
+    public static function validSharingProvider(): array
     {
         return [
             ['none', '<sharing>none</sharing>'],
@@ -925,7 +925,7 @@ class VersionTest extends TestCase
      *
      * @return array[]
      */
-    public function validEmptySharingProvider()
+    public static function validEmptySharingProvider(): array
     {
         return [
             [null],
@@ -939,7 +939,7 @@ class VersionTest extends TestCase
      *
      * @return array[]
      */
-    public function invalidSharingProvider()
+    public static function invalidSharingProvider(): array
     {
         return [
             ['all'],

--- a/tests/Unit/Client/NativeCurlClientTest.php
+++ b/tests/Unit/Client/NativeCurlClientTest.php
@@ -140,20 +140,11 @@ class NativeCurlClientTest extends TestCase
 
         $curlSetoptArray = $this->getFunctionMock(self::__NAMESPACE__, 'curl_setopt_array');
         $curlSetoptArray->expects($this->exactly(3))
-            ->withConsecutive(
-                [
-                    $this->anything(),
-                    $this->identicalTo(self::DEFAULT_CURL_OPTIONS),
-                ],
-                [
-                    $this->anything(),
-                    $this->identicalTo($expectedOptions),
-                ],
-                [
-                    $this->anything(),
-                    $this->identicalTo(self::DEFAULT_CURL_OPTIONS),
-                ],
-            )
+            ->willReturnMap([
+                [$this->anything(), $this->identicalTo(self::DEFAULT_CURL_OPTIONS), true],
+                [$this->anything(), $this->identicalTo($expectedOptions), true],
+                [$this->anything(), $this->identicalTo(self::DEFAULT_CURL_OPTIONS), true],
+            ])
         ;
 
         $curlErrno = $this->getFunctionMock(self::__NAMESPACE__, 'curl_errno');
@@ -208,20 +199,11 @@ class NativeCurlClientTest extends TestCase
 
         $curlSetoptArray = $this->getFunctionMock(self::__NAMESPACE__, 'curl_setopt_array');
         $curlSetoptArray->expects($this->exactly(3))
-            ->withConsecutive(
-                [
-                    $this->anything(),
-                    $this->identicalTo(self::DEFAULT_CURL_OPTIONS),
-                ],
-                [
-                    $this->anything(),
-                    $this->identicalTo($expectedOptions),
-                ],
-                [
-                    $this->anything(),
-                    $this->identicalTo(self::DEFAULT_CURL_OPTIONS),
-                ],
-            )
+            ->willReturnMap([
+                [$this->anything(), $this->identicalTo(self::DEFAULT_CURL_OPTIONS), true],
+                [$this->anything(), $this->identicalTo($expectedOptions), true],
+                [$this->anything(), $this->identicalTo(self::DEFAULT_CURL_OPTIONS), true],
+            ])
         ;
 
         $curlErrno = $this->getFunctionMock(self::__NAMESPACE__, 'curl_errno');
@@ -277,20 +259,11 @@ class NativeCurlClientTest extends TestCase
 
         $curlSetoptArray = $this->getFunctionMock(self::__NAMESPACE__, 'curl_setopt_array');
         $curlSetoptArray->expects($this->exactly(3))
-            ->withConsecutive(
-                [
-                    $this->anything(),
-                    $this->identicalTo(self::DEFAULT_CURL_OPTIONS),
-                ],
-                [
-                    $this->anything(),
-                    $this->identicalTo($expectedOptions),
-                ],
-                [
-                    $this->anything(),
-                    $this->identicalTo(self::DEFAULT_CURL_OPTIONS),
-                ],
-            )
+            ->willReturnMap([
+                [$this->anything(), $this->identicalTo(self::DEFAULT_CURL_OPTIONS), true],
+                [$this->anything(), $this->identicalTo($expectedOptions), true],
+                [$this->anything(), $this->identicalTo(self::DEFAULT_CURL_OPTIONS), true],
+            ])
         ;
 
         $curlErrno = $this->getFunctionMock(self::__NAMESPACE__, 'curl_errno');
@@ -346,20 +319,11 @@ class NativeCurlClientTest extends TestCase
 
         $curlSetoptArray = $this->getFunctionMock(self::__NAMESPACE__, 'curl_setopt_array');
         $curlSetoptArray->expects($this->exactly(3))
-            ->withConsecutive(
-                [
-                    $this->anything(),
-                    $this->identicalTo(self::DEFAULT_CURL_OPTIONS),
-                ],
-                [
-                    $this->anything(),
-                    $this->identicalTo($expectedOptions),
-                ],
-                [
-                    $this->anything(),
-                    $this->identicalTo(self::DEFAULT_CURL_OPTIONS),
-                ],
-            )
+            ->willReturnMap([
+                [$this->anything(), $this->identicalTo(self::DEFAULT_CURL_OPTIONS), true],
+                [$this->anything(), $this->identicalTo($expectedOptions), true],
+                [$this->anything(), $this->identicalTo(self::DEFAULT_CURL_OPTIONS), true],
+            ])
         ;
 
         $curlErrno = $this->getFunctionMock(self::__NAMESPACE__, 'curl_errno');
@@ -416,20 +380,11 @@ class NativeCurlClientTest extends TestCase
 
         $curlSetoptArray = $this->getFunctionMock(self::__NAMESPACE__, 'curl_setopt_array');
         $curlSetoptArray->expects($this->exactly(3))
-            ->withConsecutive(
-                [
-                    $this->anything(),
-                    $this->identicalTo(self::DEFAULT_CURL_OPTIONS),
-                ],
-                [
-                    $this->anything(),
-                    $this->identicalTo($expectedOptions),
-                ],
-                [
-                    $this->anything(),
-                    $this->identicalTo(self::DEFAULT_CURL_OPTIONS),
-                ],
-            )
+            ->willReturnMap([
+                [$this->anything(), $this->identicalTo(self::DEFAULT_CURL_OPTIONS), true],
+                [$this->anything(), $this->identicalTo($expectedOptions), true],
+                [$this->anything(), $this->identicalTo(self::DEFAULT_CURL_OPTIONS), true],
+            ])
         ;
 
         $curlErrno = $this->getFunctionMock(self::__NAMESPACE__, 'curl_errno');
@@ -490,20 +445,11 @@ class NativeCurlClientTest extends TestCase
 
         $curlSetoptArray = $this->getFunctionMock(self::__NAMESPACE__, 'curl_setopt_array');
         $curlSetoptArray->expects($this->exactly(3))
-            ->withConsecutive(
-                [
-                    $this->anything(),
-                    $this->identicalTo(self::DEFAULT_CURL_OPTIONS),
-                ],
-                [
-                    $this->anything(),
-                    $this->identicalTo($expectedOptions),
-                ],
-                [
-                    $this->anything(),
-                    $this->identicalTo(self::DEFAULT_CURL_OPTIONS),
-                ],
-            )
+            ->willReturnMap([
+                [$this->anything(), $this->identicalTo(self::DEFAULT_CURL_OPTIONS), true],
+                [$this->anything(), $this->identicalTo($expectedOptions), true],
+                [$this->anything(), $this->identicalTo(self::DEFAULT_CURL_OPTIONS), true],
+            ])
         ;
 
         $curlErrno = $this->getFunctionMock(self::__NAMESPACE__, 'curl_errno');
@@ -560,20 +506,11 @@ class NativeCurlClientTest extends TestCase
 
         $curlSetoptArray = $this->getFunctionMock(self::__NAMESPACE__, 'curl_setopt_array');
         $curlSetoptArray->expects($this->exactly(3))
-            ->withConsecutive(
-                [
-                    $this->anything(),
-                    $this->identicalTo(self::DEFAULT_CURL_OPTIONS),
-                ],
-                [
-                    $this->anything(),
-                    $this->identicalTo($expectedOptions),
-                ],
-                [
-                    $this->anything(),
-                    $this->identicalTo(self::DEFAULT_CURL_OPTIONS),
-                ],
-            )
+            ->willReturnMap([
+                [$this->anything(), $this->identicalTo(self::DEFAULT_CURL_OPTIONS), true],
+                [$this->anything(), $this->identicalTo($expectedOptions), true],
+                [$this->anything(), $this->identicalTo(self::DEFAULT_CURL_OPTIONS), true],
+            ])
         ;
 
         $curlErrno = $this->getFunctionMock(self::__NAMESPACE__, 'curl_errno');
@@ -628,11 +565,9 @@ class NativeCurlClientTest extends TestCase
 
         $curlSetoptArray = $this->getFunctionMock(self::__NAMESPACE__, 'curl_setopt_array');
         $curlSetoptArray->expects($this->exactly(1))
-            ->withConsecutive(
-                [
-                    $this->anything(),
-                    $this->identicalTo($expectedOptions),
-                ],
+            ->with(
+                $this->anything(),
+                $this->identicalTo($expectedOptions),
             )
         ;
 
@@ -684,11 +619,9 @@ class NativeCurlClientTest extends TestCase
 
         $curlSetoptArray = $this->getFunctionMock(self::__NAMESPACE__, 'curl_setopt_array');
         $curlSetoptArray->expects($this->exactly(1))
-            ->withConsecutive(
-                [
-                    $this->anything(),
-                    $this->identicalTo($expectedOptions),
-                ],
+            ->with(
+                $this->anything(),
+                $this->identicalTo($expectedOptions)
             )
         ;
 

--- a/tests/Unit/Client/NativeCurlClientTest.php
+++ b/tests/Unit/Client/NativeCurlClientTest.php
@@ -744,7 +744,7 @@ class NativeCurlClientTest extends TestCase
         $this->assertSame($content, $client->getLastResponseBody());
     }
 
-    public function getRequestReponseData()
+    public static function getRequestReponseData(): array
     {
         return [
             ['requestGet', '', true, 101, 'text/plain', ''],
@@ -865,7 +865,7 @@ class NativeCurlClientTest extends TestCase
         $this->assertInstanceOf($class, $client->getApi($apiName));
     }
 
-    public function getApiClassesProvider()
+    public static function getApiClassesProvider(): array
     {
         return [
             ['attachment', 'Redmine\Api\Attachment'],

--- a/tests/Unit/Client/Psr18ClientTest.php
+++ b/tests/Unit/Client/Psr18ClientTest.php
@@ -112,13 +112,12 @@ class Psr18ClientTest extends TestCase
         $request = $this->createMock(ServerRequestInterface::class);
         $request->expects($this->exactly(4))
             ->method('withHeader')
-            ->withConsecutive(
-                ['X-Redmine-API-Key', 'access_token'],
-                ['X-Redmine-API-Key', 'access_token'],
-                ['X-Redmine-Switch-User', 'Sam'],
-                ['X-Redmine-API-Key', 'access_token'],
-            )
-            ->willReturn($request);
+            ->willReturnMap([
+                ['X-Redmine-API-Key', 'access_token', $request],
+                ['X-Redmine-API-Key', 'access_token', $request],
+                ['X-Redmine-Switch-User', 'Sam', $request],
+                ['X-Redmine-API-Key', 'access_token', $request],
+            ]);
 
         $requestFactory = $this->createMock(ServerRequestFactoryInterface::class);
         $requestFactory->method('createServerRequest')->willReturn($request);

--- a/tests/Unit/Client/Psr18ClientTest.php
+++ b/tests/Unit/Client/Psr18ClientTest.php
@@ -206,7 +206,7 @@ class Psr18ClientTest extends TestCase
         $this->assertSame($content, $client->getLastResponseBody());
     }
 
-    public function getRequestReponseData()
+    public static function getRequestReponseData(): array
     {
         return [
             ['requestGet', '', true, 101, 'text/plain', ''],
@@ -253,7 +253,7 @@ class Psr18ClientTest extends TestCase
         $this->assertInstanceOf($class, $client->getApi($apiName));
     }
 
-    public function getApiClassesProvider()
+    public static function getApiClassesProvider(): array
     {
         return [
             ['attachment', 'Redmine\Api\Attachment'],

--- a/tests/Unit/Serializer/JsonSerializerTest.php
+++ b/tests/Unit/Serializer/JsonSerializerTest.php
@@ -10,7 +10,7 @@ use Redmine\Serializer\JsonSerializer;
 
 class JsonSerializerTest extends TestCase
 {
-    public function getEncodedToNormalizedData()
+    public static function getEncodedToNormalizedData(): array
     {
         return [
             [
@@ -68,7 +68,7 @@ class JsonSerializerTest extends TestCase
         $this->assertSame($expected, $serializer->getNormalized());
     }
 
-    public function getInvalidEncodedData()
+    public static function getInvalidEncodedData(): array
     {
         return [
             [
@@ -95,7 +95,7 @@ class JsonSerializerTest extends TestCase
         $serializer = JsonSerializer::createFromString($data);
     }
 
-    public function getNormalizedToEncodedData()
+    public static function getNormalizedToEncodedData(): array
     {
         return [
             [
@@ -197,11 +197,13 @@ class JsonSerializerTest extends TestCase
         $this->assertSame($expected, $encoded);
     }
 
-    public function getInvalidSerializedData()
+    public static function getInvalidSerializedData(): array
     {
-        yield [
-            'Could not encode JSON from array: Type is not supported',
-            [fopen('php://temp', 'r+')],
+        return [
+            [
+                'Could not encode JSON from array: Type is not supported',
+                [fopen('php://temp', 'r+')],
+            ],
         ];
     }
 

--- a/tests/Unit/Serializer/PathSerializerTest.php
+++ b/tests/Unit/Serializer/PathSerializerTest.php
@@ -9,7 +9,7 @@ use Redmine\Serializer\PathSerializer;
 
 class PathSerializerTest extends TestCase
 {
-    public function getPathData()
+    public static function getPathData(): array
     {
         return [
             [

--- a/tests/Unit/Serializer/XmlSerializerTest.php
+++ b/tests/Unit/Serializer/XmlSerializerTest.php
@@ -201,24 +201,13 @@ class XmlSerializerTest extends TestCase
         $this->assertSame($expected, trim($dom->saveXML()));
     }
 
-    public static function getInvalidSerializedData(): iterable
+    public static function getInvalidSerializedData(): array
     {
-        if (version_compare(\PHP_VERSION, '8.0.0', '<')) {
-            // old Exception message for PHP 7.4
-            yield [
-                'Could not create XML from array: Undefined index: ',
-                [],
-            ];
-        } else {
-            // new Exeption message for PHP 8.0
-            yield [
-                'Could not create XML from array: Undefined array key ""',
-                [],
-            ];
-        }
-        yield [
-            'Could not create XML from array: String could not be parsed as XML',
-            ['0' => ['foobar']],
+        return[
+            [
+                'Could not create XML from array: String could not be parsed as XML',
+                ['0' => ['foobar']],
+            ]
         ];
     }
 

--- a/tests/Unit/Serializer/XmlSerializerTest.php
+++ b/tests/Unit/Serializer/XmlSerializerTest.php
@@ -10,7 +10,7 @@ use Redmine\Serializer\XmlSerializer;
 
 class XmlSerializerTest extends TestCase
 {
-    public function getEncodedToNormalizedData()
+    public static function getEncodedToNormalizedData(): array
     {
         return [
             [
@@ -71,7 +71,7 @@ class XmlSerializerTest extends TestCase
         $this->assertSame($expected, $serializer->getNormalized());
     }
 
-    public function getInvalidEncodedData()
+    public static function getInvalidEncodedData(): array
     {
         return [
             [
@@ -110,7 +110,7 @@ class XmlSerializerTest extends TestCase
         $serializer = XmlSerializer::createFromString($data);
     }
 
-    public function getNormalizedToEncodedData()
+    public static function getNormalizedToEncodedData(): array
     {
         return [
             [
@@ -201,7 +201,7 @@ class XmlSerializerTest extends TestCase
         $this->assertSame($expected, trim($dom->saveXML()));
     }
 
-    public function getInvalidSerializedData()
+    public static function getInvalidSerializedData(): iterable
     {
         if (version_compare(\PHP_VERSION, '8.0.0', '<')) {
             // old Exception message for PHP 7.4

--- a/tests/Unit/Serializer/XmlSerializerTest.php
+++ b/tests/Unit/Serializer/XmlSerializerTest.php
@@ -74,24 +74,24 @@ class XmlSerializerTest extends TestCase
     public static function getInvalidEncodedData(): array
     {
         return [
-            [
-                'Catched error "String could not be parsed as XML" while decoding XML: ',
+            'empty string' => [
+                'Catched errors: "" while decoding XML: ',
                 '',
             ],
-            [
-                'Catched error "String could not be parsed as XML" while decoding XML: <?xml version="1.0" encoding="UTF-8"?>',
+            'wrong start tag' => [
+                'Catched errors: "Start tag expected, \'<\' not found'."\n".'" while decoding XML: <?xml version="1.0" encoding="UTF-8"?>',
                 '<?xml version="1.0" encoding="UTF-8"?>',
             ],
-            [
-                'Catched error "String could not be parsed as XML" while decoding XML: <?xml version="1.0" encoding="UTF-8"?><>',
+            'invalid element name as start tag' => [
+                'Catched errors: "StartTag: invalid element name'."\n".'", "Extra content at the end of the document'."\n".'" while decoding XML: <?xml version="1.0" encoding="UTF-8"?><>',
                 '<?xml version="1.0" encoding="UTF-8"?><>',
             ],
-            [
-                'Catched error "String could not be parsed as XML" while decoding XML: <?xml version="1.0" encoding="UTF-8"?><a>',
+            'Premature end of data' => [
+                'Catched errors: "Premature end of data in tag a line 1'."\n".'" while decoding XML: <?xml version="1.0" encoding="UTF-8"?><a>',
                 '<?xml version="1.0" encoding="UTF-8"?><a>',
             ],
-            [
-                'Catched error "String could not be parsed as XML" while decoding XML: <?xml version="1.0" encoding="UTF-8"?></>',
+            'invalid element name as start tag 2' => [
+                'Catched errors: "StartTag: invalid element name'."\n".'", "Extra content at the end of the document'."\n".'" while decoding XML: <?xml version="1.0" encoding="UTF-8"?></>',
                 '<?xml version="1.0" encoding="UTF-8"?></>',
             ],
         ];
@@ -204,8 +204,8 @@ class XmlSerializerTest extends TestCase
     public static function getInvalidSerializedData(): array
     {
         return[
-            [
-                'Could not create XML from array: String could not be parsed as XML',
+            'invalid element name as start tag' => [
+                'Could not create XML from array: "StartTag: invalid element name'."\n".'", "Extra content at the end of the document'."\n".'"',
                 ['0' => ['foobar']],
             ]
         ];


### PR DESCRIPTION
Hey 👋 

This PR updates all dev-dependencies and runs the tests on PHP 8.1+ with PHPUnit 10. Github actions will now also run on PHP 8.2. The test commands are now added in the composer.json and allows to create a HTML code coverage report.

This PR will also catch all warnings that are thrown by using `SimpleXMLElement`.

We cannot use PHPUnit 10.3 atm because of errors in `php-mock/php-mock-phpunit`, see https://github.com/php-mock/php-mock-phpunit/pull/61