### PR TITLE
Improve integration tests with assertXmlStringEqualsXmlString()

### DIFF
--- a/tests/Integration/GroupXmlTest.php
+++ b/tests/Integration/GroupXmlTest.php
@@ -2,12 +2,10 @@
 
 namespace Redmine\Tests\Integration;
 
-use DOMDocument;
 use Exception;
 use PHPUnit\Framework\TestCase;
 use Redmine\Exception\MissingParameterException;
 use Redmine\Tests\Fixtures\MockClient;
-use SimpleXMLElement;
 
 class GroupXmlTest extends TestCase
 {
@@ -38,18 +36,23 @@ class GroupXmlTest extends TestCase
             'name' => 'Developers',
             'user_ids' => [3, 5],
         ]);
-        $res = json_decode($res, true);
+        $response = json_decode($res, true);
 
-        $xml = '<?xml version="1.0"?>
-<group>
-    <name>Developers</name>
-    <user_ids type="array">
-        <user_id>3</user_id>
-        <user_id>5</user_id>
-    </user_ids>
-</group>
-';
-        $this->assertEquals($this->formatXml($xml), $this->formatXml($res['data']));
+        $this->assertEquals('POST', $response['method']);
+        $this->assertEquals('/groups.xml', $response['path']);
+        $this->assertXmlStringEqualsXmlString(
+            <<< XML
+            <?xml version="1.0"?>
+            <group>
+                <name>Developers</name>
+                <user_ids type="array">
+                    <user_id>3</user_id>
+                    <user_id>5</user_id>
+                </user_ids>
+            </group>
+            XML,
+            $response['data']
+        );
     }
 
     public function testUpdateNotImplemented()
@@ -61,15 +64,5 @@ class GroupXmlTest extends TestCase
         $this->expectExceptionMessage('Not implemented');
 
         $api->update(1);
-    }
-
-    private function formatXml($xml)
-    {
-        $dom = new DOMDocument('1.0');
-        $dom->preserveWhiteSpace = false;
-        $dom->formatOutput = true;
-        $dom->loadXML((new SimpleXMLElement($xml))->asXML());
-
-        return $dom->saveXML();
     }
 }

--- a/tests/Integration/IssueCategoryXmlTest.php
+++ b/tests/Integration/IssueCategoryXmlTest.php
@@ -2,11 +2,9 @@
 
 namespace Redmine\Tests\Integration;
 
-use DOMDocument;
 use PHPUnit\Framework\TestCase;
 use Redmine\Exception\MissingParameterException;
 use Redmine\Tests\Fixtures\MockClient;
-use SimpleXMLElement;
 
 class IssueCategoryXmlTest extends TestCase
 {
@@ -37,13 +35,19 @@ class IssueCategoryXmlTest extends TestCase
         $res = $api->create('otherProject', [
             'name' => 'test category',
         ]);
-        $res = json_decode($res, true);
+        $response = json_decode($res, true);
 
-        $xml = '<?xml version="1.0"?>
-<issue_category>
-    <name>test category</name>
-</issue_category>';
-        $this->assertEquals($this->formatXml($xml), $this->formatXml($res['data']));
+        $this->assertEquals('POST', $response['method']);
+        $this->assertEquals('/projects/otherProject/issue_categories.xml', $response['path']);
+        $this->assertXmlStringEqualsXmlString(
+            <<< XML
+            <?xml version="1.0"?>
+            <issue_category>
+                <name>test category</name>
+            </issue_category>
+            XML,
+            $response['data']
+        );
     }
 
     public function testUpdate()
@@ -52,22 +56,18 @@ class IssueCategoryXmlTest extends TestCase
         $res = $api->update(1, [
             'name' => 'new category name',
         ]);
-        $res = json_decode($res, true);
+        $response = json_decode($res, true);
 
-        $xml = '<?xml version="1.0"?>
-<issue_category>
-    <name>new category name</name>
-</issue_category>';
-        $this->assertEquals($this->formatXml($xml), $this->formatXml($res['data']));
-    }
-
-    private function formatXml($xml)
-    {
-        $dom = new DOMDocument('1.0');
-        $dom->preserveWhiteSpace = false;
-        $dom->formatOutput = true;
-        $dom->loadXML((new SimpleXMLElement($xml))->asXML());
-
-        return $dom->saveXML();
+        $this->assertEquals('PUT', $response['method']);
+        $this->assertEquals('/issue_categories/1.xml', $response['path']);
+        $this->assertXmlStringEqualsXmlString(
+            <<< XML
+            <?xml version="1.0"?>
+            <issue_category>
+                <name>new category name</name>
+            </issue_category>
+            XML,
+            $response['data']
+        );
     }
 }

