### PR TITLE
Do not use temporary cache in `Redmine\Api\...::list()` methods

### DIFF
--- a/src/Redmine/Api/CustomField.php
+++ b/src/Redmine/Api/CustomField.php
@@ -31,12 +31,10 @@ class CustomField extends AbstractApi
     final public function list(array $params = []): array
     {
         try {
-            $this->customFields = $this->retrieveData('/custom_fields.json', $params);
+            return $this->retrieveData('/custom_fields.json', $params);
         } catch (SerializerException $th) {
             throw new UnexpectedResponseException('The Redmine server responded with an unexpected body.', $th->getCode(), $th);
         }
-
-        return $this->customFields;
     }
 
     /**
@@ -55,7 +53,7 @@ class CustomField extends AbstractApi
         @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::list()` instead.', E_USER_DEPRECATED);
 
         try {
-            return $this->list($params);
+            $this->customFields = $this->list($params);
         } catch (Exception $e) {
             if ($this->client->getLastResponseBody() === '') {
                 return false;
@@ -67,6 +65,8 @@ class CustomField extends AbstractApi
 
             return $e->getMessage();
         }
+
+        return $this->customFields;
     }
 
     /**
@@ -80,7 +80,7 @@ class CustomField extends AbstractApi
     public function listing($forceUpdate = false, array $params = [])
     {
         if (empty($this->customFields) || $forceUpdate) {
-            $this->list($params);
+            $this->customFields = $this->list($params);
         }
         $ret = [];
         foreach ($this->customFields['custom_fields'] as $e) {

--- a/src/Redmine/Api/Group.php
+++ b/src/Redmine/Api/Group.php
@@ -34,12 +34,10 @@ class Group extends AbstractApi
     final public function list(array $params = []): array
     {
         try {
-            $this->groups = $this->retrieveData('/groups.json', $params);
+            return $this->retrieveData('/groups.json', $params);
         } catch (SerializerException $th) {
             throw new UnexpectedResponseException('The Redmine server responded with an unexpected body.', $th->getCode(), $th);
         }
-
-        return $this->groups;
     }
 
     /**
@@ -58,7 +56,7 @@ class Group extends AbstractApi
         @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::list()` instead.', E_USER_DEPRECATED);
 
         try {
-            return $this->list($params);
+            $this->groups = $this->list($params);
         } catch (Exception $e) {
             if ($this->client->getLastResponseBody() === '') {
                 return false;
@@ -70,6 +68,8 @@ class Group extends AbstractApi
 
             return $e->getMessage();
         }
+
+        return $this->groups;
     }
 
     /**
@@ -82,7 +82,7 @@ class Group extends AbstractApi
     public function listing($forceUpdate = false)
     {
         if (empty($this->groups) || $forceUpdate) {
-            $this->list();
+            $this->groups = $this->list();
         }
         $ret = [];
         foreach ($this->groups['groups'] as $e) {

--- a/src/Redmine/Api/IssueCategory.php
+++ b/src/Redmine/Api/IssueCategory.php
@@ -44,12 +44,10 @@ class IssueCategory extends AbstractApi
         }
 
         try {
-            $this->issueCategories = $this->retrieveData('/projects/'.strval($projectIdentifier).'/issue_categories.json', $params);
+            return $this->retrieveData('/projects/'.strval($projectIdentifier).'/issue_categories.json', $params);
         } catch (SerializerException $th) {
             throw new UnexpectedResponseException('The Redmine server responded with an unexpected body.', $th->getCode(), $th);
         }
-
-        return $this->issueCategories;
     }
 
     /**
@@ -94,7 +92,7 @@ class IssueCategory extends AbstractApi
     public function listing($project, $forceUpdate = false)
     {
         if (true === $forceUpdate || empty($this->issueCategories)) {
-            $this->listByProject($project);
+            $this->issueCategories = $this->listByProject($project);
         }
         $ret = [];
         foreach ($this->issueCategories['issue_categories'] as $e) {

--- a/src/Redmine/Api/IssuePriority.php
+++ b/src/Redmine/Api/IssuePriority.php
@@ -31,12 +31,10 @@ class IssuePriority extends AbstractApi
     final public function list(array $params = []): array
     {
         try {
-            $this->issuePriorities = $this->retrieveData('/enumerations/issue_priorities.json', $params);
+            return $this->retrieveData('/enumerations/issue_priorities.json', $params);
         } catch (SerializerException $th) {
             throw new UnexpectedResponseException('The Redmine server responded with an unexpected body.', $th->getCode(), $th);
         }
-
-        return $this->issuePriorities;
     }
 
     /**
@@ -55,7 +53,7 @@ class IssuePriority extends AbstractApi
         @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::list()` instead.', E_USER_DEPRECATED);
 
         try {
-            return $this->list($params);
+            $this->issuePriorities = $this->list($params);
         } catch (Exception $e) {
             if ($this->client->getLastResponseBody() === '') {
                 return false;
@@ -67,5 +65,7 @@ class IssuePriority extends AbstractApi
 
             return $e->getMessage();
         }
+
+        return $this->issuePriorities;
     }
 }

--- a/src/Redmine/Api/IssueRelation.php
+++ b/src/Redmine/Api/IssueRelation.php
@@ -33,12 +33,10 @@ class IssueRelation extends AbstractApi
     final public function listByIssueId(int $issueId, array $params = []): array
     {
         try {
-            $this->relations = $this->retrieveData('/issues/'.strval($issueId).'/relations.json', $params);
+            return $this->retrieveData('/issues/'.strval($issueId).'/relations.json', $params);
         } catch (SerializerException $th) {
             throw new UnexpectedResponseException('The Redmine server responded with an unexpected body.', $th->getCode(), $th);
         }
-
-        return $this->relations;
     }
 
     /**
@@ -58,7 +56,7 @@ class IssueRelation extends AbstractApi
         @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::listByIssueId()` instead.', E_USER_DEPRECATED);
 
         try {
-            return $this->listByIssueId($issueId, $params);
+            $this->relations = $this->listByIssueId($issueId, $params);
         } catch (Exception $e) {
             if ($this->client->getLastResponseBody() === '') {
                 return false;
@@ -70,6 +68,8 @@ class IssueRelation extends AbstractApi
 
             return $e->getMessage();
         }
+
+        return $this->relations;
     }
 
     /**

--- a/src/Redmine/Api/IssueStatus.php
+++ b/src/Redmine/Api/IssueStatus.php
@@ -31,12 +31,10 @@ class IssueStatus extends AbstractApi
     final public function list(array $params = []): array
     {
         try {
-            $this->issueStatuses = $this->retrieveData('/issue_statuses.json', $params);
+            return $this->retrieveData('/issue_statuses.json', $params);
         } catch (SerializerException $th) {
             throw new UnexpectedResponseException('The Redmine server responded with an unexpected body.', $th->getCode(), $th);
         }
-
-        return $this->issueStatuses;
     }
 
     /**
@@ -55,7 +53,7 @@ class IssueStatus extends AbstractApi
         @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::list()` instead.', E_USER_DEPRECATED);
 
         try {
-            return $this->list($params);
+            $this->issueStatuses = $this->list($params);
         } catch (Exception $e) {
             if ($this->client->getLastResponseBody() === '') {
                 return false;
@@ -67,6 +65,8 @@ class IssueStatus extends AbstractApi
 
             return $e->getMessage();
         }
+
+        return $this->issueStatuses;
     }
 
     /**
@@ -79,7 +79,7 @@ class IssueStatus extends AbstractApi
     public function listing($forceUpdate = false)
     {
         if (empty($this->issueStatuses) || $forceUpdate) {
-            $this->list();
+            $this->issueStatuses = $this->list();
         }
         $ret = [];
         foreach ($this->issueStatuses['issue_statuses'] as $e) {

--- a/src/Redmine/Api/Membership.php
+++ b/src/Redmine/Api/Membership.php
@@ -43,12 +43,10 @@ class Membership extends AbstractApi
         }
 
         try {
-            $this->memberships = $this->retrieveData('/projects/'.strval($projectIdentifier).'/memberships.json', $params);
+            return $this->retrieveData('/projects/'.strval($projectIdentifier).'/memberships.json', $params);
         } catch (SerializerException $th) {
             throw new UnexpectedResponseException('The Redmine server responded with an unexpected body.', $th->getCode(), $th);
         }
-
-        return $this->memberships;
     }
 
     /**
@@ -68,7 +66,7 @@ class Membership extends AbstractApi
         @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::listByProject()` instead.', E_USER_DEPRECATED);
 
         try {
-            return $this->listByProject(strval($project), $params);
+            $this->memberships = $this->listByProject(strval($project), $params);
         } catch (Exception $e) {
             if ($this->client->getLastResponseBody() === '') {
                 return false;
@@ -80,6 +78,8 @@ class Membership extends AbstractApi
 
             return $e->getMessage();
         }
+
+        return $this->memberships;
     }
 
     /**

--- a/src/Redmine/Api/News.php
+++ b/src/Redmine/Api/News.php
@@ -39,12 +39,10 @@ class News extends AbstractApi
         }
 
         try {
-            $this->news = $this->retrieveData('/projects/'.strval($projectIdentifier).'/news.json', $params);
+            return $this->retrieveData('/projects/'.strval($projectIdentifier).'/news.json', $params);
         } catch (SerializerException $th) {
             throw new UnexpectedResponseException('The Redmine server responded with an unexpected body.', $th->getCode(), $th);
         }
-
-        return $this->news;
     }
 
     /**
@@ -61,12 +59,10 @@ class News extends AbstractApi
     final public function list(array $params = []): array
     {
         try {
-            $this->news = $this->retrieveData('/news.json', $params);
+            return $this->retrieveData('/news.json', $params);
         } catch (SerializerException $th) {
             throw new UnexpectedResponseException('The Redmine server responded with an unexpected body.', $th->getCode(), $th);
         }
-
-        return $this->news;
     }
 
     /**
@@ -87,9 +83,9 @@ class News extends AbstractApi
 
         try {
             if (null === $project) {
-                return $this->list($params);
+                $this->news = $this->list($params);
             } else {
-                return $this->listByProject(strval($project), $params);
+                $this->news = $this->listByProject(strval($project), $params);
             }
         } catch (Exception $e) {
             if ($this->client->getLastResponseBody() === '') {
@@ -102,5 +98,7 @@ class News extends AbstractApi
 
             return $e->getMessage();
         }
+
+        return $this->news;
     }
 }

--- a/src/Redmine/Api/Project.php
+++ b/src/Redmine/Api/Project.php
@@ -34,12 +34,10 @@ class Project extends AbstractApi
     final public function list(array $params = []): array
     {
         try {
-            $this->projects = $this->retrieveData('/projects.json', $params);
+            return $this->retrieveData('/projects.json', $params);
         } catch (SerializerException $th) {
             throw new UnexpectedResponseException('The Redmine server responded with an unexpected body.', $th->getCode(), $th);
         }
-
-        return $this->projects;
     }
 
     /**
@@ -58,7 +56,7 @@ class Project extends AbstractApi
         @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::list()` instead.', E_USER_DEPRECATED);
 
         try {
-            return $this->list($params);
+            $this->projects = $this->list($params);
         } catch (Exception $e) {
             if ($this->client->getLastResponseBody() === '') {
                 return false;
@@ -70,6 +68,8 @@ class Project extends AbstractApi
 
             return $e->getMessage();
         }
+
+        return $this->projects;
     }
 
     /**
@@ -84,7 +84,7 @@ class Project extends AbstractApi
     public function listing($forceUpdate = false, $reverse = true, array $params = [])
     {
         if (true === $forceUpdate || empty($this->projects)) {
-            $this->list($params);
+            $this->projects = $this->list($params);
         }
         $ret = [];
         foreach ($this->projects['projects'] as $e) {

--- a/src/Redmine/Api/Query.php
+++ b/src/Redmine/Api/Query.php
@@ -31,12 +31,10 @@ class Query extends AbstractApi
     final public function list(array $params = []): array
     {
         try {
-            $this->query = $this->retrieveData('/queries.json', $params);
+            return $this->retrieveData('/queries.json', $params);
         } catch (SerializerException $th) {
             throw new UnexpectedResponseException('The Redmine server responded with an unexpected body.', $th->getCode(), $th);
         }
-
-        return $this->query;
     }
 
     /**
@@ -55,7 +53,7 @@ class Query extends AbstractApi
         @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::list()` instead.', E_USER_DEPRECATED);
 
         try {
-            return $this->list($params);
+            $this->query = $this->list($params);
         } catch (Exception $e) {
             if ($this->client->getLastResponseBody() === '') {
                 return false;
@@ -67,5 +65,7 @@ class Query extends AbstractApi
 
             return $e->getMessage();
         }
+
+        return $this->query;
     }
 }

--- a/src/Redmine/Api/Role.php
+++ b/src/Redmine/Api/Role.php
@@ -31,12 +31,10 @@ class Role extends AbstractApi
     final public function list(array $params = []): array
     {
         try {
-            $this->roles = $this->retrieveData('/roles.json', $params);
+            return $this->retrieveData('/roles.json', $params);
         } catch (SerializerException $th) {
             throw new UnexpectedResponseException('The Redmine server responded with an unexpected body.', $th->getCode(), $th);
         }
-
-        return $this->roles;
     }
 
     /**
@@ -55,7 +53,7 @@ class Role extends AbstractApi
         @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::list()` instead.', E_USER_DEPRECATED);
 
         try {
-            return $this->list($params);
+            $this->roles = $this->list($params);
         } catch (Exception $e) {
             if ($this->client->getLastResponseBody() === '') {
                 return false;
@@ -67,6 +65,8 @@ class Role extends AbstractApi
 
             return $e->getMessage();
         }
+
+        return $this->roles;
     }
 
     /**
@@ -79,7 +79,7 @@ class Role extends AbstractApi
     public function listing($forceUpdate = false)
     {
         if (empty($this->roles) || $forceUpdate) {
-            $this->list();
+            $this->roles = $this->list();
         }
         $ret = [];
         foreach ($this->roles['roles'] as $e) {

--- a/src/Redmine/Api/Search.php
+++ b/src/Redmine/Api/Search.php
@@ -30,12 +30,10 @@ class Search extends AbstractApi
         $params['q'] = $query;
 
         try {
-            $this->results = $this->retrieveData('/search.json', $params);
+            return $this->retrieveData('/search.json', $params);
         } catch (SerializerException $th) {
             throw new UnexpectedResponseException('The Redmine server responded with an unexpected body.', $th->getCode(), $th);
         }
-
-        return $this->results;
     }
 
     /**
@@ -55,7 +53,7 @@ class Search extends AbstractApi
         @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::listByQuery()` instead.', E_USER_DEPRECATED);
 
         try {
-            return $this->listByQuery($query, $params);
+            $this->results = $this->listByQuery($query, $params);
         } catch (Exception $e) {
             if ($this->client->getLastResponseBody() === '') {
                 return false;
@@ -67,5 +65,7 @@ class Search extends AbstractApi
 
             return $e->getMessage();
         }
+
+        return $this->results;
     }
 }

--- a/src/Redmine/Api/TimeEntry.php
+++ b/src/Redmine/Api/TimeEntry.php
@@ -33,12 +33,10 @@ class TimeEntry extends AbstractApi
     final public function list(array $params = []): array
     {
         try {
-            $this->timeEntries = $this->retrieveData('/time_entries.json', $params);
+            return $this->retrieveData('/time_entries.json', $params);
         } catch (SerializerException $th) {
             throw new UnexpectedResponseException('The Redmine server responded with an unexpected body.', $th->getCode(), $th);
         }
-
-        return $this->timeEntries;
     }
 
     /**
@@ -57,7 +55,7 @@ class TimeEntry extends AbstractApi
         @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::list()` instead.', E_USER_DEPRECATED);
 
         try {
-            return $this->list($params);
+            $this->timeEntries = $this->list($params);
         } catch (Exception $e) {
             if ($this->client->getLastResponseBody() === '') {
                 return false;
@@ -69,6 +67,8 @@ class TimeEntry extends AbstractApi
 
             return $e->getMessage();
         }
+
+        return $this->timeEntries;
     }
 
     /**

--- a/src/Redmine/Api/TimeEntryActivity.php
+++ b/src/Redmine/Api/TimeEntryActivity.php
@@ -29,12 +29,10 @@ class TimeEntryActivity extends AbstractApi
     final public function list(array $params = []): array
     {
         try {
-            $this->timeEntryActivities = $this->retrieveData('/enumerations/time_entry_activities.json', $params);
+            return $this->retrieveData('/enumerations/time_entry_activities.json', $params);
         } catch (SerializerException $th) {
             throw new UnexpectedResponseException('The Redmine server responded with an unexpected body.', $th->getCode(), $th);
         }
-
-        return $this->timeEntryActivities;
     }
 
     /**
@@ -51,7 +49,7 @@ class TimeEntryActivity extends AbstractApi
         @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::list()` instead.', E_USER_DEPRECATED);
 
         try {
-            return $this->list($params);
+            $this->timeEntryActivities = $this->list($params);
         } catch (Exception $e) {
             if ($this->client->getLastResponseBody() === '') {
                 return false;
@@ -63,6 +61,8 @@ class TimeEntryActivity extends AbstractApi
 
             return $e->getMessage();
         }
+
+        return $this->timeEntryActivities;
     }
 
     /**
@@ -75,7 +75,7 @@ class TimeEntryActivity extends AbstractApi
     public function listing($forceUpdate = false)
     {
         if (empty($this->timeEntryActivities) || $forceUpdate) {
-            $this->list();
+            $this->timeEntryActivities = $this->list();
         }
         $ret = [];
         foreach ($this->timeEntryActivities['time_entry_activities'] as $e) {

--- a/src/Redmine/Api/Tracker.php
+++ b/src/Redmine/Api/Tracker.php
@@ -31,12 +31,10 @@ class Tracker extends AbstractApi
     final public function list(array $params = []): array
     {
         try {
-            $this->trackers = $this->retrieveData('/trackers.json', $params);
+            return $this->retrieveData('/trackers.json', $params);
         } catch (SerializerException $th) {
             throw new UnexpectedResponseException('The Redmine server responded with an unexpected body.', $th->getCode(), $th);
         }
-
-        return $this->trackers;
     }
 
     /**
@@ -55,7 +53,7 @@ class Tracker extends AbstractApi
         @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::list()` instead.', E_USER_DEPRECATED);
 
         try {
-            return $this->list($params);
+            $this->trackers = $this->list($params);
         } catch (Exception $e) {
             if ($this->client->getLastResponseBody() === '') {
                 return false;
@@ -67,6 +65,8 @@ class Tracker extends AbstractApi
 
             return $e->getMessage();
         }
+
+        return $this->trackers;
     }
 
     /**
@@ -79,7 +79,7 @@ class Tracker extends AbstractApi
     public function listing($forceUpdate = false)
     {
         if (empty($this->trackers) || $forceUpdate) {
-            $this->list();
+            $this->trackers = $this->list();
         }
         $ret = [];
         foreach ($this->trackers['trackers'] as $e) {

--- a/src/Redmine/Api/User.php
+++ b/src/Redmine/Api/User.php
@@ -34,12 +34,10 @@ class User extends AbstractApi
     final public function list(array $params = []): array
     {
         try {
-            $this->users = $this->retrieveData('/users.json', $params);
+            return $this->retrieveData('/users.json', $params);
         } catch (SerializerException $th) {
             throw new UnexpectedResponseException('The Redmine server responded with an unexpected body.', $th->getCode(), $th);
         }
-
-        return $this->users;
     }
 
     /**
@@ -58,7 +56,7 @@ class User extends AbstractApi
         @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::list()` instead.', E_USER_DEPRECATED);
 
         try {
-            return $this->list($params);
+            $this->users = $this->list($params);
         } catch (Exception $e) {
             if ($this->client->getLastResponseBody() === '') {
                 return false;
@@ -70,6 +68,8 @@ class User extends AbstractApi
 
             return $e->getMessage();
         }
+
+        return $this->users;
     }
 
     /**
@@ -83,7 +83,7 @@ class User extends AbstractApi
     public function listing($forceUpdate = false, array $params = [])
     {
         if (empty($this->users) || $forceUpdate) {
-            $this->list($params);
+            $this->users = $this->list($params);
         }
         $ret = [];
         if (is_array($this->users) && isset($this->users['users'])) {

--- a/src/Redmine/Api/Version.php
+++ b/src/Redmine/Api/Version.php
@@ -42,12 +42,10 @@ class Version extends AbstractApi
         }
 
         try {
-            $this->versions = $this->retrieveData('/projects/'.strval($projectIdentifier).'/versions.json', $params);
+            return $this->retrieveData('/projects/'.strval($projectIdentifier).'/versions.json', $params);
         } catch (SerializerException $th) {
             throw new UnexpectedResponseException('The Redmine server responded with an unexpected body.', $th->getCode(), $th);
         }
-
-        return $this->versions;
     }
 
     /**
@@ -67,7 +65,7 @@ class Version extends AbstractApi
         @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::listByProject()` instead.', E_USER_DEPRECATED);
 
         try {
-            return $this->listByProject(strval($project), $params);
+            $this->versions = $this->listByProject(strval($project), $params);
         } catch (Exception $e) {
             if ($this->client->getLastResponseBody() === '') {
                 return false;
@@ -79,6 +77,8 @@ class Version extends AbstractApi
 
             return $e->getMessage();
         }
+
+        return $this->versions;
     }
 
     /**
@@ -94,7 +94,7 @@ class Version extends AbstractApi
     public function listing($project, $forceUpdate = false, $reverse = true, array $params = [])
     {
         if (true === $forceUpdate || empty($this->versions)) {
-            $this->listByProject($project, $params);
+            $this->versions = $this->listByProject($project, $params);
         }
         $ret = [];
         foreach ($this->versions['versions'] as $e) {

--- a/src/Redmine/Api/Wiki.php
+++ b/src/Redmine/Api/Wiki.php
@@ -42,12 +42,10 @@ class Wiki extends AbstractApi
         }
 
         try {
-            $this->wikiPages = $this->retrieveData('/projects/'.strval($projectIdentifier).'/wiki/index.json', $params);
+            return $this->retrieveData('/projects/'.strval($projectIdentifier).'/wiki/index.json', $params);
         } catch (SerializerException $th) {
             throw new UnexpectedResponseException('The Redmine server responded with an unexpected body.', $th->getCode(), $th);
         }
-
-        return $this->wikiPages;
     }
 
     /**
@@ -67,7 +65,7 @@ class Wiki extends AbstractApi
         @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::listByProject()` instead.', E_USER_DEPRECATED);
 
         try {
-            return $this->listByProject(strval($project), $params);
+            $this->wikiPages = $this->listByProject(strval($project), $params);
         } catch (Exception $e) {
             if ($this->client->getLastResponseBody() === '') {
                 return false;
@@ -79,6 +77,8 @@ class Wiki extends AbstractApi
 
             return $e->getMessage();
         }
+
+        return $this->wikiPages;
     }
 
     /**


### PR DESCRIPTION
This PR removes the change of the cache if using the `list()` methods and move it back in the `all()` (and `listing()`) methods for BC.

Fixes #353.