### PR TITLE
Add new UnexpectedResponseException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New method `Redmine\Api\User::list()` to list users.
 - New method `Redmine\Api\Version::listByProject()` to list versions from a project.
 - New method `Redmine\Api\Wiki::listByProject()` to list wiki pages from a project.
+- New exception `Redmine\Exception\UnexpectedResponseException` if the Redmine server responded with an unexpected body.
 
 ### Deprecated
 

--- a/src/Redmine/Api/CustomField.php
+++ b/src/Redmine/Api/CustomField.php
@@ -33,7 +33,7 @@ class CustomField extends AbstractApi
         try {
             $this->customFields = $this->retrieveData('/custom_fields.json', $params);
         } catch (SerializerException $th) {
-            throw new UnexpectedResponseException('Redmine server has responded with an unexpected body.', $th->getCode(), $th);
+            throw new UnexpectedResponseException('The Redmine server responded with an unexpected body.', $th->getCode(), $th);
         }
 
         return $this->customFields;

--- a/src/Redmine/Api/CustomField.php
+++ b/src/Redmine/Api/CustomField.php
@@ -57,12 +57,12 @@ class CustomField extends AbstractApi
         try {
             return $this->list($params);
         } catch (Exception $e) {
-            if ($e instanceof UnexpectedResponseException && $e->getPrevious() !== null) {
-                $e = $e->getPrevious();
-            }
-
             if ($this->client->getLastResponseBody() === '') {
                 return false;
+            }
+
+            if ($e instanceof UnexpectedResponseException && $e->getPrevious() !== null) {
+                $e = $e->getPrevious();
             }
 
             return $e->getMessage();

--- a/src/Redmine/Api/CustomField.php
+++ b/src/Redmine/Api/CustomField.php
@@ -24,7 +24,7 @@ class CustomField extends AbstractApi
      *
      * @param array $params optional parameters to be passed to the api (offset, limit, ...)
      *
-     * @throws SerializerException if response body could not be converted into array
+     * @throws UnexpectedResponseException if response body could not be converted into array
      *
      * @return array list of custom fields found
      */
@@ -33,7 +33,7 @@ class CustomField extends AbstractApi
         try {
             $this->customFields = $this->retrieveData('/custom_fields.json', $params);
         } catch (SerializerException $th) {
-            throw new UnexpectedResponseException('Redmine server has delivered an unexpected response.', $th->getCode(), $th);
+            throw new UnexpectedResponseException('Redmine server has responded with an unexpected body.', $th->getCode(), $th);
         }
 
         return $this->customFields;

--- a/src/Redmine/Api/Group.php
+++ b/src/Redmine/Api/Group.php
@@ -5,6 +5,7 @@ namespace Redmine\Api;
 use Redmine\Exception;
 use Redmine\Exception\MissingParameterException;
 use Redmine\Exception\SerializerException;
+use Redmine\Exception\UnexpectedResponseException;
 use Redmine\Serializer\PathSerializer;
 use Redmine\Serializer\XmlSerializer;
 
@@ -26,13 +27,17 @@ class Group extends AbstractApi
      *
      * @param array $params optional parameters to be passed to the api (offset, limit, ...)
      *
-     * @throws SerializerException if response body could not be converted into array
+     * @throws UnexpectedResponseException if response body could not be converted into array
      *
      * @return array list of groups found
      */
     final public function list(array $params = []): array
     {
-        $this->groups = $this->retrieveData('/groups.json', $params);
+        try {
+            $this->groups = $this->retrieveData('/groups.json', $params);
+        } catch (SerializerException $th) {
+            throw new UnexpectedResponseException('The Redmine server responded with an unexpected body.', $th->getCode(), $th);
+        }
 
         return $this->groups;
     }
@@ -55,6 +60,10 @@ class Group extends AbstractApi
         try {
             return $this->list($params);
         } catch (Exception $e) {
+            if ($e instanceof UnexpectedResponseException && $e->getPrevious() !== null) {
+                $e = $e->getPrevious();
+            }
+
             if ($this->client->getLastResponseBody() === '') {
                 return false;
             }

--- a/src/Redmine/Api/Group.php
+++ b/src/Redmine/Api/Group.php
@@ -60,12 +60,12 @@ class Group extends AbstractApi
         try {
             return $this->list($params);
         } catch (Exception $e) {
-            if ($e instanceof UnexpectedResponseException && $e->getPrevious() !== null) {
-                $e = $e->getPrevious();
-            }
-
             if ($this->client->getLastResponseBody() === '') {
                 return false;
+            }
+
+            if ($e instanceof UnexpectedResponseException && $e->getPrevious() !== null) {
+                $e = $e->getPrevious();
             }
 
             return $e->getMessage();

--- a/src/Redmine/Api/Issue.php
+++ b/src/Redmine/Api/Issue.php
@@ -82,12 +82,12 @@ class Issue extends AbstractApi
         try {
             return $this->list($params);
         } catch (Exception $e) {
-            if ($e instanceof UnexpectedResponseException && $e->getPrevious() !== null) {
-                $e = $e->getPrevious();
-            }
-
             if ($this->client->getLastResponseBody() === '') {
                 return false;
+            }
+
+            if ($e instanceof UnexpectedResponseException && $e->getPrevious() !== null) {
+                $e = $e->getPrevious();
             }
 
             return $e->getMessage();

--- a/src/Redmine/Api/IssuePriority.php
+++ b/src/Redmine/Api/IssuePriority.php
@@ -4,6 +4,7 @@ namespace Redmine\Api;
 
 use Redmine\Exception;
 use Redmine\Exception\SerializerException;
+use Redmine\Exception\UnexpectedResponseException;
 
 /**
  * Listing issue priorities.
@@ -23,13 +24,17 @@ class IssuePriority extends AbstractApi
      *
      * @param array $params optional parameters to be passed to the api (offset, limit, ...)
      *
-     * @throws SerializerException if response body could not be converted into array
+     * @throws UnexpectedResponseException if response body could not be converted into array
      *
      * @return array list of issue priorities found
      */
     final public function list(array $params = []): array
     {
-        $this->issuePriorities = $this->retrieveData('/enumerations/issue_priorities.json', $params);
+        try {
+            $this->issuePriorities = $this->retrieveData('/enumerations/issue_priorities.json', $params);
+        } catch (SerializerException $th) {
+            throw new UnexpectedResponseException('The Redmine server responded with an unexpected body.', $th->getCode(), $th);
+        }
 
         return $this->issuePriorities;
     }
@@ -54,6 +59,10 @@ class IssuePriority extends AbstractApi
         } catch (Exception $e) {
             if ($this->client->getLastResponseBody() === '') {
                 return false;
+            }
+
+            if ($e instanceof UnexpectedResponseException && $e->getPrevious() !== null) {
+                $e = $e->getPrevious();
             }
 
             return $e->getMessage();

--- a/src/Redmine/Api/Project.php
+++ b/src/Redmine/Api/Project.php
@@ -5,6 +5,7 @@ namespace Redmine\Api;
 use Redmine\Exception;
 use Redmine\Exception\MissingParameterException;
 use Redmine\Exception\SerializerException;
+use Redmine\Exception\UnexpectedResponseException;
 use Redmine\Serializer\PathSerializer;
 use Redmine\Serializer\XmlSerializer;
 
@@ -26,13 +27,17 @@ class Project extends AbstractApi
      *
      * @param array $params optional parameters to be passed to the api (offset, limit, ...)
      *
-     * @throws SerializerException if response body could not be converted into array
+     * @throws UnexpectedResponseException if response body could not be converted into array
      *
      * @return array list of projects found
      */
     final public function list(array $params = []): array
     {
-        $this->projects = $this->retrieveData('/projects.json', $params);
+        try {
+            $this->projects = $this->retrieveData('/projects.json', $params);
+        } catch (SerializerException $th) {
+            throw new UnexpectedResponseException('The Redmine server responded with an unexpected body.', $th->getCode(), $th);
+        }
 
         return $this->projects;
     }
@@ -57,6 +62,10 @@ class Project extends AbstractApi
         } catch (Exception $e) {
             if ($this->client->getLastResponseBody() === '') {
                 return false;
+            }
+
+            if ($e instanceof UnexpectedResponseException && $e->getPrevious() !== null) {
+                $e = $e->getPrevious();
             }
 
             return $e->getMessage();

--- a/src/Redmine/Api/Role.php
+++ b/src/Redmine/Api/Role.php
@@ -4,6 +4,7 @@ namespace Redmine\Api;
 
 use Redmine\Exception;
 use Redmine\Exception\SerializerException;
+use Redmine\Exception\UnexpectedResponseException;
 
 /**
  * Listing roles.
@@ -23,13 +24,17 @@ class Role extends AbstractApi
      *
      * @param array $params optional parameters to be passed to the api (offset, limit, ...)
      *
-     * @throws SerializerException if response body could not be converted into array
+     * @throws UnexpectedResponseException if response body could not be converted into array
      *
      * @return array list of roles found
      */
     final public function list(array $params = []): array
     {
-        $this->roles = $this->retrieveData('/roles.json', $params);
+        try {
+            $this->roles = $this->retrieveData('/roles.json', $params);
+        } catch (SerializerException $th) {
+            throw new UnexpectedResponseException('The Redmine server responded with an unexpected body.', $th->getCode(), $th);
+        }
 
         return $this->roles;
     }
@@ -54,6 +59,10 @@ class Role extends AbstractApi
         } catch (Exception $e) {
             if ($this->client->getLastResponseBody() === '') {
                 return false;
+            }
+
+            if ($e instanceof UnexpectedResponseException && $e->getPrevious() !== null) {
+                $e = $e->getPrevious();
             }
 
             return $e->getMessage();

--- a/src/Redmine/Api/Tracker.php
+++ b/src/Redmine/Api/Tracker.php
@@ -4,6 +4,7 @@ namespace Redmine\Api;
 
 use Redmine\Exception;
 use Redmine\Exception\SerializerException;
+use Redmine\Exception\UnexpectedResponseException;
 
 /**
  * Listing trackers.
@@ -23,13 +24,17 @@ class Tracker extends AbstractApi
      *
      * @param array $params optional parameters to be passed to the api (offset, limit, ...)
      *
-     * @throws SerializerException if response body could not be converted into array
+     * @throws UnexpectedResponseException if response body could not be converted into array
      *
      * @return array list of trackers found
      */
     final public function list(array $params = []): array
     {
-        $this->trackers = $this->retrieveData('/trackers.json', $params);
+        try {
+            $this->trackers = $this->retrieveData('/trackers.json', $params);
+        } catch (SerializerException $th) {
+            throw new UnexpectedResponseException('The Redmine server responded with an unexpected body.', $th->getCode(), $th);
+        }
 
         return $this->trackers;
     }
@@ -54,6 +59,10 @@ class Tracker extends AbstractApi
         } catch (Exception $e) {
             if ($this->client->getLastResponseBody() === '') {
                 return false;
+            }
+
+            if ($e instanceof UnexpectedResponseException && $e->getPrevious() !== null) {
+                $e = $e->getPrevious();
             }
 
             return $e->getMessage();

--- a/src/Redmine/Api/User.php
+++ b/src/Redmine/Api/User.php
@@ -5,6 +5,7 @@ namespace Redmine\Api;
 use Redmine\Exception;
 use Redmine\Exception\MissingParameterException;
 use Redmine\Exception\SerializerException;
+use Redmine\Exception\UnexpectedResponseException;
 use Redmine\Serializer\PathSerializer;
 use Redmine\Serializer\XmlSerializer;
 
@@ -26,13 +27,17 @@ class User extends AbstractApi
      *
      * @param array $params to allow offset/limit (and more) to be passed
      *
-     * @throws SerializerException if response body could not be converted into array
+     * @throws UnexpectedResponseException if response body could not be converted into array
      *
      * @return array list of users found
      */
     final public function list(array $params = []): array
     {
-        $this->users = $this->retrieveData('/users.json', $params);
+        try {
+            $this->users = $this->retrieveData('/users.json', $params);
+        } catch (SerializerException $th) {
+            throw new UnexpectedResponseException('The Redmine server responded with an unexpected body.', $th->getCode(), $th);
+        }
 
         return $this->users;
     }
@@ -57,6 +62,10 @@ class User extends AbstractApi
         } catch (Exception $e) {
             if ($this->client->getLastResponseBody() === '') {
                 return false;
+            }
+
+            if ($e instanceof UnexpectedResponseException && $e->getPrevious() !== null) {
+                $e = $e->getPrevious();
             }
 
             return $e->getMessage();

--- a/src/Redmine/Exception/UnexpectedResponseException.php
+++ b/src/Redmine/Exception/UnexpectedResponseException.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Redmine\Exception;
+
+use Redmine\Exception as RedmineException;
+use RuntimeException;
+
+/**
+ * Exception if the Redmine server delivers an unexpected response.
+ *
+ * Use the following methods to investigate the response:
+ *
+ * - Redmine\Client\Client::getLastResponseStatusCode()
+ * - Redmine\Client\Client::getLastResponseContentType()
+ * - Redmine\Client\Client::getLastResponseBody()
+ */
+final class UnexpectedResponseException extends RuntimeException implements RedmineException
+{
+}

--- a/tests/Unit/Api/CustomField/ListTest.php
+++ b/tests/Unit/Api/CustomField/ListTest.php
@@ -5,6 +5,7 @@ namespace Redmine\Tests\Unit\Api\CustomField;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\CustomField;
 use Redmine\Client\Client;
+use Redmine\Exception\UnexpectedResponseException;
 
 /**
  * @covers \Redmine\Api\CustomField::list
@@ -128,5 +129,30 @@ class ListTest extends TestCase
 
         // Perform the tests
         $this->assertSame($returnDataSet, $api->list($allParameters));
+    }
+
+    public function testListThrowsException()
+    {
+        // Create the used mock objects
+        $client = $this->createMock(Client::class);
+        $client->expects($this->exactly(1))
+            ->method('requestGet')
+            ->with('/custom_fields.json')
+            ->willReturn(true);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseBody')
+            ->willReturn('');
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
+
+        // Create the object under test
+        $api = new CustomField($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+        $this->expectExceptionMessage('Redmine server has delivered an unexpected response.');
+
+        // Perform the tests
+        $api->list();
     }
 }

--- a/tests/Unit/Api/CustomField/ListTest.php
+++ b/tests/Unit/Api/CustomField/ListTest.php
@@ -150,7 +150,7 @@ class ListTest extends TestCase
         $api = new CustomField($client);
 
         $this->expectException(UnexpectedResponseException::class);
-        $this->expectExceptionMessage('Redmine server has delivered an unexpected response.');
+        $this->expectExceptionMessage('Redmine server has responded with an unexpected body.');
 
         // Perform the tests
         $api->list();

--- a/tests/Unit/Api/CustomField/ListTest.php
+++ b/tests/Unit/Api/CustomField/ListTest.php
@@ -150,7 +150,7 @@ class ListTest extends TestCase
         $api = new CustomField($client);
 
         $this->expectException(UnexpectedResponseException::class);
-        $this->expectExceptionMessage('Redmine server has responded with an unexpected body.');
+        $this->expectExceptionMessage('The Redmine server responded with an unexpected body.');
 
         // Perform the tests
         $api->list();

--- a/tests/Unit/Api/Group/ListTest.php
+++ b/tests/Unit/Api/Group/ListTest.php
@@ -5,6 +5,7 @@ namespace Redmine\Tests\Unit\Api\Group;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Group;
 use Redmine\Client\Client;
+use Redmine\Exception\UnexpectedResponseException;
 
 /**
  * @covers \Redmine\Api\Group::list
@@ -62,5 +63,30 @@ class ListTest extends TestCase
 
         // Perform the tests
         $this->assertSame($expectedReturn, $api->list($parameters));
+    }
+
+    public function testListThrowsException()
+    {
+        // Create the used mock objects
+        $client = $this->createMock(Client::class);
+        $client->expects($this->exactly(1))
+            ->method('requestGet')
+            ->with('/groups.json')
+            ->willReturn(true);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseBody')
+            ->willReturn('');
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
+
+        // Create the object under test
+        $api = new Group($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+        $this->expectExceptionMessage('The Redmine server responded with an unexpected body.');
+
+        // Perform the tests
+        $api->list();
     }
 }

--- a/tests/Unit/Api/Issue/ListTest.php
+++ b/tests/Unit/Api/Issue/ListTest.php
@@ -5,6 +5,7 @@ namespace Redmine\Tests\Unit\Api\Issue;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Issue;
 use Redmine\Client\Client;
+use Redmine\Exception\UnexpectedResponseException;
 
 /**
  * @covers \Redmine\Api\Issue::list
@@ -62,5 +63,30 @@ class ListTest extends TestCase
 
         // Perform the tests
         $this->assertSame($expectedReturn, $api->list($parameters));
+    }
+
+    public function testListThrowsException()
+    {
+        // Create the used mock objects
+        $client = $this->createMock(Client::class);
+        $client->expects($this->exactly(1))
+            ->method('requestGet')
+            ->with('/issues.json')
+            ->willReturn(true);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseBody')
+            ->willReturn('');
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
+
+        // Create the object under test
+        $api = new Issue($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+        $this->expectExceptionMessage('The Redmine server responded with an unexpected body.');
+
+        // Perform the tests
+        $api->list();
     }
 }

--- a/tests/Unit/Api/IssueCategory/ListByProjectTest.php
+++ b/tests/Unit/Api/IssueCategory/ListByProjectTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Redmine\Api\IssueCategory;
 use Redmine\Client\Client;
 use Redmine\Exception\InvalidParameterException;
+use Redmine\Exception\UnexpectedResponseException;
 use Redmine\Tests\Fixtures\MockClient;
 use stdClass;
 
@@ -92,5 +93,30 @@ class ListByProjectTest extends TestCase
             'array' => [[]],
             'object' => [new stdClass()],
         ];
+    }
+
+    public function testListByProjectThrowsException()
+    {
+        // Create the used mock objects
+        $client = $this->createMock(Client::class);
+        $client->expects($this->exactly(1))
+            ->method('requestGet')
+            ->with('/projects/5/issue_categories.json')
+            ->willReturn(true);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseBody')
+            ->willReturn('');
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
+
+        // Create the object under test
+        $api = new IssueCategory($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+        $this->expectExceptionMessage('The Redmine server responded with an unexpected body.');
+
+        // Perform the tests
+        $api->listByProject(5);
     }
 }

--- a/tests/Unit/Api/IssuePriority/ListTest.php
+++ b/tests/Unit/Api/IssuePriority/ListTest.php
@@ -5,6 +5,7 @@ namespace Redmine\Tests\Unit\Api\IssuePriority;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\IssuePriority;
 use Redmine\Client\Client;
+use Redmine\Exception\UnexpectedResponseException;
 
 /**
  * @covers \Redmine\Api\IssuePriority::list
@@ -62,5 +63,30 @@ class ListTest extends TestCase
 
         // Perform the tests
         $this->assertSame($expectedReturn, $api->list($allParameters));
+    }
+
+    public function testListThrowsException()
+    {
+        // Create the used mock objects
+        $client = $this->createMock(Client::class);
+        $client->expects($this->exactly(1))
+            ->method('requestGet')
+            ->with('/enumerations/issue_priorities.json')
+            ->willReturn(true);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseBody')
+            ->willReturn('');
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
+
+        // Create the object under test
+        $api = new IssuePriority($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+        $this->expectExceptionMessage('The Redmine server responded with an unexpected body.');
+
+        // Perform the tests
+        $api->list();
     }
 }

--- a/tests/Unit/Api/IssueRelation/ListByIssueIdTest.php
+++ b/tests/Unit/Api/IssueRelation/ListByIssueIdTest.php
@@ -5,6 +5,7 @@ namespace Redmine\Tests\Unit\Api\IssueRelation;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\IssueRelation;
 use Redmine\Client\Client;
+use Redmine\Exception\UnexpectedResponseException;
 
 /**
  * @covers \Redmine\Api\IssueRelation::listByIssueId
@@ -62,5 +63,30 @@ class ListByIssueIdTest extends TestCase
 
         // Perform the tests
         $this->assertSame($expectedReturn, $api->listByIssueId(5, $parameters));
+    }
+
+    public function testListByIssueIdThrowsException()
+    {
+        // Create the used mock objects
+        $client = $this->createMock(Client::class);
+        $client->expects($this->exactly(1))
+            ->method('requestGet')
+            ->with('/issues/5/relations.json')
+            ->willReturn(true);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseBody')
+            ->willReturn('');
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
+
+        // Create the object under test
+        $api = new IssueRelation($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+        $this->expectExceptionMessage('The Redmine server responded with an unexpected body.');
+
+        // Perform the tests
+        $api->listByIssueId(5);
     }
 }

--- a/tests/Unit/Api/IssueStatus/ListTest.php
+++ b/tests/Unit/Api/IssueStatus/ListTest.php
@@ -5,6 +5,7 @@ namespace Redmine\Tests\Unit\Api\IssueStatus;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\IssueStatus;
 use Redmine\Client\Client;
+use Redmine\Exception\UnexpectedResponseException;
 
 /**
  * @covers \Redmine\Api\IssueStatus::list
@@ -62,5 +63,30 @@ class ListTest extends TestCase
 
         // Perform the tests
         $this->assertSame($expectedReturn, $api->list($parameters));
+    }
+
+    public function testListThrowsException()
+    {
+        // Create the used mock objects
+        $client = $this->createMock(Client::class);
+        $client->expects($this->exactly(1))
+            ->method('requestGet')
+            ->with('/issue_statuses.json')
+            ->willReturn(true);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseBody')
+            ->willReturn('');
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
+
+        // Create the object under test
+        $api = new IssueStatus($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+        $this->expectExceptionMessage('The Redmine server responded with an unexpected body.');
+
+        // Perform the tests
+        $api->list();
     }
 }

--- a/tests/Unit/Api/Membership/ListByProjectTest.php
+++ b/tests/Unit/Api/Membership/ListByProjectTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Redmine\Api\Membership;
 use Redmine\Client\Client;
 use Redmine\Exception\InvalidParameterException;
+use Redmine\Exception\UnexpectedResponseException;
 use Redmine\Tests\Fixtures\MockClient;
 use stdClass;
 
@@ -90,5 +91,30 @@ class ListByProjectTest extends TestCase
             'array' => [[]],
             'object' => [new stdClass()],
         ];
+    }
+
+    public function testListByProjectThrowsException()
+    {
+        // Create the used mock objects
+        $client = $this->createMock(Client::class);
+        $client->expects($this->exactly(1))
+            ->method('requestGet')
+            ->with('/projects/5/memberships.json')
+            ->willReturn(true);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseBody')
+            ->willReturn('');
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
+
+        // Create the object under test
+        $api = new Membership($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+        $this->expectExceptionMessage('The Redmine server responded with an unexpected body.');
+
+        // Perform the tests
+        $api->listByProject(5);
     }
 }

--- a/tests/Unit/Api/News/ListByProjectTest.php
+++ b/tests/Unit/Api/News/ListByProjectTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Redmine\Api\News;
 use Redmine\Client\Client;
 use Redmine\Exception\InvalidParameterException;
+use Redmine\Exception\UnexpectedResponseException;
 use Redmine\Tests\Fixtures\MockClient;
 use stdClass;
 
@@ -92,5 +93,30 @@ class ListByProjectTest extends TestCase
             'array' => [[]],
             'object' => [new stdClass()],
         ];
+    }
+
+    public function testListByProjectThrowsException()
+    {
+        // Create the used mock objects
+        $client = $this->createMock(Client::class);
+        $client->expects($this->exactly(1))
+            ->method('requestGet')
+            ->with('/projects/5/news.json')
+            ->willReturn(true);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseBody')
+            ->willReturn('');
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
+
+        // Create the object under test
+        $api = new News($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+        $this->expectExceptionMessage('The Redmine server responded with an unexpected body.');
+
+        // Perform the tests
+        $api->listByProject(5);
     }
 }

--- a/tests/Unit/Api/News/ListTest.php
+++ b/tests/Unit/Api/News/ListTest.php
@@ -5,6 +5,7 @@ namespace Redmine\Tests\Unit\Api\News;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\News;
 use Redmine\Client\Client;
+use Redmine\Exception\UnexpectedResponseException;
 
 /**
  * @covers \Redmine\Api\News::list
@@ -62,5 +63,30 @@ class ListTest extends TestCase
 
         // Perform the tests
         $this->assertSame($expectedReturn, $api->list($parameters));
+    }
+
+    public function testListThrowsException()
+    {
+        // Create the used mock objects
+        $client = $this->createMock(Client::class);
+        $client->expects($this->exactly(1))
+            ->method('requestGet')
+            ->with('/news.json')
+            ->willReturn(true);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseBody')
+            ->willReturn('');
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
+
+        // Create the object under test
+        $api = new News($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+        $this->expectExceptionMessage('The Redmine server responded with an unexpected body.');
+
+        // Perform the tests
+        $api->list();
     }
 }

--- a/tests/Unit/Api/Project/ListTest.php
+++ b/tests/Unit/Api/Project/ListTest.php
@@ -5,6 +5,7 @@ namespace Redmine\Tests\Unit\Api\Project;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Project;
 use Redmine\Client\Client;
+use Redmine\Exception\UnexpectedResponseException;
 
 /**
  * @covers \Redmine\Api\Project::list
@@ -62,5 +63,30 @@ class ListTest extends TestCase
 
         // Perform the tests
         $this->assertSame($expectedReturn, $api->list($parameters));
+    }
+
+    public function testListThrowsException()
+    {
+        // Create the used mock objects
+        $client = $this->createMock(Client::class);
+        $client->expects($this->exactly(1))
+            ->method('requestGet')
+            ->with('/projects.json')
+            ->willReturn(true);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseBody')
+            ->willReturn('');
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
+
+        // Create the object under test
+        $api = new Project($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+        $this->expectExceptionMessage('The Redmine server responded with an unexpected body.');
+
+        // Perform the tests
+        $api->list();
     }
 }

--- a/tests/Unit/Api/Query/ListTest.php
+++ b/tests/Unit/Api/Query/ListTest.php
@@ -5,6 +5,7 @@ namespace Redmine\Tests\Unit\Api\Query;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Query;
 use Redmine\Client\Client;
+use Redmine\Exception\UnexpectedResponseException;
 
 /**
  * @covers \Redmine\Api\Query::list
@@ -62,5 +63,30 @@ class ListTest extends TestCase
 
         // Perform the tests
         $this->assertSame($expectedReturn, $api->list($parameters));
+    }
+
+    public function testListThrowsException()
+    {
+        // Create the used mock objects
+        $client = $this->createMock(Client::class);
+        $client->expects($this->exactly(1))
+            ->method('requestGet')
+            ->with('/queries.json')
+            ->willReturn(true);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseBody')
+            ->willReturn('');
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
+
+        // Create the object under test
+        $api = new Query($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+        $this->expectExceptionMessage('The Redmine server responded with an unexpected body.');
+
+        // Perform the tests
+        $api->list();
     }
 }

--- a/tests/Unit/Api/Role/ListTest.php
+++ b/tests/Unit/Api/Role/ListTest.php
@@ -5,6 +5,7 @@ namespace Redmine\Tests\Unit\Api\Role;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Role;
 use Redmine\Client\Client;
+use Redmine\Exception\UnexpectedResponseException;
 
 /**
  * @covers \Redmine\Api\Role::list
@@ -62,5 +63,30 @@ class ListTest extends TestCase
 
         // Perform the tests
         $this->assertSame($expectedReturn, $api->list($parameters));
+    }
+
+    public function testListThrowsException()
+    {
+        // Create the used mock objects
+        $client = $this->createMock(Client::class);
+        $client->expects($this->exactly(1))
+            ->method('requestGet')
+            ->with('/roles.json')
+            ->willReturn(true);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseBody')
+            ->willReturn('');
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
+
+        // Create the object under test
+        $api = new Role($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+        $this->expectExceptionMessage('The Redmine server responded with an unexpected body.');
+
+        // Perform the tests
+        $api->list();
     }
 }

--- a/tests/Unit/Api/Search/ListByQueryTest.php
+++ b/tests/Unit/Api/Search/ListByQueryTest.php
@@ -5,6 +5,7 @@ namespace Redmine\Tests\Unit\Api\Search;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Search;
 use Redmine\Client\Client;
+use Redmine\Exception\UnexpectedResponseException;
 use Redmine\Tests\Fixtures\MockClient;
 
 /**
@@ -63,5 +64,30 @@ class ListByQueryTest extends TestCase
 
         // Perform the tests
         $this->assertSame($expectedReturn, $api->listByQuery('query', $parameters));
+    }
+
+    public function testListByQueryThrowsException()
+    {
+        // Create the used mock objects
+        $client = $this->createMock(Client::class);
+        $client->expects($this->exactly(1))
+            ->method('requestGet')
+            ->with('/search.json?limit=25&offset=0&q=query')
+            ->willReturn(true);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseBody')
+            ->willReturn('');
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
+
+        // Create the object under test
+        $api = new Search($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+        $this->expectExceptionMessage('The Redmine server responded with an unexpected body.');
+
+        // Perform the tests
+        $api->listByQuery('query');
     }
 }

--- a/tests/Unit/Api/TimeEntry/ListTest.php
+++ b/tests/Unit/Api/TimeEntry/ListTest.php
@@ -5,6 +5,7 @@ namespace Redmine\Tests\Unit\Api\TimeEntry;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\TimeEntry;
 use Redmine\Client\Client;
+use Redmine\Exception\UnexpectedResponseException;
 
 /**
  * @covers \Redmine\Api\TimeEntry::list
@@ -66,5 +67,30 @@ class ListTest extends TestCase
 
         // Perform the tests
         $this->assertSame($expectedReturn, $api->list($parameters));
+    }
+
+    public function testListThrowsException()
+    {
+        // Create the used mock objects
+        $client = $this->createMock(Client::class);
+        $client->expects($this->exactly(1))
+            ->method('requestGet')
+            ->with('/time_entries.json')
+            ->willReturn(true);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseBody')
+            ->willReturn('');
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
+
+        // Create the object under test
+        $api = new TimeEntry($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+        $this->expectExceptionMessage('The Redmine server responded with an unexpected body.');
+
+        // Perform the tests
+        $api->list();
     }
 }

--- a/tests/Unit/Api/TimeEntryActivity/ListTest.php
+++ b/tests/Unit/Api/TimeEntryActivity/ListTest.php
@@ -5,6 +5,7 @@ namespace Redmine\Tests\Unit\Api\TimeEntryActivity;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\TimeEntryActivity;
 use Redmine\Client\Client;
+use Redmine\Exception\UnexpectedResponseException;
 
 /**
  * @coversDefaultClass \Redmine\Api\TimeEntryActivity::list
@@ -62,5 +63,30 @@ class ListTest extends TestCase
 
         // Perform the tests
         $this->assertSame($expectedReturn, $api->list($parameters));
+    }
+
+    public function testListThrowsException()
+    {
+        // Create the used mock objects
+        $client = $this->createMock(Client::class);
+        $client->expects($this->exactly(1))
+            ->method('requestGet')
+            ->with('/enumerations/time_entry_activities.json')
+            ->willReturn(true);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseBody')
+            ->willReturn('');
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
+
+        // Create the object under test
+        $api = new TimeEntryActivity($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+        $this->expectExceptionMessage('The Redmine server responded with an unexpected body.');
+
+        // Perform the tests
+        $api->list();
     }
 }

--- a/tests/Unit/Api/Tracker/ListTest.php
+++ b/tests/Unit/Api/Tracker/ListTest.php
@@ -5,6 +5,7 @@ namespace Redmine\Tests\Unit\Api\Tracker;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Tracker;
 use Redmine\Client\Client;
+use Redmine\Exception\UnexpectedResponseException;
 
 /**
  * @covers \Redmine\Api\Tracker::list
@@ -62,5 +63,30 @@ class ListTest extends TestCase
 
         // Perform the tests
         $this->assertSame($expectedReturn, $api->list($parameters));
+    }
+
+    public function testListThrowsException()
+    {
+        // Create the used mock objects
+        $client = $this->createMock(Client::class);
+        $client->expects($this->exactly(1))
+            ->method('requestGet')
+            ->with('/trackers.json')
+            ->willReturn(true);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseBody')
+            ->willReturn('');
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
+
+        // Create the object under test
+        $api = new Tracker($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+        $this->expectExceptionMessage('The Redmine server responded with an unexpected body.');
+
+        // Perform the tests
+        $api->list();
     }
 }

--- a/tests/Unit/Api/User/ListTest.php
+++ b/tests/Unit/Api/User/ListTest.php
@@ -5,6 +5,7 @@ namespace Redmine\Tests\Unit\Api\User;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\User;
 use Redmine\Client\Client;
+use Redmine\Exception\UnexpectedResponseException;
 
 /**
  * @covers \Redmine\Api\User::list
@@ -65,5 +66,30 @@ class ListTest extends TestCase
 
         // Perform the tests
         $this->assertSame($expectedReturn, $api->list($parameters));
+    }
+
+    public function testListThrowsException()
+    {
+        // Create the used mock objects
+        $client = $this->createMock(Client::class);
+        $client->expects($this->exactly(1))
+            ->method('requestGet')
+            ->with('/users.json')
+            ->willReturn(true);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseBody')
+            ->willReturn('');
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
+
+        // Create the object under test
+        $api = new User($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+        $this->expectExceptionMessage('The Redmine server responded with an unexpected body.');
+
+        // Perform the tests
+        $api->list();
     }
 }

--- a/tests/Unit/Api/Version/ListByProjectTest.php
+++ b/tests/Unit/Api/Version/ListByProjectTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Redmine\Api\Version;
 use Redmine\Client\Client;
 use Redmine\Exception\InvalidParameterException;
+use Redmine\Exception\UnexpectedResponseException;
 use Redmine\Tests\Fixtures\MockClient;
 use stdClass;
 
@@ -93,5 +94,30 @@ class ListByProjectTest extends TestCase
             'array' => [[]],
             'object' => [new stdClass()],
         ];
+    }
+
+    public function testListByProjectThrowsException()
+    {
+        // Create the used mock objects
+        $client = $this->createMock(Client::class);
+        $client->expects($this->exactly(1))
+            ->method('requestGet')
+            ->with('/projects/5/versions.json')
+            ->willReturn(true);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseBody')
+            ->willReturn('');
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
+
+        // Create the object under test
+        $api = new Version($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+        $this->expectExceptionMessage('The Redmine server responded with an unexpected body.');
+
+        // Perform the tests
+        $api->listByProject(5);
     }
 }

--- a/tests/Unit/Api/Wiki/ListByProjectTest.php
+++ b/tests/Unit/Api/Wiki/ListByProjectTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Redmine\Api\Wiki;
 use Redmine\Client\Client;
 use Redmine\Exception\InvalidParameterException;
+use Redmine\Exception\UnexpectedResponseException;
 use Redmine\Tests\Fixtures\MockClient;
 use stdClass;
 
@@ -93,5 +94,30 @@ class ListByProjectTest extends TestCase
             'array' => [[]],
             'object' => [new stdClass()],
         ];
+    }
+
+    public function testListByProjectThrowsException()
+    {
+        // Create the used mock objects
+        $client = $this->createMock(Client::class);
+        $client->expects($this->exactly(1))
+            ->method('requestGet')
+            ->with('/projects/5/wiki/index.json')
+            ->willReturn(true);
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseBody')
+            ->willReturn('');
+        $client->expects($this->exactly(1))
+            ->method('getLastResponseContentType')
+            ->willReturn('application/json');
+
+        // Create the object under test
+        $api = new Wiki($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+        $this->expectExceptionMessage('The Redmine server responded with an unexpected body.');
+
+        // Perform the tests
+        $api->listByProject(5);
     }
 }


### PR DESCRIPTION
It is possible that the Redmine server responses with an unexpected body, e.g. because a parameter was set incorrectly (see #335). In this case the parsing of the body will fail, causing a `SerializerException`. This results in a bad DX as the developer has no clue why the parsing of the body fails.

This PR introduces a new `UnexpectedResponseException` if the Redmine server delivers an unexpected response. This is a follow-up for #337.

- Requires #337
- Fixes #335
- Fixes #339