### PR TITLE
Add phpstan

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
         uses: "ramsey/composer-install@v2"
 
       - name: Run static code analysis
-        if: ${{ matrix.php-versions >= '8.0' }}
+        if: ${{ matrix.php-versions == '8.2' }}
         run: composer run phpstan -- --error-format=github
 
       - name: Run tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,9 @@ jobs:
       - name: "Install Composer dependencies"
         uses: "ramsey/composer-install@v2"
 
+      - name: Run static code analysis
+        run: composer run phpstan -- --error-format=github
+
       - name: Run tests
         run: vendor/bin/phpunit --coverage-text
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,6 +41,7 @@ jobs:
         run: composer run phpstan -- --error-format=github
 
       - name: Run tests
+        if: ${{ matrix.php-versions >= '8.0' }}
         run: vendor/bin/phpunit --coverage-text
 
       - name: Upload coverage reports to Codecov

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 2
+    level: 3
 
     paths:
         - src/

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 1
+    level: 2
 
     paths:
         - src/

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 0
+    level: 1
 
     paths:
         - src/

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 3
+    level: 4
 
     paths:
         - src/

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -1,0 +1,9 @@
+parameters:
+    level: 0
+
+    paths:
+        - src/
+        - tests/
+
+    scanDirectories:
+        - vendor

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
         "friendsofphp/php-cs-fixer": "^3",
         "phpunit/phpunit": "^9 || 10.2.*",
         "guzzlehttp/psr7": "^2",
-        "php-mock/php-mock-phpunit": "^2.6"
+        "php-mock/php-mock-phpunit": "^2.6",
+        "phpstan/phpstan": "^1.10"
     },
     "autoload": {
         "psr-4": {
@@ -41,6 +42,7 @@
     },
     "scripts": {
         "coverage": "phpunit --coverage-html=\".phpunit.cache/code-coverage\"",
+        "phpstan": "phpstan analyze --memory-limit 512M --configuration .phpstan.neon",
         "test": "phpunit"
     }
 }

--- a/src/Redmine/Api/Group.php
+++ b/src/Redmine/Api/Group.php
@@ -63,7 +63,7 @@ class Group extends AbstractApi
      *
      * @throws MissingParameterException Missing mandatory parameters
      *