--- a/tests/Integration/IssueXmlTest.php
+++ b/tests/Integration/IssueXmlTest.php
@@ -2,10 +2,8 @@
 
 namespace Redmine\Tests\Integration;
 
-use DOMDocument;
 use PHPUnit\Framework\TestCase;
 use Redmine\Tests\Fixtures\MockClient;
-use SimpleXMLElement;
 
 class IssueXmlTest extends TestCase
 {
@@ -24,12 +22,18 @@ class IssueXmlTest extends TestCase
         $api = $this->client->getApi('issue');
         $this->assertInstanceOf('Redmine\Api\Issue', $api);
 
-        $xml = '<?xml version="1.0"?>
-<issue/>';
         $res = $api->create();
-        $res = json_decode($res, true);
+        $response = json_decode($res, true);
 
-        $this->assertEquals($this->formatXml($xml), $this->formatXml($res['data']));
+        $this->assertEquals('POST', $response['method']);
+        $this->assertEquals('/issues.xml', $response['path']);
+        $this->assertXmlStringEqualsXmlString(
+            <<< XML
+            <?xml version="1.0"?>
+            <issue/>
+            XML,
+            $response['data']
+        );
     }
 
     public function testCreateComplexWithUpload()
@@ -48,23 +52,29 @@ class IssueXmlTest extends TestCase
                 ],
             ],
         ]);
-        $res = json_decode($res, true);
+        $response = json_decode($res, true);
 
-        $xml = '<?xml version="1.0"?>
-<issue>
-    <subject>A test issue</subject>
-    <description>Here goes the issue description</description>
-    <project_id>myproject</project_id>
-    <uploads type="array">
-      <upload>
-        <token>asdfasdfasdfasdf</token>
-        <filename>MyFile.pdf</filename>
-        <description>MyFile is better then YourFile...</description>
-        <content_type>application/pdf</content_type>
-      </upload>
-    </uploads>
-</issue>';
-        $this->assertEquals($this->formatXml($xml), $this->formatXml($res['data']));
+        $this->assertEquals('POST', $response['method']);
+        $this->assertEquals('/issues.xml', $response['path']);
+        $this->assertXmlStringEqualsXmlString(
+            <<< XML
+            <?xml version="1.0"?>
+            <issue>
+                <subject>A test issue</subject>
+                <description>Here goes the issue description</description>
+                <project_id>myproject</project_id>
+                <uploads type="array">
+                    <upload>
+                        <token>asdfasdfasdfasdf</token>
+                        <filename>MyFile.pdf</filename>
+                        <description>MyFile is better then YourFile...</description>
+                        <content_type>application/pdf</content_type>
+                    </upload>
+                </uploads>
+            </issue>
+            XML,
+            $response['data']
+        );
     }
 
     public function testCreateComplex()
@@ -94,21 +104,27 @@ class IssueXmlTest extends TestCase
             ],
             'watcher_user_ids' => [],
         ]);
-        $res = json_decode($res, true);
+        $response = json_decode($res, true);
 
-        $xml = '<?xml version="1.0"?>
-<issue>
-    <subject>test api (xml) 3</subject>
-    <description>test api</description>
-    <project_id>test</project_id>
-    <assigned_to_id>1</assigned_to_id>
-    <custom_fields type="array">
-        <custom_field name="Issuer" id="2"><value>asdf</value></custom_field>
-        <custom_field name="Phone" id="5"><value>9939494</value></custom_field>
-        <custom_field name="Email" id="8"><value>asdf@asdf.com</value></custom_field>
-    </custom_fields>
-</issue>';
-        $this->assertEquals($this->formatXml($xml), $this->formatXml($res['data']));
+        $this->assertEquals('POST', $response['method']);
+        $this->assertEquals('/issues.xml', $response['path']);
+        $this->assertXmlStringEqualsXmlString(
+            <<< XML
+            <?xml version="1.0"?>
+            <issue>
+                <subject>test api (xml) 3</subject>
+                <description>test api</description>
+                <project_id>test</project_id>
+                <assigned_to_id>1</assigned_to_id>
+                <custom_fields type="array">
+                    <custom_field name="Issuer" id="2"><value>asdf</value></custom_field>
+                    <custom_field name="Phone" id="5"><value>9939494</value></custom_field>
+                    <custom_field name="Email" id="8"><value>asdf@asdf.com</value></custom_field>
+                </custom_fields>
+            </issue>
+            XML,
+            $response['data']
+        );
     }
 
     public function testCreateComplexWithLineBreakInDescription()
