### PR TITLE
Add support for PHP 8.3 and 8.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,14 +6,14 @@ on:
 
 jobs:
   tests:
-    name: Tests (PHP ${{ matrix.php-versions }} on ${{ matrix.operating-system }})
+    name: Tests (PHP ${{ matrix.php }} on ${{ matrix.operating-system }})
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
         operating-system: ["ubuntu-latest"]
-        php-versions: ["7.4", "8.0", "8.1", "8.2"]
+        php: ["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]
 
     steps:
       - name: Checkout
@@ -26,7 +26,7 @@ jobs:
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
         with:
-          php-version: ${{ matrix.php-versions }}
+          php-version: ${{ matrix.php }}
           tools: phpunit
           extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite
           coverage: xdebug
@@ -37,14 +37,14 @@ jobs:
         uses: "ramsey/composer-install@v2"
 
       - name: Run static code analysis
-        if: ${{ matrix.php-versions == '8.2' }}
+        if: ${{ matrix.php == '8.3' }}
         run: composer run phpstan -- --error-format=github
 
       - name: Run tests
         run: vendor/bin/phpunit --coverage-clover .phpunit.cache/clover.xml
 
       - name: Upload coverage reports to Codecov
-        if: ${{ success() && matrix.php-versions == '8.2' }}
+        if: ${{ success() && matrix.php == '8.3' }}
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added support for PHP 8.3
 - New method `Redmine\Api\CustomField::list()` to list custom fields.
 - New method `Redmine\Api\Group::list()` to list groups.
 - New method `Redmine\Api\Issue::list()` to list issues.


### PR DESCRIPTION
This PR adds PHP 8.3 and 8.4 in Github actions.

Closes #350.