-     * @return \SimpleXMLElement
+     * @return string|false
      */
     public function create(array $params = [])
     {

--- a/src/Redmine/Api/Issue.php
+++ b/src/Redmine/Api/Issue.php
@@ -76,7 +76,7 @@ class Issue extends AbstractApi
      *
      * @param array $params the new issue data
      *
-     * @return \SimpleXMLElement
+     * @return string|false
      */
     public function create(array $params = [])
     {
@@ -174,6 +174,7 @@ class Issue extends AbstractApi
      */
     public function setIssueStatus($id, $status)
     {
+        /** @var IssueStatus */
         $api = $this->client->getApi('issue_status');
 
         return $this->update($id, [
@@ -204,31 +205,37 @@ class Issue extends AbstractApi
     private function cleanParams(array $params = [])
     {
         if (isset($params['project'])) {
+            /** @var Project */
             $apiProject = $this->client->getApi('project');
             $params['project_id'] = $apiProject->getIdByName($params['project']);
             unset($params['project']);
             if (isset($params['category'])) {
+                /** @var IssueCategory */
                 $apiIssueCategory = $this->client->getApi('issue_category');
                 $params['category_id'] = $apiIssueCategory->getIdByName($params['project_id'], $params['category']);
                 unset($params['category']);
             }
         }
         if (isset($params['status'])) {
+            /** @var IssueStatus */
             $apiIssueStatus = $this->client->getApi('issue_status');
             $params['status_id'] = $apiIssueStatus->getIdByName($params['status']);
             unset($params['status']);
         }
         if (isset($params['tracker'])) {
+            /** @var Tracker */
             $apiTracker = $this->client->getApi('tracker');
             $params['tracker_id'] = $apiTracker->getIdByName($params['tracker']);
             unset($params['tracker']);
         }
         if (isset($params['assigned_to'])) {
+            /** @var User */
             $apiUser = $this->client->getApi('user');
             $params['assigned_to_id'] = $apiUser->getIdByUsername($params['assigned_to']);
             unset($params['assigned_to']);
         }
         if (isset($params['author'])) {
+            /** @var User */
             $apiUser = $this->client->getApi('user');
             $params['author_id'] = $apiUser->getIdByUsername($params['author']);
             unset($params['author']);

--- a/src/Redmine/Api/Membership.php
+++ b/src/Redmine/Api/Membership.php
@@ -121,7 +121,7 @@ class Membership extends AbstractApi
     {
         $memberships = $this->all($projectId, $params);
         if (!isset($memberships['memberships']) || !is_array($memberships['memberships'])) {
-            return;
+            return false;
         }
         $removed = false;
         foreach ($memberships['memberships'] as $membership) {

--- a/src/Redmine/Api/Project.php
+++ b/src/Redmine/Api/Project.php
@@ -106,7 +106,7 @@ class Project extends AbstractApi
      *
      * @throws MissingParameterException
      *
-     * @return \SimpleXMLElement
+     * @return string|false
      */
     public function create(array $params = [])
     {

--- a/src/Redmine/Client/NativeCurlClient.php
+++ b/src/Redmine/Client/NativeCurlClient.php
@@ -245,7 +245,9 @@ final class NativeCurlClient implements Client
     /**
      * Prepare the request by setting the cURL options.
      *
-     * @return resource|\CurlHandle a cURL handle on success, <b>FALSE</b> on errors
+     * BC for PHP 7.4: Do not add the return type because CurlHandle was introduced in PHP 8.0
+     *
+     * @return \CurlHandle a cURL handle on success, <b>FALSE</b> on errors
      */
     private function createCurl(string $method, string $path, string $body = '')
     {

--- a/src/Redmine/Client/NativeCurlClient.php
+++ b/src/Redmine/Client/NativeCurlClient.php
@@ -281,13 +281,13 @@ final class NativeCurlClient implements Client
                     $curlOptions[CURLOPT_POSTFIELDS] = $filedata;
                     $curlOptions[CURLOPT_INFILE] = $file;
                     $curlOptions[CURLOPT_INFILESIZE] = $size;
-                } elseif (isset($body)) {
+                } elseif ($body !== '') {
                     $curlOptions[CURLOPT_POSTFIELDS] = $body;
                 }
                 break;
             case 'put':
                 $curlOptions[CURLOPT_CUSTOMREQUEST] = 'PUT';
-                if (isset($body)) {
+                if ($body !== '') {
                     $curlOptions[CURLOPT_POSTFIELDS] = $body;
                 }
                 break;

--- a/src/Redmine/Client/NativeCurlClient.php
+++ b/src/Redmine/Client/NativeCurlClient.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Redmine\Client;
 
-use Redmine\Api;
 use Redmine\Exception\ClientException;
 
 /**
@@ -246,7 +245,7 @@ final class NativeCurlClient implements Client
     /**
      * Prepare the request by setting the cURL options.
      *
-     * @return resource a cURL handle on success, <b>FALSE</b> on errors
+     * @return resource|\CurlHandle a cURL handle on success, <b>FALSE</b> on errors
      */
     private function createCurl(string $method, string $path, string $body = '')
     {

--- a/tests/Fixtures/MockClient.php
+++ b/tests/Fixtures/MockClient.php
@@ -12,9 +12,14 @@ use Redmine\Client\ClientApiTrait;
  * The runRequest method of this client class just returns the value of
  * the path, method and data or the $runRequestReturnValue value if set.
  */
-class MockClient implements Client
+final class MockClient implements Client
 {
     use ClientApiTrait;
+
+    public static function create()
+    {
+        return new self();
+    }
 
     /**
      * Return value the mocked runRequest method should return.
@@ -34,22 +39,7 @@ class MockClient implements Client
     public $responseCodeMock;
     public $responseContentTypeMock;
 
-    private string $url;
-    private string $apikeyOrUsername;
-    private ?string $password;
-
-    /**
-     * $apikeyOrUsername should be your ApiKey, but it could also be your username.
-     * $password needs to be set if a username is given (not recommended).
-     */
-    public function __construct(
-        string $url,
-        string $apikeyOrUsername,
-        string $password = null
-    ) {
-        $this->url = $url;
-        $this->apikeyOrUsername = $apikeyOrUsername;
-        $this->password = $password;
+    private function __csontruct() {
     }
 
     /**

--- a/tests/Fixtures/MockClient.php
+++ b/tests/Fixtures/MockClient.php
@@ -39,7 +39,7 @@ final class MockClient implements Client
     public $responseCodeMock;
     public $responseContentTypeMock;
 
-    private function __csontruct() {
+    private function __construct() {
     }
 
     /**

--- a/tests/Integration/GroupXmlTest.php
+++ b/tests/Integration/GroupXmlTest.php
@@ -23,6 +23,7 @@ class GroupXmlTest extends TestCase
 
     public function testCreateBlank()
     {
+        /** @var \Redmine\Api\Group */
         $api = $this->client->getApi('group');
         $this->assertInstanceOf('Redmine\Api\Group', $api);
 
@@ -34,7 +35,9 @@ class GroupXmlTest extends TestCase
 
     public function testCreateComplex()
     {
-        $res = $this->client->getApi('group')->create([
+        /** @var \Redmine\Api\Group */
+        $api = $this->client->getApi('group');
+        $res = $api->create([
             'name' => 'Developers',
             'user_ids' => [3, 5],
         ]);
@@ -54,6 +57,7 @@ class GroupXmlTest extends TestCase
 
     public function testUpdateNotImplemented()
     {
+        /** @var \Redmine\Api\Group */
         $api = $this->client->getApi('group');
         $this->assertInstanceOf('Redmine\Api\Group', $api);
 

--- a/tests/Integration/GroupXmlTest.php
+++ b/tests/Integration/GroupXmlTest.php
@@ -11,20 +11,10 @@ use SimpleXMLElement;
 
 class GroupXmlTest extends TestCase
 {
-    /**
-     * @var MockClient
-     */
-    private $client;
-
-    public function setup(): void
-    {
-        $this->client = new MockClient('http://test.local', 'asdf');
-    }
-
     public function testCreateBlank()
     {
         /** @var \Redmine\Api\Group */
-        $api = $this->client->getApi('group');
+        $api = MockClient::create()->getApi('group');
         $this->assertInstanceOf('Redmine\Api\Group', $api);
 
         $this->expectException(MissingParameterException::class);
@@ -36,7 +26,7 @@ class GroupXmlTest extends TestCase
     public function testCreateComplex()
     {
         /** @var \Redmine\Api\Group */
-        $api = $this->client->getApi('group');
+        $api = MockClient::create()->getApi('group');
         $res = $api->create([
             'name' => 'Developers',
             'user_ids' => [3, 5],
@@ -58,7 +48,7 @@ class GroupXmlTest extends TestCase
     public function testUpdateNotImplemented()
     {
         /** @var \Redmine\Api\Group */
-        $api = $this->client->getApi('group');
+        $api = MockClient::create()->getApi('group');
         $this->assertInstanceOf('Redmine\Api\Group', $api);
 
         $this->expectException(Exception::class);

--- a/tests/Integration/IssueCategoryXmlTest.php
+++ b/tests/Integration/IssueCategoryXmlTest.php
@@ -22,6 +22,7 @@ class IssueCategoryXmlTest extends TestCase
 
     public function testCreateBlank()
     {
+        /** @var \Redmine\Api\IssueCategory */
         $api = $this->client->getApi('issue_category');
         $this->assertInstanceOf('Redmine\Api\IssueCategory', $api);
 
@@ -33,6 +34,7 @@ class IssueCategoryXmlTest extends TestCase
 
     public function testCreateComplex()
     {
+        /** @var \Redmine\Api\IssueCategory */
         $api = $this->client->getApi('issue_category');
         $res = $api->create('otherProject', [
             'name' => 'test category',
@@ -48,6 +50,7 @@ class IssueCategoryXmlTest extends TestCase
 
     public function testUpdate()
     {
+        /** @var \Redmine\Api\IssueCategory */
         $api = $this->client->getApi('issue_category');
         $res = $api->update(1, [
             'name' => 'new category name',

--- a/tests/Integration/IssueCategoryXmlTest.php
+++ b/tests/Integration/IssueCategoryXmlTest.php
@@ -10,20 +10,10 @@ use SimpleXMLElement;
 
 class IssueCategoryXmlTest extends TestCase
 {
-    /**
-     * @var MockClient
-     */
-    private $client;
-
-    public function setup(): void
-    {
-        $this->client = new MockClient('http://test.local', 'asdf');
-    }
-
     public function testCreateBlank()
     {
         /** @var \Redmine\Api\IssueCategory */
-        $api = $this->client->getApi('issue_category');
+        $api = MockClient::create()->getApi('issue_category');
         $this->assertInstanceOf('Redmine\Api\IssueCategory', $api);
 
         $this->expectException(MissingParameterException::class);
@@ -35,7 +25,7 @@ class IssueCategoryXmlTest extends TestCase
     public function testCreateComplex()
     {
         /** @var \Redmine\Api\IssueCategory */
-        $api = $this->client->getApi('issue_category');
+        $api = MockClient::create()->getApi('issue_category');
         $res = $api->create('otherProject', [
             'name' => 'test category',
         ]);
@@ -51,7 +41,7 @@ class IssueCategoryXmlTest extends TestCase
     public function testUpdate()
     {
         /** @var \Redmine\Api\IssueCategory */
-        $api = $this->client->getApi('issue_category');
+        $api = MockClient::create()->getApi('issue_category');
         $res = $api->update(1, [
             'name' => 'new category name',
         ]);

--- a/tests/Integration/IssueXmlTest.php
+++ b/tests/Integration/IssueXmlTest.php
@@ -9,20 +9,10 @@ use SimpleXMLElement;
 
 class IssueXmlTest extends TestCase
 {
-    /**
-     * @var MockClient
-     */
-    private $client;
-
-    public function setup(): void
-    {
-        $this->client = new MockClient('http://test.local', 'asdf');
-    }
-
     public function testCreateBlank()
     {
         /** @var \Redmine\Api\Issue */
-        $api = $this->client->getApi('issue');
+        $api = MockClient::create()->getApi('issue');
         $this->assertInstanceOf('Redmine\Api\Issue', $api);
 
         $xml = '<?xml version="1.0"?>
@@ -36,7 +26,7 @@ class IssueXmlTest extends TestCase
     public function testCreateComplexWithUpload()
     {
         /** @var \Redmine\Api\Issue */
-        $api = $this->client->getApi('issue');
+        $api = MockClient::create()->getApi('issue');
         $res = $api->create([
             'project_id' => 'myproject',
             'subject' => 'A test issue',
@@ -72,7 +62,7 @@ class IssueXmlTest extends TestCase
     public function testCreateComplex()
     {
         /** @var \Redmine\Api\Issue */
-        $api = $this->client->getApi('issue');
+        $api = MockClient::create()->getApi('issue');
         $res = $api->create([
             'project_id' => 'test',
             'subject' => 'test api (xml) 3',
@@ -117,7 +107,7 @@ class IssueXmlTest extends TestCase
     public function testCreateComplexWithLineBreakInDescription()
     {
         /** @var \Redmine\Api\Issue */
-        $api = $this->client->getApi('issue');
+        $api = MockClient::create()->getApi('issue');
         $res = $api->create([
             'project_id' => 'test',
             'subject' => 'test api (xml) 3',
@@ -163,7 +153,7 @@ line2</description>
     public function testUpdateIssue()
     {
         /** @var \Redmine\Api\Issue */
-        $api = $this->client->getApi('issue');
+        $api = MockClient::create()->getApi('issue');
         $res = $api->update(1, [
             'subject' => 'test note (xml) 1',
             'notes' => 'test note api',
@@ -193,7 +183,7 @@ line2</description>
     public function testAddNoteToIssue()
     {
         /** @var \Redmine\Api\Issue */
-        $api = $this->client->getApi('issue');
+        $api = MockClient::create()->getApi('issue');
         $res = $api->addNoteToIssue(1, 'some comment');
         $res = json_decode($res, true);
 

--- a/tests/Integration/IssueXmlTest.php
+++ b/tests/Integration/IssueXmlTest.php
@@ -21,6 +21,7 @@ class IssueXmlTest extends TestCase
 
     public function testCreateBlank()
     {
+        /** @var \Redmine\Api\Issue */
         $api = $this->client->getApi('issue');
         $this->assertInstanceOf('Redmine\Api\Issue', $api);
 
@@ -34,6 +35,7 @@ class IssueXmlTest extends TestCase
 
     public function testCreateComplexWithUpload()
     {
+        /** @var \Redmine\Api\Issue */
         $api = $this->client->getApi('issue');
         $res = $api->create([
             'project_id' => 'myproject',
@@ -69,6 +71,7 @@ class IssueXmlTest extends TestCase
 
     public function testCreateComplex()
     {
+        /** @var \Redmine\Api\Issue */
         $api = $this->client->getApi('issue');
         $res = $api->create([
             'project_id' => 'test',
@@ -113,6 +116,7 @@ class IssueXmlTest extends TestCase
 
     public function testCreateComplexWithLineBreakInDescription()
     {
+        /** @var \Redmine\Api\Issue */
         $api = $this->client->getApi('issue');
         $res = $api->create([
             'project_id' => 'test',
@@ -158,6 +162,7 @@ line2</description>
 
     public function testUpdateIssue()
     {
+        /** @var \Redmine\Api\Issue */
         $api = $this->client->getApi('issue');
         $res = $api->update(1, [
             'subject' => 'test note (xml) 1',
@@ -187,6 +192,7 @@ line2</description>
 
     public function testAddNoteToIssue()
     {
+        /** @var \Redmine\Api\Issue */
         $api = $this->client->getApi('issue');
         $res = $api->addNoteToIssue(1, 'some comment');
         $res = json_decode($res, true);

--- a/tests/Integration/MembershipXmlTest.php
+++ b/tests/Integration/MembershipXmlTest.php
@@ -10,20 +10,10 @@ use SimpleXMLElement;
 
 class MembershipXmlTest extends TestCase
 {
-    /**
-     * @var MockClient
-     */
-    private $client;
-
-    public function setup(): void
-    {
-        $this->client = new MockClient('http://test.local', 'asdf');
-    }
-
     public function testCreateBlank()
     {
         /** @var \Redmine\Api\Membership */
-        $api = $this->client->getApi('membership');
+        $api = MockClient::create()->getApi('membership');
         $this->assertInstanceOf('Redmine\Api\Membership', $api);
 
         $this->expectException(MissingParameterException::class);
@@ -35,7 +25,7 @@ class MembershipXmlTest extends TestCase
     public function testCreateComplex()
     {
         /** @var \Redmine\Api\Membership */
-        $api = $this->client->getApi('membership');
+        $api = MockClient::create()->getApi('membership');
         $res = $api->create('otherProject', [
             'user_id' => 1,
             'role_ids' => [1, 2],
@@ -56,7 +46,7 @@ class MembershipXmlTest extends TestCase
     public function testUpdate()
     {
         /** @var \Redmine\Api\Membership */
-        $api = $this->client->getApi('membership');
+        $api = MockClient::create()->getApi('membership');
         $res = $api->update(1, [
             'role_ids' => [1, 2],
         ]);

--- a/tests/Integration/MembershipXmlTest.php
+++ b/tests/Integration/MembershipXmlTest.php
@@ -22,6 +22,7 @@ class MembershipXmlTest extends TestCase
 
     public function testCreateBlank()
     {
+        /** @var \Redmine\Api\Membership */
         $api = $this->client->getApi('membership');
         $this->assertInstanceOf('Redmine\Api\Membership', $api);
 
@@ -33,6 +34,7 @@ class MembershipXmlTest extends TestCase
 
     public function testCreateComplex()
     {
+        /** @var \Redmine\Api\Membership */
         $api = $this->client->getApi('membership');
         $res = $api->create('otherProject', [
             'user_id' => 1,
@@ -53,6 +55,7 @@ class MembershipXmlTest extends TestCase
 
     public function testUpdate()
     {
+        /** @var \Redmine\Api\Membership */
         $api = $this->client->getApi('membership');
         $res = $api->update(1, [
             'role_ids' => [1, 2],

--- a/tests/Integration/ProjectXmlTest.php
+++ b/tests/Integration/ProjectXmlTest.php
@@ -22,6 +22,7 @@ class ProjectXmlTest extends TestCase
 
     public function testCreateBlank()
     {
+        /** @var \Redmine\Api\Project */
         $api = $this->client->getApi('project');
         $this->assertInstanceOf('Redmine\Api\Project', $api);
 
@@ -33,6 +34,7 @@ class ProjectXmlTest extends TestCase
 
     public function testCreateComplex()
     {
+        /** @var \Redmine\Api\Project */
         $api = $this->client->getApi('project');
         $res = $api->create([
             'name' => 'some name',
@@ -67,6 +69,7 @@ class ProjectXmlTest extends TestCase
 
     public function testCreateComplexWithTrackerIds()
     {
+        /** @var \Redmine\Api\Project */
         $api = $this->client->getApi('project');
         $res = $api->create([
             'name' => 'some name',
@@ -92,6 +95,7 @@ class ProjectXmlTest extends TestCase
 
     public function testUpdate()
     {
+        /** @var \Redmine\Api\Project */
         $api = $this->client->getApi('project');
         $res = $api->update(1, [
             'name' => 'different name',

--- a/tests/Integration/ProjectXmlTest.php
+++ b/tests/Integration/ProjectXmlTest.php
@@ -10,20 +10,10 @@ use SimpleXMLElement;
 
 class ProjectXmlTest extends TestCase
 {
-    /**
-     * @var MockClient
-     */
-    private $client;
-
-    public function setup(): void
-    {
-        $this->client = new MockClient('http://test.local', 'asdf');
-    }
-
     public function testCreateBlank()
     {
         /** @var \Redmine\Api\Project */
-        $api = $this->client->getApi('project');
+        $api = MockClient::create()->getApi('project');
         $this->assertInstanceOf('Redmine\Api\Project', $api);
 
         $this->expectException(MissingParameterException::class);
@@ -35,7 +25,7 @@ class ProjectXmlTest extends TestCase
     public function testCreateComplex()
     {
         /** @var \Redmine\Api\Project */
-        $api = $this->client->getApi('project');
+        $api = MockClient::create()->getApi('project');
         $res = $api->create([
             'name' => 'some name',
             'identifier' => 'the_identifier',
@@ -70,7 +60,7 @@ class ProjectXmlTest extends TestCase
     public function testCreateComplexWithTrackerIds()
     {
         /** @var \Redmine\Api\Project */
-        $api = $this->client->getApi('project');
+        $api = MockClient::create()->getApi('project');
         $res = $api->create([
             'name' => 'some name',
             'identifier' => 'the_identifier',
@@ -96,7 +86,7 @@ class ProjectXmlTest extends TestCase
     public function testUpdate()
     {
         /** @var \Redmine\Api\Project */
-        $api = $this->client->getApi('project');
+        $api = MockClient::create()->getApi('project');
         $res = $api->update(1, [
             'name' => 'different name',
         ]);

--- a/tests/Integration/UrlTest.php
+++ b/tests/Integration/UrlTest.php
@@ -19,6 +19,7 @@ class UrlTest extends TestCase
 
     public function testAttachment()
     {
+        /** @var \Redmine\Api\Attachment */
         $api = $this->client->getApi('attachment');
         $res = $api->show(1);
 
@@ -34,6 +35,7 @@ class UrlTest extends TestCase
 
     public function testCustomFields()
     {
+        /** @var \Redmine\Api\CustomField */
         $api = $this->client->getApi('custom_fields');
         $res = $api->all();
 
@@ -43,6 +45,7 @@ class UrlTest extends TestCase
 
     public function testGroup()
     {
+        /** @var \Redmine\Api\Group */
         $api = $this->client->getApi('group');
         $res = $api->create([
             'name' => 'asdf',
@@ -83,6 +86,7 @@ class UrlTest extends TestCase
 
     public function testIssue()
     {
+        /** @var \Redmine\Api\Issue */
         $api = $this->client->getApi('issue');
         $res = $api->create([
             'name' => 'asdf',
@@ -139,6 +143,7 @@ class UrlTest extends TestCase
 
     public function testIssueCategory()
     {
+        /** @var \Redmine\Api\IssueCategory */
         $api = $this->client->getApi('issue_category');
         $res = $api->create('testProject', [
             'name' => 'asdf',
@@ -181,6 +186,7 @@ class UrlTest extends TestCase
 
     public function testIssuePriority()
     {
+        /** @var \Redmine\Api\IssuePriority */
         $api = $this->client->getApi('issue_priority');
         $res = $api->all();
 
@@ -190,6 +196,7 @@ class UrlTest extends TestCase
 
     public function testIssueRelation()
     {
+        /** @var \Redmine\Api\IssueRelation */
         $api = $this->client->getApi('issue_relation');
         $res = $api->all(1);
 
@@ -208,6 +215,7 @@ class UrlTest extends TestCase
 
     public function testIssueStatus()
     {
+        /** @var \Redmine\Api\IssueStatus */
         $api = $this->client->getApi('issue_status');
         $res = $api->all();
 
@@ -217,6 +225,7 @@ class UrlTest extends TestCase
 
     public function testMembership()
     {
+        /** @var \Redmine\Api\Membership */
         $api = $this->client->getApi('membership');
         $res = $api->create('testProject', [
             'user_id' => 1,
@@ -250,6 +259,7 @@ class UrlTest extends TestCase
 
     public function testNews()
     {
+        /** @var \Redmine\Api\News */
         $api = $this->client->getApi('news');
         $res = $api->all();
 
@@ -264,6 +274,7 @@ class UrlTest extends TestCase
 
     public function testProject()
     {
+        /** @var \Redmine\Api\Project */
         $api = $this->client->getApi('project');
         $res = $api->create([
             'name' => 'asdf',
@@ -301,6 +312,7 @@ class UrlTest extends TestCase
 
     public function testQuery()
     {
+        /** @var \Redmine\Api\Query */
         $api = $this->client->getApi('query');
         $res = $api->all();
 
@@ -310,6 +322,7 @@ class UrlTest extends TestCase
 
     public function testRole()
     {
+        /** @var \Redmine\Api\Role */
         $api = $this->client->getApi('role');
         $res = $api->all();
 
@@ -324,6 +337,7 @@ class UrlTest extends TestCase
 
     public function testTimeEntry()
     {
+        /** @var \Redmine\Api\TimeEntry */
         $api = $this->client->getApi('time_entry');
         $res = $api->create([
             'issue_id' => 1,
@@ -373,6 +387,7 @@ class UrlTest extends TestCase
 
     public function testTimeEntryActivity()
     {
+        /** @var \Redmine\Api\TimeEntryActivity */
         $api = $this->client->getApi('time_entry_activity');
         $res = $api->all();
 
@@ -382,6 +397,7 @@ class UrlTest extends TestCase
 
     public function testTracker()
     {
+        /** @var \Redmine\Api\Tracker */
         $api = $this->client->getApi('tracker');
         $res = $api->all();
 
@@ -391,6 +407,7 @@ class UrlTest extends TestCase
 
     public function testUser()
     {
+        /** @var \Redmine\Api\User */
         $api = $this->client->getApi('user');
         $res = $api->create([
             'login' => 'asdf',
@@ -443,6 +460,7 @@ class UrlTest extends TestCase
 
     public function testVersion()
     {
+        /** @var \Redmine\Api\Version */
         $api = $this->client->getApi('version');
         $res = $api->create('testProject', [
             'name' => 'asdf',
@@ -477,6 +495,7 @@ class UrlTest extends TestCase
 
     public function testWiki()
     {
+        /** @var \Redmine\Api\Wiki */
         $api = $this->client->getApi('wiki');
         $res = $api->create('testProject', 'about', [
             'text' => 'asdf',

--- a/tests/Integration/UrlTest.php
+++ b/tests/Integration/UrlTest.php
@@ -7,20 +7,10 @@ use Redmine\Tests\Fixtures\MockClient;
 
 class UrlTest extends TestCase
 {
-    /**
-     * @var MockClient
-     */
-    private $client;
-
-    public function setup(): void
-    {
-        $this->client = new MockClient('http://test.local', 'asdf');
-    }
-
     public function testAttachment()
     {
         /** @var \Redmine\Api\Attachment */
-        $api = $this->client->getApi('attachment');
+        $api = MockClient::create()->getApi('attachment');
         $res = $api->show(1);
 
         $this->assertEquals('/attachments/1.json', $res['path']);
@@ -36,7 +26,7 @@ class UrlTest extends TestCase
     public function testCustomFields()
     {
         /** @var \Redmine\Api\CustomField */
-        $api = $this->client->getApi('custom_fields');
+        $api = MockClient::create()->getApi('custom_fields');
         $res = $api->all();
 
         $this->assertEquals('/custom_fields.json', $res['path']);
@@ -46,7 +36,7 @@ class UrlTest extends TestCase
     public function testGroup()
     {
         /** @var \Redmine\Api\Group */
-        $api = $this->client->getApi('group');
+        $api = MockClient::create()->getApi('group');
         $res = $api->create([
             'name' => 'asdf',
         ]);
@@ -87,7 +77,7 @@ class UrlTest extends TestCase
     public function testIssue()
     {
         /** @var \Redmine\Api\Issue */
-        $api = $this->client->getApi('issue');
+        $api = MockClient::create()->getApi('issue');
         $res = $api->create([
             'name' => 'asdf',
         ]);
@@ -144,7 +134,7 @@ class UrlTest extends TestCase
     public function testIssueCategory()
     {
         /** @var \Redmine\Api\IssueCategory */
-        $api = $this->client->getApi('issue_category');
+        $api = MockClient::create()->getApi('issue_category');
         $res = $api->create('testProject', [
             'name' => 'asdf',
         ]);
@@ -187,7 +177,7 @@ class UrlTest extends TestCase
     public function testIssuePriority()
     {
         /** @var \Redmine\Api\IssuePriority */
-        $api = $this->client->getApi('issue_priority');
+        $api = MockClient::create()->getApi('issue_priority');
         $res = $api->all();
 
         $this->assertEquals('/enumerations/issue_priorities.json', $res['path']);
@@ -197,7 +187,7 @@ class UrlTest extends TestCase
     public function testIssueRelation()
     {
         /** @var \Redmine\Api\IssueRelation */
-        $api = $this->client->getApi('issue_relation');
+        $api = MockClient::create()->getApi('issue_relation');
         $res = $api->all(1);
 
         $this->assertEquals('/issues/1/relations.json', $res['path']);
@@ -216,7 +206,7 @@ class UrlTest extends TestCase
     public function testIssueStatus()
     {
         /** @var \Redmine\Api\IssueStatus */
-        $api = $this->client->getApi('issue_status');
+        $api = MockClient::create()->getApi('issue_status');
         $res = $api->all();
 
         $this->assertEquals('/issue_statuses.json', $res['path']);
@@ -226,7 +216,7 @@ class UrlTest extends TestCase
     public function testMembership()
     {
         /** @var \Redmine\Api\Membership */
-        $api = $this->client->getApi('membership');
+        $api = MockClient::create()->getApi('membership');
         $res = $api->create('testProject', [
             'user_id' => 1,
             'role_ids' => [1],
@@ -260,7 +250,7 @@ class UrlTest extends TestCase
     public function testNews()
     {
         /** @var \Redmine\Api\News */
-        $api = $this->client->getApi('news');
+        $api = MockClient::create()->getApi('news');
         $res = $api->all();
 
         $this->assertEquals('/news.json', $res['path']);
@@ -275,7 +265,7 @@ class UrlTest extends TestCase
     public function testProject()
     {
         /** @var \Redmine\Api\Project */
-        $api = $this->client->getApi('project');
+        $api = MockClient::create()->getApi('project');
         $res = $api->create([
             'name' => 'asdf',
             'identifier' => 'asdf',
@@ -313,7 +303,7 @@ class UrlTest extends TestCase
     public function testQuery()
     {
         /** @var \Redmine\Api\Query */
-        $api = $this->client->getApi('query');
+        $api = MockClient::create()->getApi('query');
         $res = $api->all();
 
         $this->assertEquals('/queries.json', $res['path']);
@@ -323,7 +313,7 @@ class UrlTest extends TestCase
     public function testRole()
     {
         /** @var \Redmine\Api\Role */
-        $api = $this->client->getApi('role');
+        $api = MockClient::create()->getApi('role');
         $res = $api->all();
 
         $this->assertEquals('/roles.json', $res['path']);
@@ -338,7 +328,7 @@ class UrlTest extends TestCase
     public function testTimeEntry()
     {
         /** @var \Redmine\Api\TimeEntry */
-        $api = $this->client->getApi('time_entry');
+        $api = MockClient::create()->getApi('time_entry');
         $res = $api->create([
             'issue_id' => 1,
             'hours' => 12,
@@ -388,7 +378,7 @@ class UrlTest extends TestCase
     public function testTimeEntryActivity()
     {
         /** @var \Redmine\Api\TimeEntryActivity */
-        $api = $this->client->getApi('time_entry_activity');
+        $api = MockClient::create()->getApi('time_entry_activity');
         $res = $api->all();
 
         $this->assertEquals('/enumerations/time_entry_activities.json', $res['path']);
@@ -398,7 +388,7 @@ class UrlTest extends TestCase
     public function testTracker()
     {
         /** @var \Redmine\Api\Tracker */
-        $api = $this->client->getApi('tracker');
+        $api = MockClient::create()->getApi('tracker');
         $res = $api->all();
 
         $this->assertEquals('/trackers.json', $res['path']);
@@ -408,7 +398,7 @@ class UrlTest extends TestCase
     public function testUser()
     {
         /** @var \Redmine\Api\User */
-        $api = $this->client->getApi('user');
+        $api = MockClient::create()->getApi('user');
         $res = $api->create([
             'login' => 'asdf',
             'lastname' => 'asdf',
@@ -461,7 +451,7 @@ class UrlTest extends TestCase
     public function testVersion()
     {
         /** @var \Redmine\Api\Version */
-        $api = $this->client->getApi('version');
+        $api = MockClient::create()->getApi('version');
         $res = $api->create('testProject', [
             'name' => 'asdf',
         ]);
@@ -496,7 +486,7 @@ class UrlTest extends TestCase
     public function testWiki()
     {
         /** @var \Redmine\Api\Wiki */
-        $api = $this->client->getApi('wiki');
+        $api = MockClient::create()->getApi('wiki');
         $res = $api->create('testProject', 'about', [
             'text' => 'asdf',
             'comments' => 'asdf',

--- a/tests/Integration/UserXmlTest.php
+++ b/tests/Integration/UserXmlTest.php
@@ -22,6 +22,7 @@ class UserXmlTest extends TestCase
 
     public function testCreateBlank()
     {
+        /** @var \Redmine\Api\User */
         $api = $this->client->getApi('user');
         $this->assertInstanceOf('Redmine\Api\User', $api);
 
@@ -33,6 +34,7 @@ class UserXmlTest extends TestCase
 
     public function testCreateComplex()
     {
+        /** @var \Redmine\Api\User */
         $api = $this->client->getApi('user');
         $res = $api->create([
             'login' => 'test',
@@ -54,6 +56,7 @@ class UserXmlTest extends TestCase
 
     public function testUpdate()
     {
+        /** @var \Redmine\Api\User */
         $api = $this->client->getApi('user');
         $res = $api->update(1, [
             'firstname' => 'Raul',

--- a/tests/Integration/UserXmlTest.php
+++ b/tests/Integration/UserXmlTest.php
@@ -10,20 +10,10 @@ use SimpleXMLElement;
 
 class UserXmlTest extends TestCase
 {
-    /**
-     * @var MockClient
-     */
-    private $client;
-
-    public function setup(): void
-    {
-        $this->client = new MockClient('http://test.local', 'asdf');
-    }
-
     public function testCreateBlank()
     {
         /** @var \Redmine\Api\User */
-        $api = $this->client->getApi('user');
+        $api = MockClient::create()->getApi('user');
         $this->assertInstanceOf('Redmine\Api\User', $api);
 
         $this->expectException(MissingParameterException::class);
@@ -35,7 +25,7 @@ class UserXmlTest extends TestCase
     public function testCreateComplex()
     {
         /** @var \Redmine\Api\User */
-        $api = $this->client->getApi('user');
+        $api = MockClient::create()->getApi('user');
         $res = $api->create([
             'login' => 'test',
             'firstname' => 'test',
@@ -57,7 +47,7 @@ class UserXmlTest extends TestCase
     public function testUpdate()
     {
         /** @var \Redmine\Api\User */
-        $api = $this->client->getApi('user');
+        $api = MockClient::create()->getApi('user');
         $res = $api->update(1, [
             'firstname' => 'Raul',
         ]);

--- a/tests/Integration/WikiXmlTest.php
+++ b/tests/Integration/WikiXmlTest.php
@@ -21,6 +21,7 @@ class WikiXmlTest extends TestCase
 
     public function testCreateComplex()
     {
+        /** @var \Redmine\Api\Wiki */
         $api = $this->client->getApi('wiki');
         $res = $api->create('testProject', 'about', [
             'text' => 'asdf',
@@ -40,6 +41,7 @@ class WikiXmlTest extends TestCase
 
     public function testUpdate()
     {
+        /** @var \Redmine\Api\Wiki */
         $api = $this->client->getApi('wiki');
         $res = $api->update('testProject', 'about', [
             'text' => 'asdf',

--- a/tests/Integration/WikiXmlTest.php
+++ b/tests/Integration/WikiXmlTest.php
@@ -9,20 +9,10 @@ use SimpleXMLElement;
 
 class WikiXmlTest extends TestCase
 {
-    /**
-     * @var MockClient
-     */
-    private $client;
-
-    public function setup(): void
-    {
-        $this->client = new MockClient('http://test.local', 'asdf');
-    }
-
     public function testCreateComplex()
     {
         /** @var \Redmine\Api\Wiki */
-        $api = $this->client->getApi('wiki');
+        $api = MockClient::create()->getApi('wiki');
         $res = $api->create('testProject', 'about', [
             'text' => 'asdf',
             'comments' => 'asdf',
@@ -42,7 +32,7 @@ class WikiXmlTest extends TestCase
     public function testUpdate()
     {
         /** @var \Redmine\Api\Wiki */
-        $api = $this->client->getApi('wiki');
+        $api = MockClient::create()->getApi('wiki');
         $res = $api->update('testProject', 'about', [
             'text' => 'asdf',
             'comments' => 'asdf',

--- a/tests/Unit/Api/MembershipTest.php
+++ b/tests/Unit/Api/MembershipTest.php
@@ -132,6 +132,11 @@ class MembershipTest extends TestCase
      */
     public function testRemoveMemberCallsDelete()
     {
+        if (version_compare(PHP_VERSION, '8.1.0', '<')) {
+            $this->markTestSkipped('This test only runs with PHPUnit 10');
+
+            return;
+        }
         // Test values
         $response = 'API Response';
 

--- a/tests/Unit/Api/MembershipTest.php
+++ b/tests/Unit/Api/MembershipTest.php
@@ -132,6 +132,7 @@ class MembershipTest extends TestCase
      */
     public function testRemoveMemberCallsDelete()
     {
+        // @phpstan-ignore-next-line
         if (version_compare(PHP_VERSION, '8.1.0', '<')) {
             $this->markTestSkipped('This test only runs with PHPUnit 10');
 

--- a/tests/Unit/Api/MembershipTest.php
+++ b/tests/Unit/Api/MembershipTest.php
@@ -132,12 +132,10 @@ class MembershipTest extends TestCase
      */
     public function testRemoveMemberCallsDelete()
     {
-        // @phpstan-ignore-next-line
-        if (version_compare(PHP_VERSION, '8.1.0', '<')) {
+        if (version_compare(\PHPUnit\Runner\Version::id(), '10.0.0', '<')) {
             $this->markTestSkipped('This test only runs with PHPUnit 10');
-
-            return;
         }
+
         // Test values
         $response = 'API Response';
 

--- a/tests/Unit/Api/MembershipTest.php
+++ b/tests/Unit/Api/MembershipTest.php
@@ -125,6 +125,105 @@ class MembershipTest extends TestCase
     }
 
     /**
+     * Test removeMember().
+     *
+     * @covers ::removeMember
+     * @test
+     */
+    public function testRemoveMemberCallsDelete()
+    {
+        // Test values
+        $response = 'API Response';
+
+        // Create the used mock objects
+        $client = $this->createMock(Client::class);
+        $client->expects($this->once())
+            ->method('requestGet')
+            ->with($this->stringContains('/projects/1/memberships.json'))
+            ->willReturn(true);
+        $client->expects($this->once())
+            ->method('requestDelete')
+            ->with($this->stringContains('/memberships/5.xml'))
+            ->willReturn(true);
+        $client->expects($this->once())
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
+        $matcher = $this->exactly(2);
+        $client->expects($matcher)
+            ->method('getLastResponseBody')
+            ->willReturnCallback(function () use ($matcher, $response) {
+                if ($matcher->numberOfInvocations() === 1) {
+                    return '{"memberships":[{"id":5,"user":{"id":2}}]}';
+                }
+                if ($matcher->numberOfInvocations() === 2) {
+                    return $response;
+                }
+            });
+
+        // Create the object under test
+        $api = new Membership($client);
+
+        // Perform the tests
+        $this->assertSame($response, $api->removeMember(1, 2));
+    }
+
+    /**
+     * Test removeMember().
+     *
+     * @covers ::removeMember
+     * @test
+     */
+    public function testRemoveMemberReturnsFalseIfUserIsNotMemberOfProject()
+    {
+        // Create the used mock objects
+        $client = $this->createMock(Client::class);
+        $client->expects($this->once())
+            ->method('requestGet')
+            ->with($this->stringContains('/projects/1/memberships.json'))
+            ->willReturn(true);
+        $client->expects($this->once())
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
+        $client->expects($this->once())
+            ->method('getLastResponseBody')
+            ->willReturn('{"memberships":[{"id":5,"user":{"id":404}}]}');
+
+        // Create the object under test
+        $api = new Membership($client);
+
+        // Perform the tests
+        $this->assertFalse($api->removeMember(1, 2));
+    }
+
+    /**
+     * Test removeMember().
+     *
+     * @covers ::removeMember
+     * @test
+     */
+    public function testRemoveMemberReturnsFalseIfMemberlistIsMissing()
+    {
+        // Create the used mock objects
+        $client = $this->createMock(Client::class);
+        $client->expects($this->once())
+            ->method('requestGet')
+            ->with($this->stringContains('/projects/1/memberships.json'))
+            ->willReturn(true);
+        $client->expects($this->once())
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
+        $client->expects($this->once())
+            ->method('getLastResponseBody')
+            ->willReturn('{"error":"this response is invalid"}');
+
+        // Create the object under test
+        $api = new Membership($client);
+
+        // Perform the tests
+        $this->assertFalse($api->removeMember(1, 2));
+    }
+
+    /**
      * Test create().
      *
      * @covers ::create


### PR DESCRIPTION
This PR installs the static code analyser PHPStan and fixes all errors to level 4.

PHPStan will be run on Github Actions and can manually run by `composer run phpstan`.