@@ -138,22 +154,28 @@ class IssueXmlTest extends TestCase
             ],
             'watcher_user_ids' => [],
         ]);
-        $res = json_decode($res, true);
+        $response = json_decode($res, true);
 
-        $xml = '<?xml version="1.0"?>
-<issue>
-    <subject>test api (xml) 3</subject>
-    <description>line1
-line2</description>
-    <project_id>test</project_id>
-    <assigned_to_id>1</assigned_to_id>
-    <custom_fields type="array">
-        <custom_field name="Issuer" id="2"><value>asdf</value></custom_field>
-        <custom_field name="Phone" id="5"><value>9939494</value></custom_field>
-        <custom_field name="Email" id="8"><value>asdf@asdf.com</value></custom_field>
-    </custom_fields>
-</issue>';
-        $this->assertEquals($this->formatXml($xml), $this->formatXml($res['data']));
+        $this->assertEquals('POST', $response['method']);
+        $this->assertEquals('/issues.xml', $response['path']);
+        $this->assertXmlStringEqualsXmlString(
+            <<< XML
+            <?xml version="1.0"?>
+            <issue>
+                <subject>test api (xml) 3</subject>
+                <description>line1
+            line2</description>
+                <project_id>test</project_id>
+                <assigned_to_id>1</assigned_to_id>
+                <custom_fields type="array">
+                    <custom_field name="Issuer" id="2"><value>asdf</value></custom_field>
+                    <custom_field name="Phone" id="5"><value>9939494</value></custom_field>
+                    <custom_field name="Email" id="8"><value>asdf@asdf.com</value></custom_field>
+                </custom_fields>
+            </issue>
+            XML,
+            $response['data']
+        );
     }
 
     public function testUpdateIssue()
@@ -170,42 +192,44 @@ line2</description>
             // not testable because this will trigger a status name to id resolving
             // 'status' => 'Resolved',
         ]);
-        $res = json_decode($res, true);
+        $response = json_decode($res, true);
 
-        $xml = '<?xml version="1.0"?>
-<issue>
-    <id>1</id>
-    <subject>test note (xml) 1</subject>
-    <notes>test note api</notes>
-    <priority_id>5</priority_id>
-    <status_id>2</status_id>
-    <assigned_to_id>1</assigned_to_id>
-    <due_date>2014-05-13</due_date>
-</issue>';
-        $this->assertEquals($this->formatXml($xml), $this->formatXml($res['data']));
+        $this->assertEquals('PUT', $response['method']);
+        $this->assertEquals('/issues/1.xml', $response['path']);
+        $this->assertXmlStringEqualsXmlString(
+            <<< XML
+            <?xml version="1.0"?>
+            <issue>
+                <id>1</id>
+                <subject>test note (xml) 1</subject>
+                <notes>test note api</notes>
+                <priority_id>5</priority_id>
+                <status_id>2</status_id>
+                <assigned_to_id>1</assigned_to_id>
+                <due_date>2014-05-13</due_date>
+            </issue>
+            XML,
+            $response['data']
+        );
     }
 
     public function testAddNoteToIssue()
     {
         $api = $this->client->getApi('issue');
         $res = $api->addNoteToIssue(1, 'some comment');
-        $res = json_decode($res, true);
+        $response = json_decode($res, true);
 
-        $xml = '<?xml version="1.0"?>
-<issue>
-    <id>1</id>
-    <notes>some comment</notes>
-</issue>';
-        $this->assertEquals($this->formatXml($xml), $this->formatXml($res['data']));
-    }
-
-    private function formatXml($xml)
-    {
-        $dom = new DOMDocument('1.0');
-        $dom->preserveWhiteSpace = false;
-        $dom->formatOutput = true;
-        $dom->loadXML((new SimpleXMLElement($xml))->asXML());
-
-        return $dom->saveXML();
+        $this->assertEquals('PUT', $response['method']);
+        $this->assertEquals('/issues/1.xml', $response['path']);
+        $this->assertXmlStringEqualsXmlString(
+            <<< XML
+            <?xml version="1.0"?>
+            <issue>
+                <id>1</id>
+                <notes>some comment</notes>
+            </issue>
+            XML,
+            $response['data']
+        );
     }
 }

