### PR TITLE
Replace ServerRequestFactory with RequestFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/kbsali/php-redmine-api/compare/v2.2.0...v2.x)
 
+### Added
+
+- Allow `Psr\Http\Message\ServerRequestFactoryInterface` as Argument #2 ($requestFactory) in `Redmine\Client\Psr18Client::__construct()`
+
 ### Deprecated
 
+- Providing Argument #2 ($requestFactory) in `Redmine\Client\Psr18Client::__construct()` as type `Psr\Http\Message\ServerRequestFactoryInterface` is deprecated, provide as type `Psr\Http\Message\RequestFactoryInterface` instead
 - `Redmine\Api\AbstractApi::attachCustomFieldXML()` is deprecated
 - `Redmine\Api\Project::prepareParamsXml()` is deprecated
 

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ $client = new Redmine\Client\NativeCurlClient('https://redmine.example.com', '12
 The `Psr18Client` requires
 
 - a `Psr\Http\Client\ClientInterface` implementation (like guzzlehttp/guzzle), [see](https://packagist.org/providers/psr/http-client-implementation)
-- a `Psr\Http\Message\ServerRequestFactoryInterface` implementation (like guzzlehttp/psr7), [see](https://packagist.org/providers/psr/http-factory-implementation)
+- a `Psr\Http\Message\RequestFactoryInterface` implementation (like guzzlehttp/psr7), [see](https://packagist.org/providers/psr/http-factory-implementation)
 - a `Psr\Http\Message\StreamFactoryInterface` implementation (like guzzlehttp/psr7), [see](https://packagist.org/providers/psr/http-message-implementation)
 - a URL to your Redmine instance
 - an Apikey or username

--- a/docs/migrate-to-psr18client.md
+++ b/docs/migrate-to-psr18client.md
@@ -130,7 +130,7 @@ After this changes you should be able to test your code without errors.
 The `Redmine\Client\Psr18Client` requires:
 
 - a `Psr\Http\Client\ClientInterface` implementation (like guzzlehttp/guzzle), [see packagist.org](https://packagist.org/providers/psr/http-client-implementation)
-- a `Psr\Http\Message\ServerRequestFactoryInterface` implementation (like nyholm/psr7), [see packagist.org](https://packagist.org/providers/psr/http-factory-implementation)
+- a `Psr\Http\Message\RequestFactoryInterface` implementation (like nyholm/psr7), [see packagist.org](https://packagist.org/providers/psr/http-factory-implementation)
 - a `Psr\Http\Message\StreamFactoryInterface` implementation (like nyholm/psr7), [see packagist.org](https://packagist.org/providers/psr/http-message-implementation)
 - a URL to your Redmine instance
 - an Apikey or username
@@ -151,20 +151,20 @@ The `Redmine\Client\Psr18Client` requires:
 );
 ```
 
-If you want more control over the PSR-17 ServerRequestFactory you can also create a anonymous class:
+If you want more control over the PSR-17 RequestFactory you can also create a anonymous class:
 
 ```diff
-+use Psr\Http\Message\ServerRequestFactoryInterface;
-+use Psr\Http\Message\ServerRequestInterface;
++use Psr\Http\Message\RequestFactoryInterface;
++use Psr\Http\Message\RequestInterface;
 +use Psr\Http\Message\StreamFactoryInterface;
 +use Psr\Http\Message\StreamInterface;
 +
 $guzzle = new \GuzzleHttp\Client();
 -$psr17Factory = new \GuzzleHttp\Psr7\HttpFactory();
-+$psr17Factory = new class() implements ServerRequestFactoryInterface, StreamFactoryInterface {
-+    public function createServerRequest(string $method, $uri, array $serverParams = []): ServerRequestInterface
++$psr17Factory = new class() implements RequestFactoryInterface, StreamFactoryInterface {
++    public function createRequest(string $method, $uri): RequestInterface
 +    {
-+        return new \GuzzleHttp\Psr7\ServerRequest($method, $uri);
++        return new \GuzzleHttp\Psr7\Request($method, $uri);
 +    }
 +
 +    public function createStream(string $content = ''): StreamInterface

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -107,7 +107,7 @@ $client = new \Redmine\Client('https://redmine.example.com', '1234567890abcdfgh'
 The `Psr18Client` requires
 
 - a `Psr\Http\Client\ClientInterface` implementation (like guzzlehttp/guzzle) ([possible implementations](https://packagist.org/providers/psr/http-client-implementation))
-- a `Psr\Http\Message\ServerRequestFactoryInterface` implementation (like nyholm/psr7) ([possible implementations](https://packagist.org/providers/psr/http-factory-implementation))
+- a `Psr\Http\Message\RequestFactoryInterface` implementation (like nyholm/psr7) ([possible implementations](https://packagist.org/providers/psr/http-factory-implementation))
 - a `Psr\Http\Message\StreamFactoryInterface` implementation (like nyholm/psr7) ([possible implementations](https://packagist.org/providers/psr/http-message-implementation))
 - a URL to your Redmine instance
 - an Apikey or username

--- a/tests/Integration/Psr18ClientRequestGenerationTest.php
+++ b/tests/Integration/Psr18ClientRequestGenerationTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Redmine\Tests\Integration;
 
-use GuzzleHttp\Psr7\ServerRequest;
+use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Utils;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestFactoryInterface;
+use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Redmine\Client\Psr18Client;
@@ -57,10 +57,10 @@ class Psr18ClientRequestGenerationTest extends TestCase
             })
         );
 
-        $requestFactory = $this->createMock(ServerRequestFactoryInterface::class);
-        $requestFactory->method('createServerRequest')->will(
+        $requestFactory = $this->createMock(RequestFactoryInterface::class);
+        $requestFactory->method('createRequest')->will(
             $this->returnCallback(function ($method, $uri) {
-                return new ServerRequest($method, $uri);
+                return new Request($method, $uri);
             })
         );
 

--- a/tests/Integration/Psr18ClientRequestGenerationTest.php
+++ b/tests/Integration/Psr18ClientRequestGenerationTest.php
@@ -41,16 +41,6 @@ class Psr18ClientRequestGenerationTest extends TestCase
                     $headers .= $k.': '.$request->getHeaderLine($k).\PHP_EOL;
                 }
 
-                $cookies = [];
-
-                foreach ($request->getCookieParams() as $k => $v) {
-                    $cookies[] = $k.'='.$v;
-                }
-
-                if (!empty($cookies)) {
-                    $headers .= 'Cookie: '.implode('; ', $cookies).\PHP_EOL;
-                }
-
                 $fullRequest = sprintf(
                         '%s %s HTTP/%s',
                         $request->getMethod(),

--- a/tests/Unit/Client/Psr18ClientTest.php
+++ b/tests/Unit/Client/Psr18ClientTest.php
@@ -5,9 +5,10 @@ namespace Redmine\Tests\Unit\Client;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestFactoryInterface;
-use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Redmine\Client\Client;
@@ -20,6 +21,24 @@ class Psr18ClientTest extends TestCase
      * @test
      */
     public function shouldPassApiKeyToConstructor()
+    {
+        $client = new Psr18Client(
+            $this->createMock(ClientInterface::class),
+            $this->createMock(RequestFactoryInterface::class),
+            $this->createMock(StreamFactoryInterface::class),
+            'http://test.local',
+            'access_token'
+        );
+
+        $this->assertInstanceOf(Psr18Client::class, $client);
+        $this->assertInstanceOf(Client::class, $client);
+    }
+
+    /**
+     * @covers \Redmine\Client\Psr18Client
+     * @test
+     */
+    public function acceptServerRequestFactoryInConstructorForBC()
     {
         $client = new Psr18Client(
             $this->createMock(ClientInterface::class),
@@ -41,7 +60,7 @@ class Psr18ClientTest extends TestCase
     {
         $client = new Psr18Client(
             $this->createMock(ClientInterface::class),
-            $this->createMock(ServerRequestFactoryInterface::class),
+            $this->createMock(RequestFactoryInterface::class),
             $this->createMock(StreamFactoryInterface::class),
             'http://test.local',
             'username',
@@ -56,11 +75,11 @@ class Psr18ClientTest extends TestCase
      * @covers \Redmine\Client\Psr18Client
      * @test
      */
-    public function testGetLastResponseStatusCodeIsInitialNull()
+    public function testGetLastResponseStatusCodeIsInitialZero()
     {
         $client = new Psr18Client(
             $this->createMock(ClientInterface::class),
-            $this->createMock(ServerRequestFactoryInterface::class),
+            $this->createMock(RequestFactoryInterface::class),
             $this->createMock(StreamFactoryInterface::class),
             'http://test.local',
             'access_token'
@@ -77,7 +96,7 @@ class Psr18ClientTest extends TestCase
     {
         $client = new Psr18Client(
             $this->createMock(ClientInterface::class),
-            $this->createMock(ServerRequestFactoryInterface::class),
+            $this->createMock(RequestFactoryInterface::class),
             $this->createMock(StreamFactoryInterface::class),
             'http://test.local',
             'access_token'
@@ -94,7 +113,7 @@ class Psr18ClientTest extends TestCase
     {
         $client = new Psr18Client(
             $this->createMock(ClientInterface::class),
-            $this->createMock(ServerRequestFactoryInterface::class),
+            $this->createMock(RequestFactoryInterface::class),
             $this->createMock(StreamFactoryInterface::class),
             'http://test.local',
             'access_token'
@@ -109,7 +128,7 @@ class Psr18ClientTest extends TestCase
      */
     public function testStartAndStopImpersonateUser()
     {
-        $request = $this->createMock(ServerRequestInterface::class);
+        $request = $this->createMock(RequestInterface::class);
         $request->expects($this->exactly(4))
             ->method('withHeader')
             ->withConsecutive(
@@ -120,8 +139,8 @@ class Psr18ClientTest extends TestCase
             )
             ->willReturn($request);
 
-        $requestFactory = $this->createMock(ServerRequestFactoryInterface::class);
-        $requestFactory->method('createServerRequest')->willReturn($request);
+        $requestFactory = $this->createMock(RequestFactoryInterface::class);
+        $requestFactory->method('createRequest')->willReturn($request);
 
         $client = new Psr18Client(
             $this->createMock(ClientInterface::class),
@@ -150,11 +169,11 @@ class Psr18ClientTest extends TestCase
         $httpClient = $this->createMock(ClientInterface::class);
         $httpClient->method('sendRequest')->willReturn($response);
 
-        $request = $this->createMock(ServerRequestInterface::class);
+        $request = $this->createMock(RequestInterface::class);
         $request->method('withHeader')->willReturn($request);
 
-        $requestFactory = $this->createMock(ServerRequestFactoryInterface::class);
-        $requestFactory->method('createServerRequest')->willReturn($request);
+        $requestFactory = $this->createMock(RequestFactoryInterface::class);
+        $requestFactory->method('createRequest')->willReturn($request);
 
         $client = new Psr18Client(
             $httpClient,
@@ -185,12 +204,12 @@ class Psr18ClientTest extends TestCase
         $httpClient = $this->createMock(ClientInterface::class);
         $httpClient->method('sendRequest')->willReturn($response);
 
-        $request = $this->createMock(ServerRequestInterface::class);
+        $request = $this->createMock(RequestInterface::class);
         $request->method('withHeader')->willReturn($request);
         $request->method('withBody')->willReturn($request);
 
-        $requestFactory = $this->createMock(ServerRequestFactoryInterface::class);
-        $requestFactory->method('createServerRequest')->willReturn($request);
+        $requestFactory = $this->createMock(RequestFactoryInterface::class);
+        $requestFactory->method('createRequest')->willReturn($request);
 
         $client = new Psr18Client(
             $httpClient,
@@ -244,7 +263,7 @@ class Psr18ClientTest extends TestCase
     {
         $client = new Psr18Client(
             $this->createMock(ClientInterface::class),
-            $this->createMock(ServerRequestFactoryInterface::class),
+            $this->createMock(RequestFactoryInterface::class),
             $this->createMock(StreamFactoryInterface::class),
             'http://test.local',
             'access_token'
@@ -286,7 +305,7 @@ class Psr18ClientTest extends TestCase
     {
         $client = new Psr18Client(
             $this->createMock(ClientInterface::class),
-            $this->createMock(ServerRequestFactoryInterface::class),
+            $this->createMock(RequestFactoryInterface::class),
             $this->createMock(StreamFactoryInterface::class),
             'http://test.local',
             'access_token'


### PR DESCRIPTION
In #257 we introduced the new `Psr18Client`, based on a PSR-18 client and PSR-17 factories.

Some month ago I noticed that I required a `Psr\Http\Message\ServerRequestFactoryInterface`, but we only need a `Psr\Http\Message\RequestFactoryInterface`. This shouldn't be a problem, because all PSR-18 clients are working with `Psr\Http\Message\RequestInterface` implementations and `ServerRequestInterface` is extending the `RequestInterface`.

However this PR will fix this by allowing a `Psr\Http\Message\RequestFactoryInterface` implementation in the `Psr18Client`. Providing a `Psr\Http\Message\ServerRequestFactoryInterface` will also work but is deprecated and will trigger a deprecation warning. In the next major release we can remove the support for `Psr\Http\Message\ServerRequestFactoryInterface` completely.