### PR TITLE
Restore BC in `all()` methods with empty Redmine response

### DIFF
--- a/src/Redmine/Api/AbstractApi.php
+++ b/src/Redmine/Api/AbstractApi.php
@@ -307,6 +307,11 @@ abstract class AbstractApi implements Api
     private function getLastResponseBodyAsArray(): array
     {
         $body = $this->client->getLastResponseBody();
+
+        if ($body === '') {
+            return [];
+        }
+
         $contentType = $this->client->getLastResponseContentType();
         $returnData = null;
 

--- a/src/Redmine/Api/AbstractApi.php
+++ b/src/Redmine/Api/AbstractApi.php
@@ -179,7 +179,7 @@ abstract class AbstractApi implements Api
         try {
             $data = $this->retrieveData(strval($endpoint), $params);
         } catch (SerializerException $e) {
-            return 'Error decoding body as JSON: '.$e->getPrevious()->getMessage();
+            return $e->getMessage();
         } catch (Exception $e) {
             $data = false;
         }

--- a/src/Redmine/Api/AbstractApi.php
+++ b/src/Redmine/Api/AbstractApi.php
@@ -4,6 +4,7 @@ namespace Redmine\Api;
 
 use Redmine\Api;
 use Redmine\Client\Client;
+use Redmine\Exception;
 use Redmine\Exception\SerializerException;
 use Redmine\Serializer\JsonSerializer;
 use Redmine\Serializer\PathSerializer;
@@ -169,7 +170,7 @@ abstract class AbstractApi implements Api
      * @param string $endpoint API end point
      * @param array  $params   optional parameters to be passed to the api (offset, limit, ...)
      *
-     * @return array|false elements found
+     * @return string|array|false elements found or error message of false
      */
     protected function retrieveAll($endpoint, array $params = [])
     {
@@ -178,6 +179,8 @@ abstract class AbstractApi implements Api
         try {
             $data = $this->retrieveData(strval($endpoint), $params);
         } catch (SerializerException $e) {
+            return 'Error decoding body as JSON: '.$e->getPrevious()->getMessage();
+        } catch (Exception $e) {
             $data = false;
         }
 
@@ -307,10 +310,6 @@ abstract class AbstractApi implements Api
     private function getLastResponseBodyAsArray(): array
     {
         $body = $this->client->getLastResponseBody();
-
-        if ($body === '') {
-            return [];
-        }
 
         $contentType = $this->client->getLastResponseContentType();
         $returnData = null;

--- a/src/Redmine/Api/AbstractApi.php
+++ b/src/Redmine/Api/AbstractApi.php
@@ -170,7 +170,7 @@ abstract class AbstractApi implements Api
      * @param string $endpoint API end point
      * @param array  $params   optional parameters to be passed to the api (offset, limit, ...)
      *
-     * @return string|array|false elements found or error message of false
+     * @return string|array|false elements found or error message or false
      */
     protected function retrieveAll($endpoint, array $params = [])
     {
@@ -178,10 +178,12 @@ abstract class AbstractApi implements Api
 
         try {
             $data = $this->retrieveData(strval($endpoint), $params);
-        } catch (SerializerException $e) {
-            return $e->getMessage();
         } catch (Exception $e) {
-            $data = false;
+            if ($this->client->getLastResponseBody() === '') {
+                return false;
+            }
+
+            return $e->getMessage();
         }
 
         return $data;

--- a/src/Redmine/Api/AbstractApi.php
+++ b/src/Redmine/Api/AbstractApi.php
@@ -170,7 +170,7 @@ abstract class AbstractApi implements Api
      * @param string $endpoint API end point
      * @param array  $params   optional parameters to be passed to the api (offset, limit, ...)
      *
-     * @return string|array|false elements found or error message or false
+     * @return array|string|false elements found or error message or false
      */
     protected function retrieveAll($endpoint, array $params = [])
     {

--- a/src/Redmine/Api/CustomField.php
+++ b/src/Redmine/Api/CustomField.php
@@ -2,6 +2,8 @@
 
 namespace Redmine\Api;
 
+use Redmine\Exception;
+
 /**
  * Listing custom fields.
  *
@@ -38,13 +40,21 @@ class CustomField extends AbstractApi
      *
      * @param array $params optional parameters to be passed to the api (offset, limit, ...)
      *
-     * @return array list of custom fields found
+     * @return array|string|false list of custom fields found or error message or false
      */
     public function all(array $params = [])
     {
         @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::list()` instead.', E_USER_DEPRECATED);
 
-        return $this->list($params);
+        try {
+            return $this->list($params);
+        } catch (Exception $e) {
+            if ($this->client->getLastResponseBody() === '') {
+                return false;
+            }
+
+            return $e->getMessage();
+        }
     }
 
     /**

--- a/src/Redmine/Api/CustomField.php
+++ b/src/Redmine/Api/CustomField.php
@@ -3,6 +3,7 @@
 namespace Redmine\Api;
 
 use Redmine\Exception;
+use Redmine\Exception\SerializerException;
 
 /**
  * Listing custom fields.
@@ -21,6 +22,8 @@ class CustomField extends AbstractApi
      * @see http://www.redmine.org/projects/redmine/wiki/Rest_CustomFields#GET
      *
      * @param array $params optional parameters to be passed to the api (offset, limit, ...)
+     *
+     * @throws SerializerException if response body could not be converted into array
      *
      * @return array list of custom fields found
      */

--- a/src/Redmine/Api/Group.php
+++ b/src/Redmine/Api/Group.php
@@ -2,7 +2,7 @@
 
 namespace Redmine\Api;
 
-use Exception;
+use Redmine\Exception;
 use Redmine\Exception\MissingParameterException;
 use Redmine\Serializer\PathSerializer;
 use Redmine\Serializer\XmlSerializer;
@@ -122,7 +122,7 @@ class Group extends AbstractApi
      */
     public function update($id, array $params = [])
     {
-        throw new Exception('Not implemented');
+        throw new \Exception('Not implemented');
     }
 
     /**

--- a/src/Redmine/Api/Group.php
+++ b/src/Redmine/Api/Group.php
@@ -43,13 +43,21 @@ class Group extends AbstractApi
      *
      * @param array $params optional parameters to be passed to the api (offset, limit, ...)
      *
-     * @return array list of groups found
+     * @return array|string|false list of groups found or error message or false
      */
     public function all(array $params = [])
     {
         @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::list()` instead.', E_USER_DEPRECATED);
 
-        return $this->list($params);
+        try {
+            return $this->list($params);
+        } catch (Exception $e) {
+            if ($this->client->getLastResponseBody() === '') {
+                return false;
+            }
+
+            return $e->getMessage();
+        }
     }
 
     /**

--- a/src/Redmine/Api/Group.php
+++ b/src/Redmine/Api/Group.php
@@ -4,6 +4,7 @@ namespace Redmine\Api;
 
 use Redmine\Exception;
 use Redmine\Exception\MissingParameterException;
+use Redmine\Exception\SerializerException;
 use Redmine\Serializer\PathSerializer;
 use Redmine\Serializer\XmlSerializer;
 
@@ -24,6 +25,8 @@ class Group extends AbstractApi
      * @see http://www.redmine.org/projects/redmine/wiki/Rest_Groups#GET
      *
      * @param array $params optional parameters to be passed to the api (offset, limit, ...)
+     *
+     * @throws SerializerException if response body could not be converted into array
      *
      * @return array list of groups found
      */

--- a/src/Redmine/Api/Issue.php
+++ b/src/Redmine/Api/Issue.php
@@ -3,6 +3,7 @@
 namespace Redmine\Api;
 
 use Redmine\Exception;
+use Redmine\Exception\SerializerException;
 use Redmine\Serializer\JsonSerializer;
 use Redmine\Serializer\PathSerializer;
 use Redmine\Serializer\XmlSerializer;
@@ -38,6 +39,8 @@ class Issue extends AbstractApi
      * - query_id : id of the previously saved query
      *
      * @param array $params the additional parameters (cf available $params above)
+     *
+     * @throws SerializerException if response body could not be converted into array
      *
      * @return array list of issues found
      */

--- a/src/Redmine/Api/Issue.php
+++ b/src/Redmine/Api/Issue.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Api;
 
+use Redmine\Exception;
 use Redmine\Serializer\JsonSerializer;
 use Redmine\Serializer\PathSerializer;
 use Redmine\Serializer\XmlSerializer;
@@ -64,13 +65,21 @@ class Issue extends AbstractApi
      *
      * @param array $params the additional parameters (cf available $params above)
      *
-     * @return array list of issues found
+     * @return array|string|false list of issues found or error message or false
      */
     public function all(array $params = [])
     {
         @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::list()` instead.', E_USER_DEPRECATED);
 
-        return $this->list($params);
+        try {
+            return $this->list($params);
+        } catch (Exception $e) {
+            if ($this->client->getLastResponseBody() === '') {
+                return false;
+            }
+
+            return $e->getMessage();
+        }
     }
 
     /**

--- a/src/Redmine/Api/IssueCategory.php
+++ b/src/Redmine/Api/IssueCategory.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Api;
 
+use Redmine\Exception;
 use Redmine\Exception\InvalidParameterException;
 use Redmine\Exception\MissingParameterException;
 use Redmine\Serializer\PathSerializer;
@@ -54,13 +55,21 @@ class IssueCategory extends AbstractApi
      * @param string|int $project project id or literal identifier
      * @param array      $params  optional parameters to be passed to the api (offset, limit, ...)
      *
-     * @return array list of issue categories found
+     * @return array|string|false list of issue categories found or error message or false
      */
     public function all($project, array $params = [])
     {
         @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::listByProject()` instead.', E_USER_DEPRECATED);
 
-        return $this->listByProject(strval($project), $params);
+        try {
+            return $this->listByProject(strval($project), $params);
+        } catch (Exception $e) {
+            if ($this->client->getLastResponseBody() === '') {
+                return false;
+            }
+
+            return $e->getMessage();
+        }
     }
 
     /**

--- a/src/Redmine/Api/IssueCategory.php
+++ b/src/Redmine/Api/IssueCategory.php
@@ -5,6 +5,7 @@ namespace Redmine\Api;
 use Redmine\Exception;
 use Redmine\Exception\InvalidParameterException;
 use Redmine\Exception\MissingParameterException;
+use Redmine\Exception\SerializerException;
 use Redmine\Serializer\PathSerializer;
 use Redmine\Serializer\XmlSerializer;
 
@@ -28,6 +29,7 @@ class IssueCategory extends AbstractApi
      * @param array      $params            optional parameters to be passed to the api (offset, limit, ...)
      *
      * @throws InvalidParameterException if $projectIdentifier is not of type int or string
+     * @throws SerializerException if response body could not be converted into array
      *
      * @return array list of issue categories found
      */

--- a/src/Redmine/Api/IssuePriority.php
+++ b/src/Redmine/Api/IssuePriority.php
@@ -3,6 +3,7 @@
 namespace Redmine\Api;
 
 use Redmine\Exception;
+use Redmine\Exception\SerializerException;
 
 /**
  * Listing issue priorities.
@@ -21,6 +22,8 @@ class IssuePriority extends AbstractApi
      * @see http://www.redmine.org/projects/redmine/wiki/Rest_Enumerations#enumerationsissue_prioritiesformat
      *
      * @param array $params optional parameters to be passed to the api (offset, limit, ...)
+     *
+     * @throws SerializerException if response body could not be converted into array
      *
      * @return array list of issue priorities found
      */

--- a/src/Redmine/Api/IssuePriority.php
+++ b/src/Redmine/Api/IssuePriority.php
@@ -40,7 +40,7 @@ class IssuePriority extends AbstractApi
      *
      * @param array $params optional parameters to be passed to the api (offset, limit, ...)
      *
-     * @return array list of issue priorities found
+     * @return array|string|false list of issue priorities found or error message or false
      */
     public function all(array $params = [])
     {

--- a/src/Redmine/Api/IssuePriority.php
+++ b/src/Redmine/Api/IssuePriority.php
@@ -2,6 +2,8 @@
 
 namespace Redmine\Api;
 
+use Redmine\Exception;
+
 /**
  * Listing issue priorities.
  *
@@ -44,6 +46,14 @@ class IssuePriority extends AbstractApi
     {
         @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::list()` instead.', E_USER_DEPRECATED);
 
-        return $this->list($params);
+        try {
+            return $this->list($params);
+        } catch (Exception $e) {
+            if ($this->client->getLastResponseBody() === '') {
+                return false;
+            }
+
+            return $e->getMessage();
+        }
     }
 }

--- a/src/Redmine/Api/IssueRelation.php
+++ b/src/Redmine/Api/IssueRelation.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Api;
 
+use Redmine\Exception;
 use Redmine\Serializer\JsonSerializer;
 
 /**
@@ -42,13 +43,21 @@ class IssueRelation extends AbstractApi
      * @param int   $issueId the issue id
      * @param array $params  optional parameters to be passed to the api (offset, limit, ...)
      *
-     * @return array list of relations found
+     * @return array|string|false list of relations found or error message or false
      */
     public function all($issueId, array $params = [])
     {
         @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::listByIssueId()` instead.', E_USER_DEPRECATED);
 
-        return $this->listByIssueId($issueId, $params);
+        try {
+            return $this->listByIssueId($issueId, $params);
+        } catch (Exception $e) {
+            if ($this->client->getLastResponseBody() === '') {
+                return false;
+            }
+
+            return $e->getMessage();
+        }
     }
 
     /**

--- a/src/Redmine/Api/IssueRelation.php
+++ b/src/Redmine/Api/IssueRelation.php
@@ -3,6 +3,7 @@
 namespace Redmine\Api;
 
 use Redmine\Exception;
+use Redmine\Exception\SerializerException;
 use Redmine\Serializer\JsonSerializer;
 
 /**
@@ -23,6 +24,8 @@ class IssueRelation extends AbstractApi
      *
      * @param int   $issueId the issue id
      * @param array $params  optional parameters to be passed to the api (offset, limit, ...)
+     *
+     * @throws SerializerException if response body could not be converted into array
      *
      * @return array list of relations found
      */

--- a/src/Redmine/Api/IssueStatus.php
+++ b/src/Redmine/Api/IssueStatus.php
@@ -3,6 +3,7 @@
 namespace Redmine\Api;
 
 use Redmine\Exception;
+use Redmine\Exception\SerializerException;
 
 /**
  * Listing issue statuses.
@@ -21,6 +22,8 @@ class IssueStatus extends AbstractApi
      * @see http://www.redmine.org/projects/redmine/wiki/Rest_IssueStatuses#GET
      *
      * @param array $params optional parameters to be passed to the api (offset, limit, ...)
+     *
+     * @throws SerializerException if response body could not be converted into array
      *
      * @return array list of issue statuses found
      */

--- a/src/Redmine/Api/IssueStatus.php
+++ b/src/Redmine/Api/IssueStatus.php
@@ -2,6 +2,8 @@
 
 namespace Redmine\Api;
 
+use Redmine\Exception;
+
 /**
  * Listing issue statuses.
  *
@@ -38,13 +40,21 @@ class IssueStatus extends AbstractApi
      *
      * @param array $params optional parameters to be passed to the api (offset, limit, ...)
      *
-     * @return array list of issue statuses found
+     * @return array|string|false list of issue statuses found or error message or false
      */
     public function all(array $params = [])
     {
         @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::list()` instead.', E_USER_DEPRECATED);
 
-        return $this->list($params);
+        try {
+            return $this->list($params);
+        } catch (Exception $e) {
+            if ($this->client->getLastResponseBody() === '') {
+                return false;
+            }
+
+            return $e->getMessage();
+        }
     }
 
     /**

--- a/src/Redmine/Api/Membership.php
+++ b/src/Redmine/Api/Membership.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Api;
 
+use Redmine\Exception;
 use Redmine\Exception\InvalidParameterException;
 use Redmine\Exception\MissingParameterException;
 use Redmine\Serializer\XmlSerializer;
@@ -53,13 +54,21 @@ class Membership extends AbstractApi
      * @param string|int $project project id or literal identifier
      * @param array      $params  optional parameters to be passed to the api (offset, limit, ...)
      *
-     * @return array list of memberships found
+     * @return array|string|false list of memberships found or error message or false
      */
     public function all($project, array $params = [])
     {
         @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::listByProject()` instead.', E_USER_DEPRECATED);
 
-        return $this->listByProject(strval($project), $params);
+        try {
+            return $this->listByProject(strval($project), $params);
+        } catch (Exception $e) {
+            if ($this->client->getLastResponseBody() === '') {
+                return false;
+            }
+
+            return $e->getMessage();
+        }
     }
 
     /**

--- a/src/Redmine/Api/Membership.php
+++ b/src/Redmine/Api/Membership.php
@@ -5,6 +5,7 @@ namespace Redmine\Api;
 use Redmine\Exception;
 use Redmine\Exception\InvalidParameterException;
 use Redmine\Exception\MissingParameterException;
+use Redmine\Exception\SerializerException;
 use Redmine\Serializer\XmlSerializer;
 
 /**
@@ -27,6 +28,7 @@ class Membership extends AbstractApi
      * @param array      $params            optional parameters to be passed to the api (offset, limit, ...)
      *
      * @throws InvalidParameterException if $projectIdentifier is not of type int or string
+     * @throws SerializerException if response body could not be converted into array
      *
      * @return array list of memberships found
      */

--- a/src/Redmine/Api/News.php
+++ b/src/Redmine/Api/News.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Api;
 
+use Redmine\Exception;
 use Redmine\Exception\InvalidParameterException;
 
 /**
@@ -63,16 +64,24 @@ class News extends AbstractApi
      * @param string|int $project project id or literal identifier [optional]
      * @param array      $params  optional parameters to be passed to the api (offset, limit, ...)
      *
-     * @return array list of news found
+     * @return array|string|false list of news found or error message or false
      */
     public function all($project = null, array $params = [])
     {
         @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::list()` or `'.__CLASS__.'::listByProject()` instead.', E_USER_DEPRECATED);
 
-        if (null === $project) {
-            return $this->list($params);
-        } else {
-            return $this->listByProject(strval($project), $params);
+        try {
+            if (null === $project) {
+                return $this->list($params);
+            } else {
+                return $this->listByProject(strval($project), $params);
+            }
+        } catch (Exception $e) {
+            if ($this->client->getLastResponseBody() === '') {
+                return false;
+            }
+
+            return $e->getMessage();
         }
     }
 }

--- a/src/Redmine/Api/News.php
+++ b/src/Redmine/Api/News.php
@@ -4,6 +4,7 @@ namespace Redmine\Api;
 
 use Redmine\Exception;
 use Redmine\Exception\InvalidParameterException;
+use Redmine\Exception\SerializerException;
 
 /**
  * @see   http://www.redmine.org/projects/redmine/wiki/Rest_News
@@ -21,6 +22,9 @@ class News extends AbstractApi
      *
      * @param string|int $projectIdentifier project id or literal identifier
      * @param array      $params            optional parameters to be passed to the api (offset, limit, ...)
+     *
+     * @throws InvalidParameterException if $projectIdentifier is not of type int or string
+     * @throws SerializerException if response body could not be converted into array
      *
      * @return array list of news found
      */
@@ -44,6 +48,8 @@ class News extends AbstractApi
      * @see http://www.redmine.org/projects/redmine/wiki/Rest_News#GET
      *
      * @param array $params optional parameters to be passed to the api (offset, limit, ...)
+     *
+     * @throws SerializerException if response body could not be converted into array
      *
      * @return array list of news found
      */

--- a/src/Redmine/Api/Project.php
+++ b/src/Redmine/Api/Project.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Api;
 
+use Redmine\Exception;
 use Redmine\Exception\MissingParameterException;
 use Redmine\Serializer\PathSerializer;
 use Redmine\Serializer\XmlSerializer;
@@ -42,13 +43,21 @@ class Project extends AbstractApi
      *
      * @param array $params optional parameters to be passed to the api (offset, limit, ...)
      *
-     * @return array list of projects found
+     * @return array|string|false list of projects found or error message or false
      */
     public function all(array $params = [])
     {
         @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::list()` instead.', E_USER_DEPRECATED);
 
-        return $this->list($params);
+        try {
+            return $this->list($params);
+        } catch (Exception $e) {
+            if ($this->client->getLastResponseBody() === '') {
+                return false;
+            }
+
+            return $e->getMessage();
+        }
     }
 
     /**

--- a/src/Redmine/Api/Project.php
+++ b/src/Redmine/Api/Project.php
@@ -4,6 +4,7 @@ namespace Redmine\Api;
 
 use Redmine\Exception;
 use Redmine\Exception\MissingParameterException;
+use Redmine\Exception\SerializerException;
 use Redmine\Serializer\PathSerializer;
 use Redmine\Serializer\XmlSerializer;
 
@@ -24,6 +25,8 @@ class Project extends AbstractApi
      * @see http://www.redmine.org/projects/redmine/wiki/Rest_Projects
      *
      * @param array $params optional parameters to be passed to the api (offset, limit, ...)
+     *
+     * @throws SerializerException if response body could not be converted into array
      *
      * @return array list of projects found
      */

--- a/src/Redmine/Api/Query.php
+++ b/src/Redmine/Api/Query.php
@@ -3,6 +3,7 @@
 namespace Redmine\Api;
 
 use Redmine\Exception;
+use Redmine\Exception\SerializerException;
 
 /**
  * Custom queries retrieval.
@@ -21,6 +22,8 @@ class Query extends AbstractApi
      * @see http://www.redmine.org/projects/redmine/wiki/Rest_Queries#GET
      *
      * @param array $params optional parameters to be passed to the api (offset, limit, ...)
+     *
+     * @throws SerializerException if response body could not be converted into array
      *
      * @return array list of queries found
      */

--- a/src/Redmine/Api/Query.php
+++ b/src/Redmine/Api/Query.php
@@ -2,6 +2,8 @@
 
 namespace Redmine\Api;
 
+use Redmine\Exception;
+
 /**
  * Custom queries retrieval.
  *
@@ -38,12 +40,20 @@ class Query extends AbstractApi
      *
      * @param array $params optional parameters to be passed to the api (offset, limit, ...)
      *
-     * @return array list of queries found
+     * @return array|string|false list of queries found or error message or false
      */
     public function all(array $params = [])
     {
         @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::list()` instead.', E_USER_DEPRECATED);
 
-        return $this->list($params);
+        try {
+            return $this->list($params);
+        } catch (Exception $e) {
+            if ($this->client->getLastResponseBody() === '') {
+                return false;
+            }
+
+            return $e->getMessage();
+        }
     }
 }

--- a/src/Redmine/Api/Role.php
+++ b/src/Redmine/Api/Role.php
@@ -2,6 +2,8 @@
 
 namespace Redmine\Api;
 
+use Redmine\Exception;
+
 /**
  * Listing roles.
  *
@@ -38,13 +40,21 @@ class Role extends AbstractApi
      *
      * @param array $params optional parameters to be passed to the api (offset, limit, ...)
      *
-     * @return array list of roles found
+     * @return array|string|false list of roles found or error message or false
      */
     public function all(array $params = [])
     {
         @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::list()` instead.', E_USER_DEPRECATED);
 
-        return $this->list($params);
+        try {
+            return $this->list($params);
+        } catch (Exception $e) {
+            if ($this->client->getLastResponseBody() === '') {
+                return false;
+            }
+
+            return $e->getMessage();
+        }
     }
 
     /**

--- a/src/Redmine/Api/Role.php
+++ b/src/Redmine/Api/Role.php
@@ -3,6 +3,7 @@
 namespace Redmine\Api;
 
 use Redmine\Exception;
+use Redmine\Exception\SerializerException;
 
 /**
  * Listing roles.
@@ -21,6 +22,8 @@ class Role extends AbstractApi
      * @see http://www.redmine.org/projects/redmine/wiki/Rest_Roles#GET
      *
      * @param array $params optional parameters to be passed to the api (offset, limit, ...)
+     *
+     * @throws SerializerException if response body could not be converted into array
      *
      * @return array list of roles found
      */

--- a/src/Redmine/Api/Search.php
+++ b/src/Redmine/Api/Search.php
@@ -39,7 +39,7 @@ class Search extends AbstractApi
      * @param string $query  string to search
      * @param array  $params optional parameters to be passed to the api (offset, limit, ...)
      *
-     * @return array list of results (projects, issues)
+     * @return array|string|false list of results (projects, issues) found or error message or false
      */
     public function search($query, array $params = [])
     {

--- a/src/Redmine/Api/Search.php
+++ b/src/Redmine/Api/Search.php
@@ -3,6 +3,7 @@
 namespace Redmine\Api;
 
 use Redmine\Exception;
+use Redmine\Exception\SerializerException;
 
 /**
  * @see   http://www.redmine.org/projects/redmine/wiki/Rest_Search
@@ -18,6 +19,8 @@ class Search extends AbstractApi
      *
      * @param string $query  string to search
      * @param array  $params optional parameters to be passed to the api (offset, limit, ...)
+     *
+     * @throws SerializerException if response body could not be converted into array
      *
      * @return array list of results (projects, issues)
      */

--- a/src/Redmine/Api/Search.php
+++ b/src/Redmine/Api/Search.php
@@ -2,6 +2,8 @@
 
 namespace Redmine\Api;
 
+use Redmine\Exception;
+
 /**
  * @see   http://www.redmine.org/projects/redmine/wiki/Rest_Search
  */
@@ -43,6 +45,14 @@ class Search extends AbstractApi
     {
         @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::listByQuery()` instead.', E_USER_DEPRECATED);
 
-        return $this->listByQuery($query, $params);
+        try {
+            return $this->listByQuery($query, $params);
+        } catch (Exception $e) {
+            if ($this->client->getLastResponseBody() === '') {
+                return false;
+            }
+
+            return $e->getMessage();
+        }
     }
 }

--- a/src/Redmine/Api/TimeEntry.php
+++ b/src/Redmine/Api/TimeEntry.php
@@ -4,6 +4,7 @@ namespace Redmine\Api;
 
 use Redmine\Exception;
 use Redmine\Exception\MissingParameterException;
+use Redmine\Exception\SerializerException;
 use Redmine\Serializer\XmlSerializer;
 
 /**
@@ -23,6 +24,8 @@ class TimeEntry extends AbstractApi
      * @see http://www.redmine.org/projects/redmine/wiki/Rest_TimeEntries
      *
      * @param array $params optional parameters to be passed to the api (offset, limit, ...)
+     *
+     * @throws SerializerException if response body could not be converted into array
      *
      * @return array list of time entries found
      */

--- a/src/Redmine/Api/TimeEntry.php
+++ b/src/Redmine/Api/TimeEntry.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Api;
 
+use Redmine\Exception;
 use Redmine\Exception\MissingParameterException;
 use Redmine\Serializer\XmlSerializer;
 
@@ -41,13 +42,21 @@ class TimeEntry extends AbstractApi
      *
      * @param array $params optional parameters to be passed to the api (offset, limit, ...)
      *
-     * @return array list of time entries found
+     * @return array|string|false list of time entries found or error message or false
      */
     public function all(array $params = [])
     {
         @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::list()` instead.', E_USER_DEPRECATED);
 
-        return $this->list($params);
+        try {
+            return $this->list($params);
+        } catch (Exception $e) {
+            if ($this->client->getLastResponseBody() === '') {
+                return false;
+            }
+
+            return $e->getMessage();
+        }
     }
 
     /**

--- a/src/Redmine/Api/TimeEntryActivity.php
+++ b/src/Redmine/Api/TimeEntryActivity.php
@@ -2,6 +2,8 @@
 
 namespace Redmine\Api;
 
+use Redmine\Exception;
+
 /**
  * Listing time entry activities.
  *
@@ -34,13 +36,21 @@ class TimeEntryActivity extends AbstractApi
      *
      * @param array $params optional parameters to be passed to the api (offset, limit, ...)
      *
-     * @return array list of time entry activities found
+     * @return array|string|false list of time entry activities found or error message or false
      */
     public function all(array $params = [])
     {
         @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::list()` instead.', E_USER_DEPRECATED);
 
-        return $this->list($params);
+        try {
+            return $this->list($params);
+        } catch (Exception $e) {
+            if ($this->client->getLastResponseBody() === '') {
+                return false;
+            }
+
+            return $e->getMessage();
+        }
     }
 
     /**

--- a/src/Redmine/Api/TimeEntryActivity.php
+++ b/src/Redmine/Api/TimeEntryActivity.php
@@ -3,6 +3,7 @@
 namespace Redmine\Api;
 
 use Redmine\Exception;
+use Redmine\Exception\SerializerException;
 
 /**
  * Listing time entry activities.
@@ -19,6 +20,8 @@ class TimeEntryActivity extends AbstractApi
      * List time entry activities.
      *
      * @param array $params optional parameters to be passed to the api (offset, limit, ...)
+     *
+     * @throws SerializerException if response body could not be converted into array
      *
      * @return array list of time entry activities found
      */

--- a/src/Redmine/Api/Tracker.php
+++ b/src/Redmine/Api/Tracker.php
@@ -3,6 +3,7 @@
 namespace Redmine\Api;
 
 use Redmine\Exception;
+use Redmine\Exception\SerializerException;
 
 /**
  * Listing trackers.
@@ -21,6 +22,8 @@ class Tracker extends AbstractApi
      * @see http://www.redmine.org/projects/redmine/wiki/Rest_Trackers#GET
      *
      * @param array $params optional parameters to be passed to the api (offset, limit, ...)
+     *
+     * @throws SerializerException if response body could not be converted into array
      *
      * @return array list of trackers found
      */

--- a/src/Redmine/Api/Tracker.php
+++ b/src/Redmine/Api/Tracker.php
@@ -2,6 +2,8 @@
 
 namespace Redmine\Api;
 
+use Redmine\Exception;
+
 /**
  * Listing trackers.
  *
@@ -38,13 +40,21 @@ class Tracker extends AbstractApi
      *
      * @param array $params optional parameters to be passed to the api (offset, limit, ...)
      *
-     * @return array list of trackers found
+     * @return array|string|false list of trackers found or error message or false
      */
     public function all(array $params = [])
     {
         @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::list()` instead.', E_USER_DEPRECATED);
 
-        return $this->list($params);
+        try {
+            return $this->list($params);
+        } catch (Exception $e) {
+            if ($this->client->getLastResponseBody() === '') {
+                return false;
+            }
+
+            return $e->getMessage();
+        }
     }
 
     /**

--- a/src/Redmine/Api/User.php
+++ b/src/Redmine/Api/User.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Api;
 
+use Redmine\Exception;
 use Redmine\Exception\MissingParameterException;
 use Redmine\Serializer\PathSerializer;
 use Redmine\Serializer\XmlSerializer;
@@ -42,13 +43,21 @@ class User extends AbstractApi
      *
      * @param array $params to allow offset/limit (and more) to be passed
      *
-     * @return array list of users found
+     * @return array|string|false list of users found or error message or false
      */
     public function all(array $params = [])
     {
         @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::list()` instead.', E_USER_DEPRECATED);
 
-        return $this->list($params);
+        try {
+            return $this->list($params);
+        } catch (Exception $e) {
+            if ($this->client->getLastResponseBody() === '') {
+                return false;
+            }
+
+            return $e->getMessage();
+        }
     }
 
     /**

--- a/src/Redmine/Api/User.php
+++ b/src/Redmine/Api/User.php
@@ -4,6 +4,7 @@ namespace Redmine\Api;
 
 use Redmine\Exception;
 use Redmine\Exception\MissingParameterException;
+use Redmine\Exception\SerializerException;
 use Redmine\Serializer\PathSerializer;
 use Redmine\Serializer\XmlSerializer;
 
@@ -24,6 +25,8 @@ class User extends AbstractApi
      * @see http://www.redmine.org/projects/redmine/wiki/Rest_Users#GET
      *
      * @param array $params to allow offset/limit (and more) to be passed
+     *
+     * @throws SerializerException if response body could not be converted into array
      *
      * @return array list of users found
      */

--- a/src/Redmine/Api/Version.php
+++ b/src/Redmine/Api/Version.php
@@ -5,6 +5,7 @@ namespace Redmine\Api;
 use Redmine\Exception;
 use Redmine\Exception\InvalidParameterException;
 use Redmine\Exception\MissingParameterException;
+use Redmine\Exception\SerializerException;
 use Redmine\Serializer\XmlSerializer;
 
 /**
@@ -25,6 +26,8 @@ class Version extends AbstractApi
      *
      * @param string|int $projectIdentifier project id or literal identifier
      * @param array      $params            optional parameters to be passed to the api (offset, limit, ...)
+     *
+     * @throws SerializerException if response body could not be converted into array
      *
      * @return array list of versions found
      */

--- a/src/Redmine/Api/Version.php
+++ b/src/Redmine/Api/Version.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Api;
 
+use Redmine\Exception;
 use Redmine\Exception\InvalidParameterException;
 use Redmine\Exception\MissingParameterException;
 use Redmine\Serializer\XmlSerializer;
@@ -51,13 +52,21 @@ class Version extends AbstractApi
      * @param string|int $project project id or literal identifier
      * @param array      $params  optional parameters to be passed to the api (offset, limit, ...)
      *
-     * @return array list of versions found
+     * @return array|string|false list of versions found or error message or false
      */
     public function all($project, array $params = [])
     {
         @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::listByProject()` instead.', E_USER_DEPRECATED);
 
-        return $this->listByProject(strval($project), $params);
+        try {
+            return $this->listByProject(strval($project), $params);
+        } catch (Exception $e) {
+            if ($this->client->getLastResponseBody() === '') {
+                return false;
+            }
+
+            return $e->getMessage();
+        }
     }
 
     /**

--- a/src/Redmine/Api/Wiki.php
+++ b/src/Redmine/Api/Wiki.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Api;
 
+use Redmine\Exception;
 use Redmine\Exception\InvalidParameterException;
 use Redmine\Serializer\PathSerializer;
 use Redmine\Serializer\XmlSerializer;
@@ -51,13 +52,21 @@ class Wiki extends AbstractApi
      * @param int|string $project project name
      * @param array      $params  optional parameters to be passed to the api (offset, limit, ...)
      *
-     * @return array list of wiki pages found for the given project
+     * @return array|string|false list of wiki pages found or error message or false
      */
     public function all($project, array $params = [])
     {
         @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::listByProject()` instead.', E_USER_DEPRECATED);
 
-        return $this->listByProject(strval($project), $params);
+        try {
+            return $this->listByProject(strval($project), $params);
+        } catch (Exception $e) {
+            if ($this->client->getLastResponseBody() === '') {
+                return false;
+            }
+
+            return $e->getMessage();
+        }
     }
 
     /**

--- a/src/Redmine/Api/Wiki.php
+++ b/src/Redmine/Api/Wiki.php
@@ -4,6 +4,7 @@ namespace Redmine\Api;
 
 use Redmine\Exception;
 use Redmine\Exception\InvalidParameterException;
+use Redmine\Exception\SerializerException;
 use Redmine\Serializer\PathSerializer;
 use Redmine\Serializer\XmlSerializer;
 
@@ -25,6 +26,8 @@ class Wiki extends AbstractApi
      *
      * @param int|string $projectIdentifier project id or slug
      * @param array      $params  optional parameters to be passed to the api (offset, limit, ...)
+     *
+     * @throws SerializerException if response body could not be converted into array
      *
      * @return array list of wiki pages found for the given project
      */

--- a/tests/Unit/Api/AbstractApiTest.php
+++ b/tests/Unit/Api/AbstractApiTest.php
@@ -301,7 +301,7 @@ class AbstractApiTest extends TestCase
         return [
             'test decode by default' => ['{"foo_bar": 12345}', 'application/json', ['foo_bar' => 12345]],
             'String' => ['"string"', 'application/json', 'Could not convert response body into array: "string"'],
-            'Empty body' => ['', 'application/json', 'Catched error "Syntax error" while decoding JSON: '],
+            'Empty body' => ['', 'application/json', false],
         ];
     }
 

--- a/tests/Unit/Api/AbstractApiTest.php
+++ b/tests/Unit/Api/AbstractApiTest.php
@@ -299,9 +299,9 @@ class AbstractApiTest extends TestCase
     public static function getRetrieveAllData(): array
     {
         return [
-            'test decode by default' => ['{"foo_bar": 12345}', 'application/json', ['foo_bar' => 12345]],
-            'String' => ['"string"', 'application/json', 'Could not convert response body into array: "string"'],
-            'Empty body' => ['', 'application/json', false],
+            'array response' => ['{"foo_bar": 12345}', 'application/json', ['foo_bar' => 12345]],
+            'string response' => ['"string"', 'application/json', 'Could not convert response body into array: "string"'],
+            'false response' => ['', 'application/json', false],
         ];
     }
 

--- a/tests/Unit/Api/AbstractApiTest.php
+++ b/tests/Unit/Api/AbstractApiTest.php
@@ -249,7 +249,7 @@ class AbstractApiTest extends TestCase
     /**
      * @covers \Redmine\Api\AbstractApi::retrieveData
      *
-     * @dataProvider retrieveDataToExceptionData
+     * @dataProvider getRetrieveDataToExceptionData
      */
     public function testRetrieveDataThrowsException($response, $contentType, $expectedException, $expectedMessage)
     {
@@ -269,7 +269,7 @@ class AbstractApiTest extends TestCase
         $method->invoke($api, '/issues.json');
     }
 
-    public static function retrieveDataToExceptionData(): array
+    public static function getRetrieveDataToExceptionData(): array
     {
         return [
             'Empty body' => ['', 'application/json', SerializerException::class, 'Syntax error" while decoding JSON: '],
@@ -279,7 +279,7 @@ class AbstractApiTest extends TestCase
     /**
      * @covers \Redmine\Api\AbstractApi::retrieveAll
      *
-     * @dataProvider retrieveAllData
+     * @dataProvider getRetrieveAllData
      */
     public function testDeprecatedRetrieveAll($content, $contentType, $expected)
     {
@@ -296,11 +296,12 @@ class AbstractApiTest extends TestCase
         $this->assertSame($expected, $method->invoke($api, ''));
     }
 
-    public static function retrieveAllData(): array
+    public static function getRetrieveAllData(): array
     {
         return [
             'test decode by default' => ['{"foo_bar": 12345}', 'application/json', ['foo_bar' => 12345]],
-            'Empty body' => ['', 'application/json', 'Error decoding body as JSON: Syntax error'],
+            'String' => ['"string"', 'application/json', 'Could not convert response body into array: "string"'],
+            'Empty body' => ['', 'application/json', 'Catched error "Syntax error" while decoding JSON: '],
         ];
     }
 

--- a/tests/Unit/Api/AbstractApiTest.php
+++ b/tests/Unit/Api/AbstractApiTest.php
@@ -249,21 +249,30 @@ class AbstractApiTest extends TestCase
 
     /**
      * @covers \Redmine\Api\AbstractApi::retrieveAll
+     *
+     * @dataProvider retrieveAllData
      */
-    public function testDeprecatedRetrieveAll()
+    public function testDeprecatedRetrieveAll($content, $contentType, $expected)
     {
         $client = $this->createMock(Client::class);
         $client->method('requestGet')->willReturn(true);
-        $client->method('getLastResponseBody')->willReturn('<?xml version="1.0"?><issue/>');
-        $client->method('getLastResponseContentType')->willReturn('application/xml');
+        $client->method('getLastResponseBody')->willReturn($content);
+        $client->method('getLastResponseContentType')->willReturn($contentType);
 
         $api = new class($client) extends AbstractApi {};
 
         $method = new ReflectionMethod($api, 'retrieveAll');
         $method->setAccessible(true);
 
-        $this->assertSame([], $method->invoke($api, '/issues.xml'));
+        $this->assertSame($expected, $method->invoke($api, ''));
+    }
 
+    public static function retrieveAllData(): array
+    {
+        return [
+            'test decode by default' => ['{"foo_bar": 12345}', 'application/json', ['foo_bar' => 12345]],
+            'Empty body' => ['', 'application/json', []],
+        ];
     }
 
     /**

--- a/tests/Unit/Api/AbstractApiTest.php
+++ b/tests/Unit/Api/AbstractApiTest.php
@@ -21,7 +21,7 @@ class AbstractApiTest extends TestCase
     {
         $client = $this->createMock(Client::class);
 
-        $api = $this->getMockForAbstractClass(AbstractApi::class, [$client]);
+        $api = new class($client) extends AbstractApi {};
 
         $method = new ReflectionMethod($api, 'isNotNull');
         $method->setAccessible(true);
@@ -61,7 +61,7 @@ class AbstractApiTest extends TestCase
         $client = $this->createMock(Client::class);
         $client->method('getLastResponseStatusCode')->willReturn($statusCode);
 
-        $api = $this->getMockForAbstractClass(AbstractApi::class, [$client]);
+        $api = new class($client) extends AbstractApi {};
 
         $this->assertSame($expectedBoolean, $api->lastCallFailed());
     }
@@ -147,7 +147,7 @@ class AbstractApiTest extends TestCase
         $client->method('getLastResponseBody')->willReturn($response);
         $client->method('getLastResponseContentType')->willReturn('application/json');
 
-        $api = $this->getMockForAbstractClass(AbstractApi::class, [$client]);
+        $api = new class($client) extends AbstractApi {};
 
         $method = new ReflectionMethod($api, 'get');
         $method->setAccessible(true);
@@ -183,7 +183,7 @@ class AbstractApiTest extends TestCase
         $client->method('getLastResponseBody')->willReturn($response);
         $client->method('getLastResponseContentType')->willReturn('application/xml');
 
-        $api = $this->getMockForAbstractClass(AbstractApi::class, [$client]);
+        $api = new class($client) extends AbstractApi {};
 
         $method = new ReflectionMethod($api, $methodName);
         $method->setAccessible(true);
@@ -230,7 +230,7 @@ class AbstractApiTest extends TestCase
         $client->method('getLastResponseBody')->willReturn($response);
         $client->method('getLastResponseContentType')->willReturn($contentType);
 
-        $api = $this->getMockForAbstractClass(AbstractApi::class, [$client]);
+        $api = new class($client) extends AbstractApi {};
 
         $method = new ReflectionMethod($api, 'retrieveData');
         $method->setAccessible(true);
@@ -257,7 +257,7 @@ class AbstractApiTest extends TestCase
         $client->method('getLastResponseBody')->willReturn('<?xml version="1.0"?><issue/>');
         $client->method('getLastResponseContentType')->willReturn('application/xml');
 
-        $api = $this->getMockForAbstractClass(AbstractApi::class, [$client]);
+        $api = new class($client) extends AbstractApi {};
 
         $method = new ReflectionMethod($api, 'retrieveAll');
         $method->setAccessible(true);
@@ -273,7 +273,7 @@ class AbstractApiTest extends TestCase
     {
         $client = $this->createMock(Client::class);
 
-        $api = $this->getMockForAbstractClass(AbstractApi::class, [$client]);
+        $api = new class($client) extends AbstractApi {};
 
         $method = new ReflectionMethod($api, 'attachCustomFieldXML');
         $method->setAccessible(true);

--- a/tests/Unit/Api/CustomFieldTest.php
+++ b/tests/Unit/Api/CustomFieldTest.php
@@ -47,34 +47,38 @@ class CustomFieldTest extends TestCase
      * @covers ::get
      * @covers ::retrieveAll
      * @covers ::isNotNull
+     * @dataProvider getAllData
      * @test
      */
-    public function testAllReturnsClientGetResponse()
+    public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
     {
-        // Test values
-        $response = '["API Response"]';
-        $expectedResponse = ['API Response'];
-
         // Create the used mock objects
         $client = $this->createMock(Client::class);
-        $client->expects($this->once())
-            ->method('requestGet')
-            ->with(
-                $this->stringStartsWith('/custom_fields.json')
-            )
-            ->willReturn(true);
         $client->expects($this->exactly(1))
+            ->method('requestGet')
+            ->with('/custom_fields.json')
+            ->willReturn(true);
+        $client->expects($this->atLeast(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
         $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
-            ->willReturn('application/json');
+            ->willReturn($responseType);
 
         // Create the object under test
         $api = new CustomField($client);
 
         // Perform the tests
         $this->assertSame($expectedResponse, $api->all());
+    }
+
+    public static function getAllData(): array
+    {
+        return [
+            'array response' => ['["API Response"]', 'application/json', ['API Response']],
+            'string response' => ['"string"', 'application/json', 'Could not convert response body into array: "string"'],
+            'false response' => ['', 'application/json', false],
+        ];
     }
 
     /**

--- a/tests/Unit/Api/GroupTest.php
+++ b/tests/Unit/Api/GroupTest.php
@@ -45,34 +45,38 @@ class GroupTest extends TestCase
      * Test all().
      *
      * @covers ::all
+     * @dataProvider getAllData
      * @test
      */
-    public function testAllReturnsClientGetResponse()
+    public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
     {
-        // Test values
-        $response = '["API Response"]';
-        $expectedReturn = ['API Response'];
-
         // Create the used mock objects
         $client = $this->createMock(Client::class);
-        $client->expects($this->once())
-            ->method('requestGet')
-            ->with(
-                $this->stringStartsWith('/groups.json')
-            )
-            ->willReturn(true);
         $client->expects($this->exactly(1))
+            ->method('requestGet')
+            ->with('/groups.json')
+            ->willReturn(true);
+        $client->expects($this->atLeast(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
         $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
-            ->willReturn('application/json');
+            ->willReturn($responseType);
 
         // Create the object under test
         $api = new Group($client);
 
         // Perform the tests
-        $this->assertSame($expectedReturn, $api->all());
+        $this->assertSame($expectedResponse, $api->all());
+    }
+
+    public static function getAllData(): array
+    {
+        return [
+            'array response' => ['["API Response"]', 'application/json', ['API Response']],
+            'string response' => ['"string"', 'application/json', 'Could not convert response body into array: "string"'],
+            'false response' => ['', 'application/json', false],
+        ];
     }
 
     /**

--- a/tests/Unit/Api/IssueCategoryTest.php
+++ b/tests/Unit/Api/IssueCategoryTest.php
@@ -45,35 +45,41 @@ class IssueCategoryTest extends TestCase
      * Test all().
      *
      * @covers ::all
+     * @dataProvider getAllDAta
      * @test
      */
-    public function testAllReturnsClientGetResponseWithProject()
+    public function testAllReturnsClientGetResponseWithProject($response, $responseType, $expectedResponse)
     {
         // Test values
         $projectId = 5;
-        $response = '["API Response"]';
-        $expectedReturn = ['API Response'];
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
-        $client->expects($this->once())
-            ->method('requestGet')
-            ->with(
-                $this->stringStartsWith('/projects/5/issue_categories.json')
-            )
-            ->willReturn(true);
         $client->expects($this->exactly(1))
+            ->method('requestGet')
+            ->with('/projects/5/issue_categories.json')
+            ->willReturn(true);
+        $client->expects($this->atLeast(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
         $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
-            ->willReturn('application/json');
+            ->willReturn($responseType);
 
         // Create the object under test
         $api = new IssueCategory($client);
 
         // Perform the tests
-        $this->assertSame($expectedReturn, $api->all($projectId));
+        $this->assertSame($expectedResponse, $api->all($projectId));
+    }
+
+    public static function getAllData(): array
+    {
+        return [
+            'array response' => ['["API Response"]', 'application/json', ['API Response']],
+            'string response' => ['"string"', 'application/json', 'Could not convert response body into array: "string"'],
+            'false response' => ['', 'application/json', false],
+        ];
     }
 
     /**

--- a/tests/Unit/Api/IssuePriorityTest.php
+++ b/tests/Unit/Api/IssuePriorityTest.php
@@ -44,34 +44,38 @@ class IssuePriorityTest extends TestCase
      * Test all().
      *
      * @covers ::all
+     * @dataProvider getAllData
      * @test
      */
-    public function testAllReturnsClientGetResponse()
+    public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
     {
-        // Test values
-        $response = '["API Response"]';
-        $expectedReturn = ['API Response'];
-
         // Create the used mock objects
         $client = $this->createMock(Client::class);
-        $client->expects($this->once())
-            ->method('requestGet')
-            ->with(
-                $this->stringStartsWith('/enumerations/issue_priorities.json')
-            )
-            ->willReturn(true);
         $client->expects($this->exactly(1))
+            ->method('requestGet')
+            ->with('/enumerations/issue_priorities.json')
+            ->willReturn(true);
+        $client->expects($this->atLeast(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
         $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
-            ->willReturn('application/json');
+            ->willReturn($responseType);
 
         // Create the object under test
         $api = new IssuePriority($client);
 
         // Perform the tests
-        $this->assertSame($expectedReturn, $api->all());
+        $this->assertSame($expectedResponse, $api->all());
+    }
+
+    public static function getAllData(): array
+    {
+        return [
+            'array response' => ['["API Response"]', 'application/json', ['API Response']],
+            'string response' => ['"string"', 'application/json', 'Could not convert response body into array: "string"'],
+            'false response' => ['', 'application/json', false],
+        ];
     }
 
     /**

--- a/tests/Unit/Api/IssueRelationTest.php
+++ b/tests/Unit/Api/IssueRelationTest.php
@@ -44,34 +44,38 @@ class IssueRelationTest extends TestCase
      * Test all().
      *
      * @covers ::all
+     * @dataProvider getAllData
      * @test
      */
-    public function testAllReturnsClientGetResponseWithProject()
+    public function testAllReturnsClientGetResponseWithProject($response, $responseType, $expectedResponse)
     {
-        // Test values
-        $response = '["API Response"]';
-        $expectedReturn = ['API Response'];
-
         // Create the used mock objects
         $client = $this->createMock(Client::class);
-        $client->expects($this->once())
-            ->method('requestGet')
-            ->with(
-                $this->stringStartsWith('/issues/5/relations.json')
-            )
-            ->willReturn(true);
         $client->expects($this->exactly(1))
+            ->method('requestGet')
+            ->with('/issues/5/relations.json')
+            ->willReturn(true);
+        $client->expects($this->atLeast(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
         $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
-            ->willReturn('application/json');
+            ->willReturn($responseType);
 
         // Create the object under test
         $api = new IssueRelation($client);
 
         // Perform the tests
-        $this->assertSame($expectedReturn, $api->all(5));
+        $this->assertSame($expectedResponse, $api->all(5));
+    }
+
+    public static function getAllData(): array
+    {
+        return [
+            'array response' => ['["API Response"]', 'application/json', ['API Response']],
+            'string response' => ['"string"', 'application/json', 'Could not convert response body into array: "string"'],
+            'false response' => ['', 'application/json', false],
+        ];
     }
 
     /**

--- a/tests/Unit/Api/IssueStatusTest.php
+++ b/tests/Unit/Api/IssueStatusTest.php
@@ -53,9 +53,7 @@ class IssueStatusTest extends TestCase
         $client = $this->createMock(Client::class);
         $client->expects($this->exactly(1))
             ->method('requestGet')
-            ->with(
-                $this->stringStartsWith('/issue_statuses.json')
-            )
+            ->with('/issue_statuses.json')
             ->willReturn(true);
         $client->expects($this->atLeast(1))
             ->method('getLastResponseBody')

--- a/tests/Unit/Api/IssueStatusTest.php
+++ b/tests/Unit/Api/IssueStatusTest.php
@@ -44,34 +44,40 @@ class IssueStatusTest extends TestCase
      * Test all().
      *
      * @covers ::all
+     * @dataProvider getAllData
      * @test
      */
-    public function testAllReturnsClientGetResponse()
+    public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
     {
-        // Test values
-        $response = '["API Response"]';
-        $expectedReturn = ['API Response'];
-
         // Create the used mock objects
         $client = $this->createMock(Client::class);
-        $client->expects($this->once())
+        $client->expects($this->exactly(1))
             ->method('requestGet')
             ->with(
                 $this->stringStartsWith('/issue_statuses.json')
             )
             ->willReturn(true);
-        $client->expects($this->exactly(1))
+        $client->expects($this->atLeast(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
         $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
-            ->willReturn('application/json');
+            ->willReturn($responseType);
 
         // Create the object under test
         $api = new IssueStatus($client);
 
         // Perform the tests
-        $this->assertSame($expectedReturn, $api->all());
+        $this->assertSame($expectedResponse, $api->all());
+    }
+
+    public static function getAllData(): array
+    {
+        return [
+            'array response' => ['["API Response"]', 'application/json', ['API Response']],
+            'string response' => ['"string"', 'application/json', 'Could not convert response body into array: "string"'],
+            'false response' => ['', 'application/json', false],
+        ];
     }
 
     /**

--- a/tests/Unit/Api/IssueTest.php
+++ b/tests/Unit/Api/IssueTest.php
@@ -67,34 +67,38 @@ class IssueTest extends TestCase
      * Test all().
      *
      * @covers ::all
+     * @dataProvider getAllData
      * @test
      */
-    public function testAllReturnsClientGetResponse()
+    public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
     {
-        // Test values
-        $response = '["API Response"]';
-        $expectedReturn = ['API Response'];
-
         // Create the used mock objects
         $client = $this->createMock(Client::class);
-        $client->expects($this->once())
-            ->method('requestGet')
-            ->with(
-                $this->stringStartsWith('/issues.json')
-            )
-            ->willReturn(true);
         $client->expects($this->exactly(1))
+            ->method('requestGet')
+            ->with('/issues.json')
+            ->willReturn(true);
+        $client->expects($this->atLeast(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
         $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
-            ->willReturn('application/json');
+            ->willReturn($responseType);
 
         // Create the object under test
         $api = new Issue($client);
 
         // Perform the tests
-        $this->assertSame($expectedReturn, $api->all());
+        $this->assertSame($expectedResponse, $api->all());
+    }
+
+    public static function getAllData(): array
+    {
+        return [
+            'array response' => ['["API Response"]', 'application/json', ['API Response']],
+            'string response' => ['"string"', 'application/json', 'Could not convert response body into array: "string"'],
+            'false response' => ['', 'application/json', false],
+        ];
     }
 
     /**

--- a/tests/Unit/Api/MembershipTest.php
+++ b/tests/Unit/Api/MembershipTest.php
@@ -46,34 +46,38 @@ class MembershipTest extends TestCase
      * Test all().
      *
      * @covers ::all
+     * @dataProvider getAllData
      * @test
      */
-    public function testAllReturnsClientGetResponseWithProject()
+    public function testAllReturnsClientGetResponseWithProject($response, $responseType, $expectedResponse)
     {
-        // Test values
-        $response = '["API Response"]';
-        $expectedReturn = ['API Response'];
-
         // Create the used mock objects
         $client = $this->createMock(Client::class);
-        $client->expects($this->once())
-            ->method('requestGet')
-            ->with(
-                $this->stringStartsWith('/projects/5/memberships.json')
-            )
-            ->willReturn(true);
         $client->expects($this->exactly(1))
+            ->method('requestGet')
+            ->with('/projects/5/memberships.json')
+            ->willReturn(true);
+        $client->expects($this->atLeast(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
         $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
-            ->willReturn('application/json');
+            ->willReturn($responseType);
 
         // Create the object under test
         $api = new Membership($client);
 
         // Perform the tests
-        $this->assertSame($expectedReturn, $api->all(5));
+        $this->assertSame($expectedResponse, $api->all(5));
+    }
+
+    public static function getAllData(): array
+    {
+        return [
+            'array response' => ['["API Response"]', 'application/json', ['API Response']],
+            'string response' => ['"string"', 'application/json', 'Could not convert response body into array: "string"'],
+            'false response' => ['', 'application/json', false],
+        ];
     }
 
     /**

--- a/tests/Unit/Api/NewsTest.php
+++ b/tests/Unit/Api/NewsTest.php
@@ -44,34 +44,38 @@ class NewsTest extends TestCase
      * Test all().
      *
      * @covers ::all
+     * @dataProvider getAllData
      * @test
      */
-    public function testAllReturnsClientGetResponse()
+    public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
     {
-        // Test values
-        $response = '["API Response"]';
-        $expectedReturn = ['API Response'];
-
         // Create the used mock objects
         $client = $this->createMock(Client::class);
-        $client->expects($this->once())
-            ->method('requestGet')
-            ->with(
-                $this->stringStartsWith('/news.json')
-            )
-            ->willReturn(true);
         $client->expects($this->exactly(1))
+            ->method('requestGet')
+            ->with('/news.json')
+            ->willReturn(true);
+        $client->expects($this->atLeast(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
         $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
-            ->willReturn('application/json');
+            ->willReturn($responseType);
 
         // Create the object under test
         $api = new News($client);
 
         // Perform the tests
-        $this->assertSame($expectedReturn, $api->all());
+        $this->assertSame($expectedResponse, $api->all());
+    }
+
+    public static function getAllData(): array
+    {
+        return [
+            'array response' => ['["API Response"]', 'application/json', ['API Response']],
+            'string response' => ['"string"', 'application/json', 'Could not convert response body into array: "string"'],
+            'false response' => ['', 'application/json', false],
+        ];
     }
 
     /**

--- a/tests/Unit/Api/ProjectTest.php
+++ b/tests/Unit/Api/ProjectTest.php
@@ -47,32 +47,38 @@ class ProjectTest extends TestCase
      * Test all().
      *
      * @covers ::all
+     * @dataProvider getAllData
      * @test
      */
-    public function testAllReturnsClientGetResponse()
+    public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
     {
-        // Test values
-        $response = '["API Response"]';
-        $expectedReturn = ['API Response'];
-
         // Create the used mock objects
         $client = $this->createMock(Client::class);
-        $client->expects($this->once())
+        $client->expects($this->exactly(1))
             ->method('requestGet')
             ->with('/projects.json')
             ->willReturn(true);
-        $client->expects($this->exactly(1))
+        $client->expects($this->atLeast(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
         $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
-            ->willReturn('application/json');
+            ->willReturn($responseType);
 
         // Create the object under test
         $api = new Project($client);
 
         // Perform the tests
-        $this->assertSame($expectedReturn, $api->all());
+        $this->assertSame($expectedResponse, $api->all());
+    }
+
+    public static function getAllData(): array
+    {
+        return [
+            'array response' => ['["API Response"]', 'application/json', ['API Response']],
+            'string response' => ['"string"', 'application/json', 'Could not convert response body into array: "string"'],
+            'false response' => ['', 'application/json', false],
+        ];
     }
 
     /**

--- a/tests/Unit/Api/QueryTest.php
+++ b/tests/Unit/Api/QueryTest.php
@@ -44,34 +44,38 @@ class QueryTest extends TestCase
      * Test all().
      *
      * @covers ::all
+     * @dataProvider getAllData
      * @test
      */
-    public function testAllReturnsClientGetResponse()
+    public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
     {
-        // Test values
-        $response = '["API Response"]';
-        $expectedReturn = ['API Response'];
-
         // Create the used mock objects
         $client = $this->createMock(Client::class);
-        $client->expects($this->once())
-            ->method('requestGet')
-            ->with(
-                $this->stringStartsWith('/queries.json')
-            )
-            ->willReturn(true);
         $client->expects($this->exactly(1))
+            ->method('requestGet')
+            ->with('/queries.json')
+            ->willReturn(true);
+        $client->expects($this->atLeast(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
         $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
-            ->willReturn('application/json');
+            ->willReturn($responseType);
 
         // Create the object under test
         $api = new Query($client);
 
         // Perform the tests
-        $this->assertSame($expectedReturn, $api->all());
+        $this->assertSame($expectedResponse, $api->all());
+    }
+
+    public static function getAllData(): array
+    {
+        return [
+            'array response' => ['["API Response"]', 'application/json', ['API Response']],
+            'string response' => ['"string"', 'application/json', 'Could not convert response body into array: "string"'],
+            'false response' => ['', 'application/json', false],
+        ];
     }
 
     /**

--- a/tests/Unit/Api/RoleTest.php
+++ b/tests/Unit/Api/RoleTest.php
@@ -44,34 +44,38 @@ class RoleTest extends TestCase
      * Test all().
      *
      * @covers ::all
+     * @dataProvider getAllData
      * @test
      */
-    public function testAllReturnsClientGetResponse()
+    public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
     {
-        // Test values
-        $response = '["API Response"]';
-        $expectedReturn = ['API Response'];
-
         // Create the used mock objects
         $client = $this->createMock(Client::class);
-        $client->expects($this->once())
-            ->method('requestGet')
-            ->with(
-                $this->stringStartsWith('/roles.json')
-            )
-            ->willReturn(true);
         $client->expects($this->exactly(1))
+            ->method('requestGet')
+            ->with('/roles.json')
+            ->willReturn(true);
+        $client->expects($this->atLeast(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
         $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
-            ->willReturn('application/json');
+            ->willReturn($responseType);
 
         // Create the object under test
         $api = new Role($client);
 
         // Perform the tests
-        $this->assertSame($expectedReturn, $api->all());
+        $this->assertSame($expectedResponse, $api->all());
+    }
+
+    public static function getAllData(): array
+    {
+        return [
+            'array response' => ['["API Response"]', 'application/json', ['API Response']],
+            'string response' => ['"string"', 'application/json', 'Could not convert response body into array: "string"'],
+            'false response' => ['', 'application/json', false],
+        ];
     }
 
     /**

--- a/tests/Unit/Api/Search/SearchTest.php
+++ b/tests/Unit/Api/Search/SearchTest.php
@@ -33,30 +33,38 @@ class SearchTest extends TestCase
         $api->search('query');
     }
 
-    public function testSearchReturnsClientGetResponse()
+    /**
+     * @dataProvider getAllData
+     */
+    public function testSearchReturnsClientGetResponse($response, $responseType, $expectedResponse)
     {
-        // Test values
-        $response = '["API Response"]';
-        $expectedReturn = ['API Response'];
-
         // Create the used mock objects
         $client = $this->createMock(Client::class);
-        $client->expects($this->once())
+        $client->expects($this->exactly(1))
             ->method('requestGet')
             ->with('/search.json?limit=25&offset=0&q=query')
             ->willReturn(true);
-        $client->expects($this->exactly(1))
+        $client->expects($this->atLeast(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
         $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
-            ->willReturn('application/json');
+            ->willReturn($responseType);
 
         // Create the object under test
         $api = new Search($client);
 
         // Perform the tests
-        $this->assertSame($expectedReturn, $api->search('query'));
+        $this->assertSame($expectedResponse, $api->search('query'));
+    }
+
+    public static function getAllData(): array
+    {
+        return [
+            'array response' => ['["API Response"]', 'application/json', ['API Response']],
+            'string response' => ['"string"', 'application/json', 'Could not convert response body into array: "string"'],
+            'false response' => ['', 'application/json', false],
+        ];
     }
 
     public function testSearchReturnsClientGetResponseWithParameters()

--- a/tests/Unit/Api/TimeEntryActivityTest.php
+++ b/tests/Unit/Api/TimeEntryActivityTest.php
@@ -44,34 +44,38 @@ class TimeEntryActivityTest extends TestCase
      * Test all().
      *
      * @covers ::all
+     * @dataProvider getAllData
      * @test
      */
-    public function testAllReturnsClientGetResponse()
+    public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
     {
-        // Test values
-        $response = '["API Response"]';
-        $expectedReturn = ['API Response'];
-
         // Create the used mock objects
         $client = $this->createMock(Client::class);
-        $client->expects($this->once())
-            ->method('requestGet')
-            ->with(
-                $this->stringStartsWith('/enumerations/time_entry_activities.json')
-            )
-            ->willReturn(true);
         $client->expects($this->exactly(1))
+            ->method('requestGet')
+            ->with('/enumerations/time_entry_activities.json')
+            ->willReturn(true);
+        $client->expects($this->atLeast(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
         $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
-            ->willReturn('application/json');
+            ->willReturn($responseType);
 
         // Create the object under test
         $api = new TimeEntryActivity($client);
 
         // Perform the tests
-        $this->assertSame($expectedReturn, $api->all());
+        $this->assertSame($expectedResponse, $api->all());
+    }
+
+    public static function getAllData(): array
+    {
+        return [
+            'array response' => ['["API Response"]', 'application/json', ['API Response']],
+            'string response' => ['"string"', 'application/json', 'Could not convert response body into array: "string"'],
+            'false response' => ['', 'application/json', false],
+        ];
     }
 
     /**

--- a/tests/Unit/Api/TimeEntryTest.php
+++ b/tests/Unit/Api/TimeEntryTest.php
@@ -70,6 +70,15 @@ class TimeEntryTest extends TestCase
         $this->assertSame($expectedResponse, $api->all());
     }
 
+    public static function getAllData(): array
+    {
+        return [
+            'array response' => ['["API Response"]', 'application/json', ['API Response']],
+            'string response' => ['"string"', 'application/json', 'Could not convert response body into array: "string"'],
+            'false response' => ['', 'application/json', false],
+        ];
+    }
+
     /**
      * Test all().
      *

--- a/tests/Unit/Api/TimeEntryTest.php
+++ b/tests/Unit/Api/TimeEntryTest.php
@@ -45,32 +45,29 @@ class TimeEntryTest extends TestCase
      * Test all().
      *
      * @covers ::all
+     * @dataProvider getAllData
      * @test
      */
-    public function testAllReturnsClientGetResponse()
+    public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
     {
-        // Test values
-        $response = '["API Response"]';
-        $expectedReturn = ['API Response'];
-
         // Create the used mock objects
         $client = $this->createMock(Client::class);
-        $client->expects($this->once())
+        $client->expects($this->exactly(1))
             ->method('requestGet')
             ->with('/time_entries.json')
             ->willReturn(true);
-        $client->expects($this->exactly(1))
+        $client->expects($this->atLeast(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
         $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
-            ->willReturn('application/json');
+            ->willReturn($responseType);
 
         // Create the object under test
         $api = new TimeEntry($client);
 
         // Perform the tests
-        $this->assertSame($expectedReturn, $api->all());
+        $this->assertSame($expectedResponse, $api->all());
     }
 
     /**

--- a/tests/Unit/Api/TrackerTest.php
+++ b/tests/Unit/Api/TrackerTest.php
@@ -44,34 +44,38 @@ class TrackerTest extends TestCase
      * Test all().
      *
      * @covers ::all
+     * @dataProvider getAllData
      * @test
      */
-    public function testAllReturnsClientGetResponse()
+    public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
     {
-        // Test values
-        $response = '["API Response"]';
-        $expectedReturn = ['API Response'];
-
         // Create the used mock objects
         $client = $this->createMock(Client::class);
-        $client->expects($this->once())
-            ->method('requestGet')
-            ->with(
-                $this->stringStartsWith('/trackers.json')
-            )
-            ->willReturn(true);
         $client->expects($this->exactly(1))
+            ->method('requestGet')
+            ->with('/trackers.json')
+            ->willReturn(true);
+        $client->expects($this->atLeast(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
         $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
-            ->willReturn('application/json');
+            ->willReturn($responseType);
 
         // Create the object under test
         $api = new Tracker($client);
 
         // Perform the tests
-        $this->assertSame($expectedReturn, $api->all());
+        $this->assertSame($expectedResponse, $api->all());
+    }
+
+    public static function getAllData(): array
+    {
+        return [
+            'array response' => ['["API Response"]', 'application/json', ['API Response']],
+            'string response' => ['"string"', 'application/json', 'Could not convert response body into array: "string"'],
+            'false response' => ['', 'application/json', false],
+        ];
     }
 
     /**

--- a/tests/Unit/Api/UserTest.php
+++ b/tests/Unit/Api/UserTest.php
@@ -119,32 +119,38 @@ class UserTest extends TestCase
      * Test all().
      *
      * @covers ::all
+     * @dataProvider getAllData
      * @test
      */
-    public function testAllReturnsClientGetResponse()
+    public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
     {
-        // Test values
-        $response = '["API Response"]';
-        $expectedReturn = ['API Response'];
-
         // Create the used mock objects
         $client = $this->createMock(Client::class);
-        $client->expects($this->once())
+        $client->expects($this->exactly(1))
             ->method('requestGet')
             ->with('/users.json')
             ->willReturn(true);
-        $client->expects($this->exactly(1))
+        $client->expects($this->atLeast(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
         $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
-            ->willReturn('application/json');
+            ->willReturn($responseType);
 
         // Create the object under test
         $api = new User($client);
 
         // Perform the tests
-        $this->assertSame($expectedReturn, $api->all());
+        $this->assertSame($expectedResponse, $api->all());
+    }
+
+    public static function getAllData(): array
+    {
+        return [
+            'array response' => ['["API Response"]', 'application/json', ['API Response']],
+            'string response' => ['"string"', 'application/json', 'Could not convert response body into array: "string"'],
+            'false response' => ['', 'application/json', false],
+        ];
     }
 
     /**

--- a/tests/Unit/Api/VersionTest.php
+++ b/tests/Unit/Api/VersionTest.php
@@ -46,32 +46,38 @@ class VersionTest extends TestCase
      * Test all().
      *
      * @covers ::all
+     * @dataProvider getAllData
      * @test
      */
-    public function testAllReturnsClientGetResponse()
+    public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
     {
-        // Test values
-        $response = '["API Response"]';
-        $expectedReturn = ['API Response'];
-
         // Create the used mock objects
         $client = $this->createMock(Client::class);
-        $client->expects($this->once())
+        $client->expects($this->exactly(1))
             ->method('requestGet')
             ->with('/projects/5/versions.json')
             ->willReturn(true);
-        $client->expects($this->once())
+        $client->expects($this->atLeast(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
         $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
-            ->willReturn('application/json');
+            ->willReturn($responseType);
 
         // Create the object under test
         $api = new Version($client);
 
         // Perform the tests
-        $this->assertSame($expectedReturn, $api->all(5));
+        $this->assertSame($expectedResponse, $api->all(5));
+    }
+
+    public static function getAllData(): array
+    {
+        return [
+            'array response' => ['["API Response"]', 'application/json', ['API Response']],
+            'string response' => ['"string"', 'application/json', 'Could not convert response body into array: "string"'],
+            'false response' => ['', 'application/json', false],
+        ];
     }
 
     /**

--- a/tests/Unit/Api/WikiTest.php
+++ b/tests/Unit/Api/WikiTest.php
@@ -44,32 +44,38 @@ class WikiTest extends TestCase
      * Test all().
      *
      * @covers ::all
+     * @dataProvider getAllData
      * @test
      */
-    public function testAllReturnsClientGetResponse()
+    public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
     {
-        // Test values
-        $response = '["API Response"]';
-        $expectedReturn = ['API Response'];
-
         // Create the used mock objects
         $client = $this->createMock(Client::class);
-        $client->expects($this->once())
+        $client->expects($this->exactly(1))
             ->method('requestGet')
             ->with('/projects/5/wiki/index.json')
             ->willReturn(true);
-        $client->expects($this->once())
+        $client->expects($this->atLeast(1))
             ->method('getLastResponseBody')
             ->willReturn($response);
         $client->expects($this->exactly(1))
             ->method('getLastResponseContentType')
-            ->willReturn('application/json');
+            ->willReturn($responseType);
 
         // Create the object under test
         $api = new Wiki($client);
 
         // Perform the tests
-        $this->assertSame($expectedReturn, $api->all(5));
+        $this->assertSame($expectedResponse, $api->all(5));
+    }
+
+    public static function getAllData(): array
+    {
+        return [
+            'array response' => ['["API Response"]', 'application/json', ['API Response']],
+            'string response' => ['"string"', 'application/json', 'Could not convert response body into array: "string"'],
+            'false response' => ['', 'application/json', false],
+        ];
     }
 
     /**


### PR DESCRIPTION
This PR handles a possible bug of Redmine. If Redmine is called with an unknown query_id parameter, Redmine responses with an 404 status code and an empty response body.

I'm not sure if in this case we should return an empty array or throw an more meaningful exception. Because this case throws a JsonException at the moment, it should not be a breaking change to throw another exception.

Any thoughts?

Refs #335.