--- a/tests/Integration/MembershipXmlTest.php
+++ b/tests/Integration/MembershipXmlTest.php
@@ -2,11 +2,9 @@
 
 namespace Redmine\Tests\Integration;
 
-use DOMDocument;
 use PHPUnit\Framework\TestCase;
 use Redmine\Exception\MissingParameterException;
 use Redmine\Tests\Fixtures\MockClient;
-use SimpleXMLElement;
 
 class MembershipXmlTest extends TestCase
 {
@@ -38,17 +36,23 @@ class MembershipXmlTest extends TestCase
             'user_id' => 1,
             'role_ids' => [1, 2],
         ]);
-        $res = json_decode($res, true);
+        $response = json_decode($res, true);
 
-        $xml = '<?xml version="1.0"?>
-<membership>
-    <user_id>1</user_id>
-    <role_ids type="array">
-        <role_id>1</role_id>
-        <role_id>2</role_id>
-    </role_ids>
-</membership>';
-        $this->assertEquals($this->formatXml($xml), $this->formatXml($res['data']));
+        $this->assertEquals('POST', $response['method']);
+        $this->assertEquals('/projects/otherProject/memberships.xml', $response['path']);
+        $this->assertXmlStringEqualsXmlString(
+            <<< XML
+            <?xml version="1.0"?>
+            <membership>
+                <user_id>1</user_id>
+                <role_ids type="array">
+                    <role_id>1</role_id>
+                    <role_id>2</role_id>
+                </role_ids>
+            </membership>
+            XML,
+            $response['data']
+        );
     }
 
     public function testUpdate()
@@ -57,25 +61,21 @@ class MembershipXmlTest extends TestCase
         $res = $api->update(1, [
             'role_ids' => [1, 2],
         ]);
-        $res = json_decode($res, true);
+        $response = json_decode($res, true);
 
-        $xml = '<?xml version="1.0"?>
-<membership>
-    <role_ids type="array">
-        <role_id>1</role_id>
-        <role_id>2</role_id>
-    </role_ids>
-</membership>';
-        $this->assertEquals($this->formatXml($xml), $this->formatXml($res['data']));
-    }
-
-    private function formatXml($xml)
-    {
-        $dom = new DOMDocument('1.0');
-        $dom->preserveWhiteSpace = false;
-        $dom->formatOutput = true;
-        $dom->loadXML((new SimpleXMLElement($xml))->asXML());
-
-        return $dom->saveXML();
+        $this->assertEquals('PUT', $response['method']);
+        $this->assertEquals('/memberships/1.xml', $response['path']);
+        $this->assertXmlStringEqualsXmlString(
+            <<< XML
+            <?xml version="1.0"?>
+            <membership>
+                <role_ids type="array">
+                    <role_id>1</role_id>
+                    <role_id>2</role_id>
+                </role_ids>
+            </membership>
+            XML,
+            $response['data']
+        );
     }
 }

--- a/tests/Integration/ProjectXmlTest.php
+++ b/tests/Integration/ProjectXmlTest.php
@@ -2,11 +2,9 @@
 
 namespace Redmine\Tests\Integration;
 
-use DOMDocument;
 use PHPUnit\Framework\TestCase;
 use Redmine\Exception\MissingParameterException;
 use Redmine\Tests\Fixtures\MockClient;
-use SimpleXMLElement;
 
 class ProjectXmlTest extends TestCase
 {
@@ -46,23 +44,29 @@ class ProjectXmlTest extends TestCase
                 ],
             ],
         ]);
-        $res = json_decode($res, true);
+        $response = json_decode($res, true);
 
