### PR TITLE
Install Redmine with docker compose for local development

### DIFF
--- a/.docker/PHP83-Dockerfile
+++ b/.docker/PHP83-Dockerfile
@@ -2,8 +2,7 @@ FROM php:8.3-fpm
 
 RUN apt-get update
 RUN apt-get --yes --no-install-recommends install \
-    apt-utils
-RUN apt-get --yes --no-install-recommends install \
+    apt-utils \
     git \
     vim \
     curl \

--- a/.docker/PHP83-Dockerfile
+++ b/.docker/PHP83-Dockerfile
@@ -1,0 +1,53 @@
+FROM php:8.3-fpm
+
+RUN apt-get update
+RUN apt-get --yes --no-install-recommends install \
+    apt-utils
+RUN apt-get --yes --no-install-recommends install \
+    git \
+    vim \
+    curl \
+    build-essential \
+    locales \
+    zip unzip \
+    libfreetype6-dev \
+    libjpeg62-turbo-dev \
+    libmagickwand-dev \
+    libpng-dev \
+    libzip-dev
+RUN docker-php-ext-configure gd \
+    --with-freetype \
+    --with-jpeg
+RUN docker-php-ext-install -j$(nproc) \
+    pdo \
+    pdo_mysql \
+    mysqli \
+    zip \
+    exif \
+    intl \
+    sockets \
+    gd \
+    bcmath \
+    opcache
+
+COPY build/php/opcache.ini /usr/local/etc/php/conf.d/
+COPY build/php/custom.ini /usr/local/etc/php/conf.d/
+
+RUN pecl install xdebug-3.3.1 && docker-php-ext-enable xdebug
+
+RUN php --version
+
+# Install Composer
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+# COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
+
+RUN composer --version
+
+RUN usermod -u 1000 www-data
+RUN usermod -a -G www-data root
+RUN mkdir -p /var/www
+RUN chown -R www-data:www-data /var/www
+RUN mkdir -p /var/www/.composer
+RUN chown -R www-data:www-data /var/www/.composer
+
+WORKDIR /var/www/project/

--- a/.docker/PHP83-Dockerfile
+++ b/.docker/PHP83-Dockerfile
@@ -45,9 +45,7 @@ RUN composer --version
 
 RUN usermod -u 1000 www-data
 RUN usermod -a -G www-data root
-RUN mkdir -p /var/www
-RUN chown -R www-data:www-data /var/www
 RUN mkdir -p /var/www/.composer
-RUN chown -R www-data:www-data /var/www/.composer
+RUN chown -R www-data:www-data /var/www
 
 WORKDIR /var/www/project/

--- a/.docker/build/php/custom.ini
+++ b/.docker/build/php/custom.ini
@@ -1,0 +1,6 @@
+date.timezone = "Europe/Berlin"
+memory_limit = 4096M
+upload_max_filesize = 200M
+post_max_size = 200M
+
+xdebug.mode = "develop,coverage"

