### PR TITLE
Introducing the low-level API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 - Providing Argument #2 ($requestFactory) in `Redmine\Client\Psr18Client::__construct()` as type `Psr\Http\Message\ServerRequestFactoryInterface` is deprecated, provide as type `Psr\Http\Message\RequestFactoryInterface` instead
-- `Redmine\Api\AbstractApi::attachCustomFieldXML()` is deprecated
-- `Redmine\Api\Project::prepareParamsXml()` is deprecated
+- `Redmine\Api\AbstractApi::attachCustomFieldXML()` is deprecated, use `Redmine\Serializer\XmlSerializer::createFromArray()` instead
+- `Redmine\Api\Project::prepareParamsXml()` is deprecated, use `Redmine\Serializer\XmlSerializer::createFromArray()` instead
 
 ## [v2.2.0](https://github.com/kbsali/php-redmine-api/compare/v2.1.1...v2.2.0) - 2022-03-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- New class `Redmine\Serializer\PathSerializer` to build an URL path with query parameters.
+- New class `Redmine\Serializer\JsonSerializer` to encode or normalize JSON data.
+- New class `Redmine\Serializer\XmlSerializer` to encode or normalize XML data.
 - Allow `Psr\Http\Message\ServerRequestFactoryInterface` as Argument #2 ($requestFactory) in `Redmine\Client\Psr18Client::__construct()`
 - Added support for PHP 8.2
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Uses [Redmine API](http://www.redmine.org/projects/redmine/wiki/Rest_api/).
 
 Redmine is missing some APIs for a full remote management of the data:
 * List of activities & roles: http://www.redmine.org/issues/11464
-* Closing a project: https://www.redmine.org/issues/13725
 
 A possible solution to this would be to create an extra APIs implementing the
 missing entry points. See existing effort in doing so:

--- a/README.md
+++ b/README.md
@@ -15,26 +15,8 @@ Uses [Redmine API](http://www.redmine.org/projects/redmine/wiki/Rest_api/).
 * Choose between using native `cURL` function or any
 [PSR-18](https://www.php-fig.org/psr/psr-18/) http client like
 [Guzzle](https://github.com/guzzle/guzzle) for handling http connections
-* API entry points implementation state:
-  * :heavy_check_mark: Attachments
-  * :heavy_check_mark: Groups
-  * :heavy_check_mark: Custom Fields
-  * :heavy_check_mark: Issues
-  * :heavy_check_mark: Issue Categories
-  * :heavy_check_mark: Issue Priorities
-  * :x: *Issue Relations - only partially implemented*
-  * :heavy_check_mark: Issue Statuses
-  * :heavy_check_mark: News
-  * :heavy_check_mark: Projects
-  * :heavy_check_mark: Project Memberships
-  * :heavy_check_mark: Queries
-  * :heavy_check_mark: Roles
-  * :heavy_check_mark: Time Entries
-  * :heavy_check_mark: Time Entry Activities
-  * :heavy_check_mark: Trackers
-  * :heavy_check_mark: Users
-  * :heavy_check_mark: Versions
-  * :heavy_check_mark: Wiki
+* [mid-level API](https://github.com/kbsali/php-redmine-api/blob/v2.x/docs/usage.md#mid-level-api) e.g. `$client->getApi('issue')->create($data)`
+* [low-level API](https://github.com/kbsali/php-redmine-api/blob/v2.x/docs/usage.md#low-level-api) e.g. `$client->requestPost('/issues.json', $data)`
 
 ## Todo
 

--- a/README.md
+++ b/README.md
@@ -15,22 +15,8 @@ Uses [Redmine API](http://www.redmine.org/projects/redmine/wiki/Rest_api/).
 * Choose between using native `cURL` function or any
 [PSR-18](https://www.php-fig.org/psr/psr-18/) http client like
 [Guzzle](https://github.com/guzzle/guzzle) for handling http connections
-* [mid-level API](https://github.com/kbsali/php-redmine-api/blob/v2.x/docs/usage.md#mid-level-api) e.g. `$client->getApi('issue')->create($data)`
-* [low-level API](https://github.com/kbsali/php-redmine-api/blob/v2.x/docs/usage.md#low-level-api) e.g. `$client->requestPost('/issues.json', $data)`
-
-## Todo
-
-* Check header's response code (especially for POST/PUT/DELETE requests)
-* See http://stackoverflow.com/questions/9183178/php-curl-retrieving-response-headers-and-body-in-a-single-request/9183272#9183272
-
-## Limitations / Missing Redmine-API
-
-Redmine is missing some APIs for a full remote management of the data:
-* List of activities & roles: http://www.redmine.org/issues/11464
-
-A possible solution to this would be to create an extra APIs implementing the
-missing entry points. See existing effort in doing so:
-https://github.com/rschobbert/redmine-miss-api
+* [mid-level API](docs/usage.md#mid-level-api) e.g. `$client->getApi('issue')->create($data)`
+* [low-level API](docs/usage.md#low-level-api) e.g. `$client->requestPost('/issues.json', $data)`
 
 ## Requirements
 
@@ -45,6 +31,20 @@ https://github.com/rschobbert/redmine-miss-api
 
 * The PHP [cURL](http://php.net/manual/en/book.curl.php) extension if you want to use the native `cURL` functions.
 * [PHPUnit](https://phpunit.de/) >= 9.0 (optional) to run the test suite
+
+## Todo
+
+* Check header's response code (especially for POST/PUT/DELETE requests)
+* See http://stackoverflow.com/questions/9183178/php-curl-retrieving-response-headers-and-body-in-a-single-request/9183272#9183272
+
+## Limitations / Missing Redmine-API
+
+Redmine is missing some APIs for a full remote management of the data:
+* List of activities & roles: http://www.redmine.org/issues/11464
+
+A possible solution to this would be to create an extra APIs implementing the
+missing entry points. See existing effort in doing so:
+https://github.com/rschobbert/redmine-miss-api
 
 ## Install
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -598,7 +598,7 @@ Using this methods you can use every Redmine API endpoint. The following example
 ```php
 $client->requestPut(
     '/projects/1.xml',
-    \Redmine\Serializer\XmlSerializer::createFromArray([
+    (string) \Redmine\Serializer\XmlSerializer::createFromArray([
         'project' => [
             'name' => 'renamed project',
             'custom_fields' => [
@@ -610,7 +610,7 @@ $client->requestPut(
                 ],
             ],
         ]
-    ])->getEncoded()
+    ])
 );
 ```
 
@@ -620,7 +620,7 @@ Or to fetch data with complex query parameters you can use `requestGet()` with t
 
 ```php
 $client->requestGet(
-    \Redmine\Serializer\PathSerializer::create(
+    (string) \Redmine\Serializer\PathSerializer::create(
         '/time_entries.json',
         [
             'f' => ['spent_on'],
@@ -632,7 +632,7 @@ $client->requestGet(
                 ],
             ],
         ],
-    )->getPath()
+    )
 );
 ```
 

--- a/src/Redmine/Api/AbstractApi.php
+++ b/src/Redmine/Api/AbstractApi.php
@@ -32,12 +32,12 @@ abstract class AbstractApi implements Api
      *
      * @return bool
      *
-     * @deprecated This method does not correctly handle 2xx codes that are not 200 or 201, use \Redmine\Client\Client::getLastResponseStatusCode() instead
+     * @deprecated since v2.1.0, because it does not correctly handle 2xx codes that are not 200 or 201, use \Redmine\Client\Client::getLastResponseStatusCode() instead
      * @see Client::getLastResponseStatusCode() for checking the status code directly
      */
     public function lastCallFailed()
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated, use \Redmine\Client\Client::getLastResponseStatusCode() instead.', E_USER_DEPRECATED);
+        @trigger_error('`'.__METHOD__.'()` is deprecated since v2.1.0, use \Redmine\Client\Client::getLastResponseStatusCode() instead.', E_USER_DEPRECATED);
 
         $code = $this->client->getLastResponseStatusCode();
 
@@ -164,7 +164,7 @@ abstract class AbstractApi implements Api
      * Retrieves all the elements of a given endpoint (even if the
      * total number of elements is greater than 100).
      *
-     * @deprecated the `retrieveAll()` method is deprecated, use `retrieveData()` instead
+     * @deprecated since v2.2.0, use `retrieveData()` instead
      *
      * @param string $endpoint API end point
      * @param array  $params   optional parameters to be passed to the api (offset, limit, ...)
@@ -173,7 +173,7 @@ abstract class AbstractApi implements Api
      */
     protected function retrieveAll($endpoint, array $params = [])
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated, use `retrieveData()` instead.', E_USER_DEPRECATED);
+        @trigger_error('`'.__METHOD__.'()` is deprecated since v2.2.0, use `retrieveData()` instead.', E_USER_DEPRECATED);
 
         try {
             $data = $this->retrieveData(strval($endpoint), $params);
@@ -253,7 +253,7 @@ abstract class AbstractApi implements Api
     /**
      * Attaches Custom Fields to a create/update query.
      *
-     * @deprecated the `attachCustomFieldXML()` method is deprecated.
+     * @deprecated since v2.3.0, use `\Redmine\Serializer\XmlSerializer::createFromArray()` instead
      *
      * @param SimpleXMLElement $xml    XML Element the custom fields are attached to
      * @param array            $fields array of fields to attach, each field needs name, id and value set
@@ -264,7 +264,7 @@ abstract class AbstractApi implements Api
      */
     protected function attachCustomFieldXML(SimpleXMLElement $xml, array $fields)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated.', E_USER_DEPRECATED);
+        @trigger_error('`'.__METHOD__.'()` is deprecated since v2.3.0, use `\Redmine\Serializer\XmlSerializer::createFromArray()` instead.', E_USER_DEPRECATED);
 
         $_fields = $xml->addChild('custom_fields');
         $_fields->addAttribute('type', 'array');

--- a/src/Redmine/Api/Project.php
+++ b/src/Redmine/Api/Project.php
@@ -156,7 +156,7 @@ class Project extends AbstractApi
     }
 
     /**
-     * @deprecated the `prepareParamsXml()` method is deprecated, use `\Redmine\Serializer\XmlSerializer::createFromArray()` instead.
+     * @deprecated since v2.3.0, use `\Redmine\Serializer\XmlSerializer::createFromArray()` instead.
      *
      * @param array $params
      *
@@ -164,7 +164,7 @@ class Project extends AbstractApi
      */
     protected function prepareParamsXml($params)
     {
-        @trigger_error('The '.__METHOD__.' method is deprecated, use `\Redmine\Serializer\XmlSerializer::createFromArray()` instead.', E_USER_DEPRECATED);
+        @trigger_error('`'.__METHOD__.'()` is deprecated since v2.3.0, use `\Redmine\Serializer\XmlSerializer::createFromArray()` instead.', E_USER_DEPRECATED);
 
         return new \SimpleXMLElement(
             XmlSerializer::createFromArray(['project' => $params])->getEncoded()

--- a/src/Redmine/Serializer/JsonSerializer.php
+++ b/src/Redmine/Serializer/JsonSerializer.php
@@ -7,8 +7,6 @@ use Redmine\Exception\SerializerException;
 
 /**
  * JsonSerializer.
- *
- * @internal
  */
 final class JsonSerializer
 {

--- a/src/Redmine/Serializer/JsonSerializer.php
+++ b/src/Redmine/Serializer/JsonSerializer.php
@@ -4,11 +4,12 @@ namespace Redmine\Serializer;
 
 use JsonException;
 use Redmine\Exception\SerializerException;
+use Stringable;
 
 /**
  * JsonSerializer.
  */
-final class JsonSerializer
+final class JsonSerializer implements Stringable
 {
     /**
      * @throws SerializerException if $data is not valid JSON
@@ -53,6 +54,11 @@ final class JsonSerializer
     public function getEncoded(): string
     {
         return $this->encoded;
+    }
+
+    public function __toString(): string
+    {
+        return $this->getEncoded();
     }
 
     private function decode(string $encoded): void

--- a/src/Redmine/Serializer/PathSerializer.php
+++ b/src/Redmine/Serializer/PathSerializer.php
@@ -2,10 +2,12 @@
 
 namespace Redmine\Serializer;
 
+use Stringable;
+
 /**
- * PathSerializer.
+ * PathSerializer to handle query parameters.
  */
-final class PathSerializer
+final class PathSerializer implements Stringable
 {
     public static function create(string $path, array $queryParams = []): self
     {
@@ -37,5 +39,10 @@ final class PathSerializer
         }
 
         return $this->path.$queryString;
+    }
+
+    public function __toString(): string
+    {
+        return $this->getPath();
     }
 }

--- a/src/Redmine/Serializer/PathSerializer.php
+++ b/src/Redmine/Serializer/PathSerializer.php
@@ -4,8 +4,6 @@ namespace Redmine\Serializer;
 
 /**
  * PathSerializer.
- *
- * @internal
  */
 final class PathSerializer
 {

--- a/src/Redmine/Serializer/XmlSerializer.php
+++ b/src/Redmine/Serializer/XmlSerializer.php
@@ -9,8 +9,6 @@ use Throwable;
 
 /**
  * XmlSerializer.
- *
- * @internal
  */
 final class XmlSerializer
 {

--- a/src/Redmine/Serializer/XmlSerializer.php
+++ b/src/Redmine/Serializer/XmlSerializer.php
@@ -5,12 +5,13 @@ namespace Redmine\Serializer;
 use JsonException;
 use Redmine\Exception\SerializerException;
 use SimpleXMLElement;
+use Stringable;
 use Throwable;
 
 /**
  * XmlSerializer.
  */
-final class XmlSerializer
+final class XmlSerializer implements Stringable
 {
     /**
      * @throws SerializerException if $data is not valid XML
@@ -57,6 +58,11 @@ final class XmlSerializer
     public function getEncoded(): string
     {
         return $this->encoded;
+    }
+
+    public function __toString(): string
+    {
+        return $this->getEncoded();
     }
 
     private function deserialize(string $encoded): void

--- a/tests/Unit/Api/AbstractApiTest.php
+++ b/tests/Unit/Api/AbstractApiTest.php
@@ -236,4 +236,21 @@ class AbstractApiTest extends TestCase
         $this->assertSame([], $method->invoke($api, '/issues.xml'));
 
     }
+
+    /**
+     * @covers \Redmine\Api\AbstractApi::attachCustomFieldXML
+     */
+    public function testDeprecatedAttachCustomFieldXML()
+    {
+        $client = $this->createMock(Client::class);
+
+        $api = $this->getMockForAbstractClass(AbstractApi::class, [$client]);
+
+        $method = new ReflectionMethod($api, 'attachCustomFieldXML');
+        $method->setAccessible(true);
+
+        $xml = new SimpleXMLElement('<?xml version="1.0"?><issue/>');
+
+        $this->assertInstanceOf(SimpleXMLElement::class, $method->invoke($api, $xml, []));
+    }
 }

--- a/tests/Unit/Api/ProjectTest.php
+++ b/tests/Unit/Api/ProjectTest.php
@@ -6,6 +6,8 @@ use PHPUnit\Framework\TestCase;
 use Redmine\Api\Project;
 use Redmine\Client\Client;
 use Redmine\Exception\MissingParameterException;
+use ReflectionMethod;
+use SimpleXMLElement;
 
 /**
  * @coversDefaultClass \Redmine\Api\Project
@@ -533,5 +535,20 @@ class ProjectTest extends TestCase
 
         // Perform the tests
         $this->assertSame($response, $api->update(5, $parameters));
+    }
+
+    /**
+     * @covers \Redmine\Api\Project::prepareParamsXml
+     */
+    public function testDeprecatedPrepareParamsXml()
+    {
+        $client = $this->createMock(Client::class);
+
+        $api = new Project($client);
+
+        $method = new ReflectionMethod($api, 'prepareParamsXml');
+        $method->setAccessible(true);
+
+        $this->assertInstanceOf(SimpleXMLElement::class, $method->invoke($api, ['id' => 1]));
     }
 }

--- a/tests/Unit/Serializer/JsonSerializerTest.php
+++ b/tests/Unit/Serializer/JsonSerializerTest.php
@@ -180,21 +180,17 @@ class JsonSerializerTest extends TestCase
     }
 
     /**
+     * @covers \Redmine\Serializer\JsonSerializer::getEncoded
+     * @covers \Redmine\Serializer\JsonSerializer::__toString
      * @test
      *
      * @dataProvider getNormalizedToEncodedData
      */
-    public function createFromArrayDecodesToExpectedString(array $data, $expected)
+    public function createFromArrayEncodesToExpectedString(array $data, $expected)
     {
         $serializer = JsonSerializer::createFromArray($data);
 
-        // decode the result, so we encode again with JSON_PRETTY_PRINT to compare the formated output
-        $encoded = json_encode(
-            json_decode($serializer->getEncoded(), true, 512, \JSON_THROW_ON_ERROR),
-            \JSON_THROW_ON_ERROR | \JSON_PRETTY_PRINT
-        );
-
-        $this->assertSame($expected, $encoded);
+        $this->assertJsonStringEqualsJsonString($expected, $serializer->__toString());
     }
 
     public static function getInvalidSerializedData(): array

--- a/tests/Unit/Serializer/PathSerializerTest.php
+++ b/tests/Unit/Serializer/PathSerializerTest.php
@@ -48,6 +48,8 @@ class PathSerializerTest extends TestCase
     }
 
     /**
+     * @covers \Redmine\Serializer\PathSerializer::getPath
+     * @covers \Redmine\Serializer\PathSerializer::__toString
      * @test
      *
      * @dataProvider getPathData
@@ -56,6 +58,6 @@ class PathSerializerTest extends TestCase
     {
         $serializer = PathSerializer::create($path, $params);
 
-        $this->assertSame($expected, $serializer->getPath());
+        $this->assertSame($expected, $serializer->__toString());
     }
 }

--- a/tests/Unit/Serializer/XmlSerializerTest.php
+++ b/tests/Unit/Serializer/XmlSerializerTest.php
@@ -186,19 +186,17 @@ class XmlSerializerTest extends TestCase
     }
 
     /**
+     * @covers \Redmine\Serializer\XmlSerializer::getEncoded
+     * @covers \Redmine\Serializer\XmlSerializer::__toString
      * @test
      *
      * @dataProvider getNormalizedToEncodedData
      */
-    public function createFromArrayDecodesToExpectedString(array $data, $expected)
+    public function createFromArrayEncodesToExpectedString(array $data, $expected)
     {
         $serializer = XmlSerializer::createFromArray($data);
 
-        // Load the encoded string into a DOMDocument, so we can compare the formated output
-        $dom = dom_import_simplexml(new \SimpleXMLElement($serializer->getEncoded()))->ownerDocument;
-        $dom->formatOutput = true;
-
-        $this->assertSame($expected, trim($dom->saveXML()));
+        $this->assertXmlStringEqualsXmlString($expected, $serializer->__toString());
     }
 
     public static function getInvalidSerializedData(): array


### PR DESCRIPTION
Hey 👋

This issue is more about a communication strategy than a technical issue.

I was thinking about #146 to implement a switch for JSON/XML responses.

## The problem

Example: To change a project I run this code:

```php
$response = $client->getApi('project')->update(1, [
    'name' => 'renamed project',
    'custom_fields' => [
        [
            'id' => 123,
            'name' => 'cf_name',
            'field_format' => 'string',
            'value' => [1, 2, 3],
        ],
    ],
]);
```

Because `Redmine\Api\Project::update()` uses the XML endpoint internally `$response` is a `SimpleXMLElement` instance and the **response body contains XML** as well, but I would like to have JSON:

```php
var_dump($client->getLastResponseBody());
// (string): "<?xml version="1.0" encoding="UTF-8"?><project[...]"
// But I would like to have JSON...
```

## Workaround 1

The current workaround is to check for `SimpleXMLElement` and use `json_encode($response)`.

```php
if ($response instanceof \SimpleXMLElement)
{
    $responseAsJsonString = json_encode($response);
}
```

## Workaround 2

Another workaround could be to use `$client->requestPut()` directly to request the JSON endpoint:

```php
$client->requestPut(
    '/projects/1.json',
    '{"project":{"name":"renamed project","custom_fields":[["id":123,"name":"cf_name","field_format":"string","value":[1,2,3]]]}}'
]);

$response = $client->getLastResponseBody();
```

Now `$response` will be a JSON string. But this is not very intuitive, because now you have to know about the correct endpoints and handle JSON data with `json_encode()` and `json_decode()` again for the request instead on the response.

## New solution: Allow Serializers

So I came up with the idea to allow the public usage of the new serializer from #310 and #315. (The serializers are marked as `@internal` atm)

The code from the first example could be look like this:

```php
$client->requestPut('/projects/1.json', (string) \Redmine\Serializer\JsonSerializer::createFromArray(['project' => [
    'name' => 'renamed project',
    'custom_fields' => [
        [
            'id' => 123,
            'name' => 'cf_name',
            'field_format' => 'string',
            'value' => [1, 2, 3],
        ],
    ],
]]));

$response = $client->getLastResponseBody();
```

## low-level API: `$client->request*()` + Serializers

To switch between JSON or XML request/response by using the correct endpoint is already possible but requires more knowledge about the Redmine API, converting and sanitizing XML/JSON data and handling query parameters. The Serializer can simplify this.

For better communication I propose to call this the **low-level API**. 

In this PR I started to point this out.

## mid-level API: `$client->getApi()`

In contrary the "normal" way of calling `$client->getApi('...')` will be called the **mid-level API**. The mid-level API is build on top of the low-level API.

The mid-level API remains the recommended way to use php-redmine-api, but for special cases or missing features like #192 or #263 we can point to the low-level API as workaround.