-        $xml = '<?xml version="1.0"?>
-<project>
-    <name>some name</name>
-    <identifier>the_identifier</identifier>
-    <custom_fields type="array">
-        <custom_field name="cf_name" field_format="string" id="123" multiple="true">
-            <value type="array">
-                <value>1</value>
-                <value>2</value>
-                <value>3</value>
-            </value>
-        </custom_field>
-    </custom_fields>
-</project>';
-        $this->assertEquals($this->formatXml($xml), $this->formatXml($res['data']));
+        $this->assertEquals('POST', $response['method']);
+        $this->assertEquals('/projects.xml', $response['path']);
+        $this->assertXmlStringEqualsXmlString(
+            <<< XML
+            <?xml version="1.0"?>
+            <project>
+                <name>some name</name>
+                <identifier>the_identifier</identifier>
+                <custom_fields type="array">
+                    <custom_field name="cf_name" field_format="string" id="123" multiple="true">
+                        <value type="array">
+                            <value>1</value>
+                            <value>2</value>
+                            <value>3</value>
+                        </value>
+                    </custom_field>
+                </custom_fields>
+            </project>
+            XML,
+            $response['data']
+        );
     }
 
     public function testCreateComplexWithTrackerIds()
@@ -75,19 +79,25 @@ class ProjectXmlTest extends TestCase
                 1, 2, 3,
             ],
         ]);
-        $res = json_decode($res, true);
+        $response = json_decode($res, true);
 
-        $xml = '<?xml version="1.0"?>
-<project>
-    <name>some name</name>
-    <identifier>the_identifier</identifier>
-    <tracker_ids type="array">
-        <tracker>1</tracker>
-        <tracker>2</tracker>
-        <tracker>3</tracker>
-    </tracker_ids>
-</project>';
-        $this->assertEquals($this->formatXml($xml), $this->formatXml($res['data']));
+        $this->assertEquals('POST', $response['method']);
+        $this->assertEquals('/projects.xml', $response['path']);
+        $this->assertXmlStringEqualsXmlString(
+            <<< XML
+            <?xml version="1.0"?>
+            <project>
+                <name>some name</name>
+                <identifier>the_identifier</identifier>
+                <tracker_ids type="array">
+                    <tracker>1</tracker>
+                    <tracker>2</tracker>
+                    <tracker>3</tracker>
+                </tracker_ids>
+            </project>
+            XML,
+            $response['data']
+        );
     }
 
     public function testUpdate()
@@ -96,23 +106,19 @@ class ProjectXmlTest extends TestCase
         $res = $api->update(1, [
             'name' => 'different name',
         ]);
-        $res = json_decode($res, true);
+        $response = json_decode($res, true);
 
-        $xml = '<?xml version="1.0"?>
-<project>
-    <id>1</id>
-    <name>different name</name>
-</project>';
-        $this->assertEquals($this->formatXml($xml), $this->formatXml($res['data']));
-    }
-
-    private function formatXml($xml)
-    {
-        $dom = new DOMDocument('1.0');
-        $dom->preserveWhiteSpace = false;
-        $dom->formatOutput = true;
-        $dom->loadXML((new SimpleXMLElement($xml))->asXML());
-
-        return $dom->saveXML();
+        $this->assertEquals('PUT', $response['method']);
+        $this->assertEquals('/projects/1.xml', $response['path']);
+        $this->assertXmlStringEqualsXmlString(
+            <<< XML
+            <?xml version="1.0"?>
+            <project>
+                <id>1</id>
+                <name>different name</name>
+            </project>
+            XML,
+            $response['data']
+        );
     }
 }

--- a/tests/Integration/UserXmlTest.php
+++ b/tests/Integration/UserXmlTest.php
@@ -2,11 +2,9 @@
 
 namespace Redmine\Tests\Integration;
 
-use DOMDocument;
 use PHPUnit\Framework\TestCase;
 use Redmine\Exception\MissingParameterException;
 use Redmine\Tests\Fixtures\MockClient;
-use SimpleXMLElement;
 
 class UserXmlTest extends TestCase
 {
@@ -40,16 +38,22 @@ class UserXmlTest extends TestCase
             'lastname' => 'test',
             'mail' => 'test@example.com',
         ]);
-        $res = json_decode($res, true);
+        $response = json_decode($res, true);
 
-        $xml = '<?xml version="1.0"?>
-<user>
-    <login>test</login>
-    <lastname>test</lastname>
-    <firstname>test</firstname>
-    <mail>test@example.com</mail>
-</user>';
-        $this->assertEquals($this->formatXml($xml), $this->formatXml($res['data']));
+        $this->assertEquals('POST', $response['method']);
+        $this->assertEquals('/users.xml', $response['path']);
+        $this->assertXmlStringEqualsXmlString(
+            <<< XML
+            <?xml version="1.0"?>
+            <user>
+                <login>test</login>
+                <lastname>test</lastname>
+                <firstname>test</firstname>
+                <mail>test@example.com</mail>
+            </user>
+            XML,
+            $response['data']
+        );
     }
 
     public function testUpdate()