--- a/.docker/build/php/opcache.ini
+++ b/.docker/build/php/opcache.ini
@@ -1,0 +1,93 @@
+opcache.enable=1
+
+; Determines if Zend OPCache is enabled for the CLI version of PHP
+opcache.enable_cli=0
+
+; The OPcache shared memory storage size.
+opcache.memory_consumption=256
+
+; The amount of memory for interned strings in Mbytes.
+;opcache.interned_strings_buffer=4
+
+; The maximum number of keys (scripts) in the OPcache hash table.
+; Only numbers between 200 and 100000 are allowed.
+opcache.max_accelerated_files=100000
+
+; The maximum percentage of "wasted" memory until a restart is scheduled.
+;opcache.max_wasted_percentage=5
+
+; When this directive is enabled, the OPcache appends the current working
+; directory to the script key, thus eliminating possible collisions between
+; files with the same name (basename). Disabling the directive improves
+; performance, but may break existing applications.
+;opcache.use_cwd=1
+
+; When disabled, you must reset the OPcache manually or restart the
+; webserver for changes to the filesystem to take effect.
+;opcache.validate_timestamps=1
+
+; How often (in seconds) to check file timestamps for changes to the shared
+; memory storage allocation. ("1" means validate once per second, but only
+; once per request. "0" means always validate)
+;opcache.revalidate_freq=2
+
+; Enables or disables file search in include_path optimization
+;opcache.revalidate_path=0
+
+; If disabled, all PHPDoc comments are dropped from the code to reduce the
+; size of the optimized code.
+;opcache.save_comments=1
+
+; If disabled, PHPDoc comments are not loaded from SHM, so "Doc Comments"
+; may be always stored (save_comments=1), but not loaded by applications
+; that don't need them anyway.
+;opcache.load_comments=1
+
+; If enabled, a fast shutdown sequence is used for the accelerated code
+;opcache.fast_shutdown=0
+
+; Allow file existence override (file_exists, etc.) performance feature.
+;opcache.enable_file_override=0
+
+; A bitmask, where each bit enables or disables the appropriate OPcache
+; passes
+;opcache.optimization_level=0xffffffff
+
+;opcache.inherited_hack=1
+;opcache.dups_fix=0
+
+; The location of the OPcache blacklist file (wildcards allowed).
+; Each OPcache blacklist file is a text file that holds the names of files
+; that should not be accelerated. The file format is to add each filename
+; to a new line. The filename may be a full path or just a file prefix
+; (i.e., /var/www/x  blacklists all the files and directories in /var/www
+; that start with 'x'). Line starting with a ; are ignored (comments).
+;opcache.blacklist_filename=
+
+; Allows exclusion of large files from being cached. By default all files
+; are cached.
+;opcache.max_file_size=0
+
+; Check the cache checksum each N requests.
+; The default value of "0" means that the checks are disabled.
+;opcache.consistency_checks=0
+
+; How long to wait (in seconds) for a scheduled restart to begin if the cache
+; is not being accessed.
+;opcache.force_restart_timeout=180
+
+; OPcache error_log file name. Empty string assumes "stderr".
+;opcache.error_log=
+
+; All OPcache errors go to the Web server log.
+; By default, only fatal errors (level 0) or errors (level 1) are logged.
+; You can also enable warnings (level 2), info messages (level 3) or
+; debug messages (level 4).
+;opcache.log_verbosity_level=1
+
+; Preferred Shared Memory back-end. Leave empty and let the system decide.
+;opcache.preferred_memory_model=
+
+; Protect the shared memory from unexpected writing during script execution.
+; Useful for internal debugging only.
+;opcache.protect_memory=0

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,9 @@
-.editorconfig     export-ignore
-.gitattributes    export-ignore
-.gitignore        export-ignore
-.php_cs           export-ignore
-.scrutinizer.yml  export-ignore
-.travis.yml       export-ignore
+.docker              export-ignore
+.github              export-ignore
+.editorconfig        export-ignore
+.gitattributes       export-ignore
+.gitignore           export-ignore
+.php-cs-fixer.php    export-ignore
+.phpstan.neon        export-ignore
+.scrutinizer.yml     export-ignore
+.docker-compose.yml  export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
-.php-cs-fixer.cache
-.phpunit.cache
-composer.lock
-composer.phar
-phpunit.xml
-vendor
+/.docker/mariadb_data
+/.docker/redmine_data
+/.php-cs-fixer.cache
+/.phpunit.cache
+/composer.lock
+/phpunit.xml
+/vendor

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.7"
+
+services:
+    php:
+        build: # Info to build the Docker image
+            context: ./.docker # Specify where the Dockerfile is located (e.g. in the root directory of the project)
+            dockerfile: PHP83-Dockerfile # Specify the name of the Dockerfile
+        ports:
+            - 8111:80
+        # environment: # You can use this section to set environment variables. But you can also use the .env file.
+        #     - DATABASE_URL=mysql://root:root@db/youthweb_dev
+        volumes:
+            - ./:/var/www/project/ # Location of the project for php-fpm. Note this should be the same for NGINX.*
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
             - ./.docker/redmine_data:/usr/src/redmine/files
 
     mariadb:
-        image: mariadb:10.7
+        image: mariadb:10.11
         environment:
             MYSQL_ROOT_PASSWORD: "root"
             MYSQL_DATABASE: "redmine"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,35 @@ services:
             dockerfile: PHP83-Dockerfile # Specify the name of the Dockerfile
         ports:
             - 8111:80
-        # environment: # You can use this section to set environment variables. But you can also use the .env file.
-        #     - DATABASE_URL=mysql://root:root@db/youthweb_dev
+        depends_on:
+            - redmine
         volumes:
             - ./:/var/www/project/ # Location of the project for php-fpm. Note this should be the same for NGINX.*
+
+    redmine:
+        image: redmine:5.1.1
+        ports:
+            - "3000:3000"
+        environment:
+            REDMINE_DB_MYSQL: "mariadb"
+            REDMINE_DB_PORT: ""
+            REDMINE_DB_USERNAME: "redmine"
+            REDMINE_DB_PASSWORD: "redmine"
+            REDMINE_DB_DATABASE: "redmine"
+            REDMINE_SECRET_KEY_BASE: supersecretkey
+            REDMINE_PLUGINS_MIGRATE: true
+        depends_on:
+            - mariadb
+        volumes:
+            - ./.docker/redmine_data:/usr/src/redmine/files
+
+    mariadb:
+        image: mariadb:10.7
+        environment:
+            MYSQL_ROOT_PASSWORD: "root"
+            MYSQL_DATABASE: "redmine"
+            MYSQL_USER: "redmine"
+            MYSQL_PASSWORD: "redmine"
+        volumes:
+            - ./.docker/mariadb_data:/var/lib/mysql
 


### PR DESCRIPTION
This PR adds a `docker-compose.yml` and some docker configuration. This allows us to quickly setup a dev environment using PHP 8.3, Redmine 5.1.1 and MariaDB 10.11 by running `docker compose up -d`.

This command installs Redmine, runs the database migration and starts Redmine. The Redmine instance is available at http://localhost:3000 and can be used with the default credentials admin/admin. By modifying the version numbers in the `docker-compose.yml` a custom Redmine version can be installed.

This PR is the base for more integration tests and features depending on different Redmine versions.

To install all dependencies of php-redmine-api run `docker compose exec -u 1000 php composer update`.

The PHPUnit tests can be run with `docker compose exec -u 1000 php composer run test`.

The PHPStan tests can be run with `docker compose exec -u 1000 php composer run phpstan`.

The Code coverate can be run with `docker compose exec -u 1000 php composer run coverage`.