@@ -58,23 +62,19 @@ class UserXmlTest extends TestCase
         $res = $api->update(1, [
             'firstname' => 'Raul',
         ]);
-        $res = json_decode($res, true);
+        $response = json_decode($res, true);
 
-        $xml = '<?xml version="1.0"?>
-<user>
-    <id>1</id>
-    <firstname>Raul</firstname>
-</user>';
-        $this->assertEquals($this->formatXml($xml), $this->formatXml($res['data']));
-    }
-
-    private function formatXml($xml)
-    {
-        $dom = new DOMDocument('1.0');
-        $dom->preserveWhiteSpace = false;
-        $dom->formatOutput = true;
-        $dom->loadXML((new SimpleXMLElement($xml))->asXML());
-
-        return $dom->saveXML();
+        $this->assertEquals('PUT', $response['method']);
+        $this->assertEquals('/users/1.xml', $response['path']);
+        $this->assertXmlStringEqualsXmlString(
+            <<< XML
+            <?xml version="1.0"?>
+            <user>
+                <id>1</id>
+                <firstname>Raul</firstname>
+            </user>
+            XML,
+            $response['data']
+        );
     }
 }

--- a/tests/Integration/WikiXmlTest.php
+++ b/tests/Integration/WikiXmlTest.php
@@ -2,10 +2,8 @@
 
 namespace Redmine\Tests\Integration;
 
-use DOMDocument;
 use PHPUnit\Framework\TestCase;
 use Redmine\Tests\Fixtures\MockClient;
-use SimpleXMLElement;
 
 class WikiXmlTest extends TestCase
 {
@@ -27,15 +25,21 @@ class WikiXmlTest extends TestCase
             'comments' => 'asdf',
             'version' => 'asdf',
         ]);
-        $res = json_decode($res, true);
+        $response = json_decode($res, true);
 
-        $xml = '<?xml version="1.0"?>
-<wiki_page>
-    <text>asdf</text>
-    <comments>asdf</comments>
-    <version>asdf</version>
-</wiki_page>';
-        $this->assertEquals($this->formatXml($xml), $this->formatXml($res['data']));
+        $this->assertEquals('PUT', $response['method']);
+        $this->assertEquals('/projects/testProject/wiki/about.xml', $response['path']);
+        $this->assertXmlStringEqualsXmlString(
+            <<< XML
+            <?xml version="1.0"?>
+            <wiki_page>
+                <text>asdf</text>
+                <comments>asdf</comments>
+                <version>asdf</version>
+            </wiki_page>
+            XML,
+            $response['data']
+        );
     }
 
     public function testUpdate()
@@ -46,24 +50,20 @@ class WikiXmlTest extends TestCase
             'comments' => 'asdf',
             'version' => 'asdf',
         ]);
-        $res = json_decode($res, true);
+        $response = json_decode($res, true);
 
-        $xml = '<?xml version="1.0"?>
-<wiki_page>
-    <text>asdf</text>
-    <comments>asdf</comments>
-    <version>asdf</version>
-</wiki_page>';
-        $this->assertEquals($this->formatXml($xml), $this->formatXml($res['data']));
-    }
-
-    private function formatXml($xml)
-    {
-        $dom = new DOMDocument('1.0');
-        $dom->preserveWhiteSpace = false;
-        $dom->formatOutput = true;
-        $dom->loadXML((new SimpleXMLElement($xml))->asXML());
-
-        return $dom->saveXML();
+        $this->assertEquals('PUT', $response['method']);
+        $this->assertEquals('/projects/testProject/wiki/about.xml', $response['path']);
+        $this->assertXmlStringEqualsXmlString(
+            <<< XML
+            <?xml version="1.0"?>
+            <wiki_page>
+                <text>asdf</text>
+                <comments>asdf</comments>
+                <version>asdf</version>
+            </wiki_page>
+            XML,
+            $response['data']
+        );
     }
 }


### PR DESCRIPTION
This PR improves the integration tests by using `assertXmlStringEqualsXmlString()` from PHPUnit. I also add assertions for the HTTP methods and the path and formated the expected XML as heredoc.