### PR TITLE
Change code style to PER CS 2.0

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -9,12 +9,13 @@ $finder = PhpCsFixer\Finder::create()
 
 $config = new PhpCsFixer\Config();
 return $config->setRules([
-        '@Symfony' => true,
-
+        '@PER-CS2.0' => true,
+        '@PER-CS2.0:risky' => true,
         'array_syntax' => ['syntax' => 'short'],
         'linebreak_after_opening_tag' => true,
         'ordered_imports' => true,
         'phpdoc_order' => true,
     ])
     ->setFinder($finder)
+    ->setRiskyAllowed(true)
 ;

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "psr/http-factory": "^1.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3",
+        "friendsofphp/php-cs-fixer": "^3.45",
         "phpunit/phpunit": "^9 || ^10.5",
         "guzzlehttp/psr7": "^2",
         "php-mock/php-mock-phpunit": "^2.6",
@@ -46,6 +46,7 @@
         }
     },
     "scripts": {
+        "codestyle": "php-cs-fixer fix",
         "coverage": "phpunit --coverage-html=\".phpunit.cache/code-coverage\"",
         "phpstan": "phpstan analyze --memory-limit 512M --configuration .phpstan.neon",
         "test": "phpunit"

--- a/src/Redmine/Api.php
+++ b/src/Redmine/Api.php
@@ -5,6 +5,4 @@ namespace Redmine;
 /**
  * api interface.
  */
-interface Api
-{
-}
+interface Api {}

--- a/src/Redmine/Api/AbstractApi.php
+++ b/src/Redmine/Api/AbstractApi.php
@@ -38,7 +38,7 @@ abstract class AbstractApi implements Api
      */
     public function lastCallFailed()
     {
-        @trigger_error('`'.__METHOD__.'()` is deprecated since v2.1.0, use \Redmine\Client\Client::getLastResponseStatusCode() instead.', E_USER_DEPRECATED);
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.1.0, use \Redmine\Client\Client::getLastResponseStatusCode() instead.', E_USER_DEPRECATED);
 
         $code = $this->client->getLastResponseStatusCode();
 
@@ -69,7 +69,7 @@ abstract class AbstractApi implements Api
             try {
                 return JsonSerializer::createFromString($body)->getNormalized();
             } catch (SerializerException $e) {
-                return 'Error decoding body as JSON: '.$e->getPrevious()->getMessage();
+                return 'Error decoding body as JSON: ' . $e->getPrevious()->getMessage();
             }
         }
 
@@ -174,7 +174,7 @@ abstract class AbstractApi implements Api
      */
     protected function retrieveAll($endpoint, array $params = [])
     {
-        @trigger_error('`'.__METHOD__.'()` is deprecated since v2.2.0, use `retrieveData()` instead.', E_USER_DEPRECATED);
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.2.0, use `retrieveData()` instead.', E_USER_DEPRECATED);
 
         try {
             $data = $this->retrieveData(strval($endpoint), $params);
@@ -242,7 +242,8 @@ abstract class AbstractApi implements Api
 
             $offset += $_limit;
 
-            if (empty($newDataSet) || !isset($newDataSet['limit']) || (
+            if (
+                empty($newDataSet) || !isset($newDataSet['limit']) || (
                     isset($newDataSet['offset']) &&
                     isset($newDataSet['total_count']) &&
                     $newDataSet['offset'] >= $newDataSet['total_count']
@@ -269,7 +270,7 @@ abstract class AbstractApi implements Api
      */
     protected function attachCustomFieldXML(SimpleXMLElement $xml, array $fields)
     {
-        @trigger_error('`'.__METHOD__.'()` is deprecated since v2.3.0, use `\Redmine\Serializer\XmlSerializer::createFromArray()` instead.', E_USER_DEPRECATED);
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.3.0, use `\Redmine\Serializer\XmlSerializer::createFromArray()` instead.', E_USER_DEPRECATED);
 
         $_fields = $xml->addChild('custom_fields');
         $_fields->addAttribute('type', 'array');
@@ -324,7 +325,7 @@ abstract class AbstractApi implements Api
         }
 
         if (!is_array($returnData)) {
-            throw new SerializerException('Could not convert response body into array: '.$body);
+            throw new SerializerException('Could not convert response body into array: ' . $body);
         }
 
         return $returnData;

--- a/src/Redmine/Api/Attachment.php
+++ b/src/Redmine/Api/Attachment.php
@@ -24,7 +24,7 @@ class Attachment extends AbstractApi
      */
     public function show($id)
     {
-        return $this->get('/attachments/'.urlencode($id).'.json');
+        return $this->get('/attachments/' . urlencode($id) . '.json');
     }
 
     /**
@@ -36,7 +36,7 @@ class Attachment extends AbstractApi
      */
     public function download($id)
     {
-        return $this->get('/attachments/download/'.urlencode($id), false);
+        return $this->get('/attachments/download/' . urlencode($id), false);
     }
 
     /**
@@ -70,6 +70,6 @@ class Attachment extends AbstractApi
      */
     public function remove($id)
     {
-        return $this->delete('/attachments/'.$id.'.xml');
+        return $this->delete('/attachments/' . $id . '.xml');
     }
 }

--- a/src/Redmine/Api/CustomField.php
+++ b/src/Redmine/Api/CustomField.php
@@ -50,7 +50,7 @@ class CustomField extends AbstractApi
      */
     public function all(array $params = [])
     {
-        @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::list()` instead.', E_USER_DEPRECATED);
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.4.0, use `' . __CLASS__ . '::list()` instead.', E_USER_DEPRECATED);
 
         try {
             $this->customFields = $this->list($params);

--- a/src/Redmine/Api/Group.php
+++ b/src/Redmine/Api/Group.php
@@ -53,7 +53,7 @@ class Group extends AbstractApi
      */
     public function all(array $params = [])
     {
-        @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::list()` instead.', E_USER_DEPRECATED);
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.4.0, use `' . __CLASS__ . '::list()` instead.', E_USER_DEPRECATED);
 
         try {
             $this->groups = $this->list($params);
@@ -152,7 +152,7 @@ class Group extends AbstractApi
     public function show($id, array $params = [])
     {
         return $this->get(
-            PathSerializer::create('/groups/'.urlencode($id).'.json', $params)->getPath()
+            PathSerializer::create('/groups/' . urlencode($id) . '.json', $params)->getPath()
         );
     }
 
@@ -167,7 +167,7 @@ class Group extends AbstractApi
      */
     public function remove($id)
     {
-        return $this->delete('/groups/'.$id.'.xml');
+        return $this->delete('/groups/' . $id . '.xml');
     }
 
     /**
@@ -183,7 +183,7 @@ class Group extends AbstractApi
     public function addUser($id, $userId)
     {
         return $this->post(
-            '/groups/'.$id.'/users.xml',
+            '/groups/' . $id . '/users.xml',
             XmlSerializer::createFromArray(['user_id' => $userId])->getEncoded()
         );
     }
@@ -200,6 +200,6 @@ class Group extends AbstractApi
      */
     public function removeUser($id, $userId)
     {
-        return $this->delete('/groups/'.$id.'/users/'.$userId.'.xml');
+        return $this->delete('/groups/' . $id . '/users/' . $userId . '.xml');
     }
 }

--- a/src/Redmine/Api/Issue.php
+++ b/src/Redmine/Api/Issue.php
@@ -77,7 +77,7 @@ class Issue extends AbstractApi
      */
     public function all(array $params = [])
     {
-        @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::list()` instead.', E_USER_DEPRECATED);
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.4.0, use `' . __CLASS__ . '::list()` instead.', E_USER_DEPRECATED);
 
         try {
             return $this->list($params);
@@ -113,7 +113,7 @@ class Issue extends AbstractApi
         }
 
         return $this->get(
-            PathSerializer::create('/issues/'.urlencode($id).'.json', $params)->getPath()
+            PathSerializer::create('/issues/' . urlencode($id) . '.json', $params)->getPath()
         );
     }
 
@@ -185,7 +185,7 @@ class Issue extends AbstractApi
         }
 
         return $this->put(
-            '/issues/'.$id.'.xml',
+            '/issues/' . $id . '.xml',
             XmlSerializer::createFromArray(['issue' => $sanitizedParams])->getEncoded()
         );
     }
@@ -199,7 +199,7 @@ class Issue extends AbstractApi
     public function addWatcher($id, $watcherUserId)
     {
         return $this->post(
-            '/issues/'.$id.'/watchers.xml',
+            '/issues/' . $id . '/watchers.xml',
             XmlSerializer::createFromArray(['user_id' => $watcherUserId])->getEncoded()
         );
     }
@@ -212,7 +212,7 @@ class Issue extends AbstractApi
      */
     public function removeWatcher($id, $watcherUserId)
     {
-        return $this->delete('/issues/'.$id.'/watchers/'.$watcherUserId.'.xml');
+        return $this->delete('/issues/' . $id . '/watchers/' . $watcherUserId . '.xml');
     }
 
     /**
@@ -329,7 +329,7 @@ class Issue extends AbstractApi
         ];
 
         return $this->put(
-            '/issues/'.$id.'.json',
+            '/issues/' . $id . '.json',
             JsonSerializer::createFromArray(['issue' => $params])->getEncoded()
         );
     }
@@ -343,6 +343,6 @@ class Issue extends AbstractApi
      */
     public function remove($id)
     {
-        return $this->delete('/issues/'.$id.'.xml');
+        return $this->delete('/issues/' . $id . '.xml');
     }
 }

--- a/src/Redmine/Api/IssueCategory.php
+++ b/src/Redmine/Api/IssueCategory.php
@@ -44,7 +44,7 @@ class IssueCategory extends AbstractApi
         }
 
         try {
-            return $this->retrieveData('/projects/'.strval($projectIdentifier).'/issue_categories.json', $params);
+            return $this->retrieveData('/projects/' . strval($projectIdentifier) . '/issue_categories.json', $params);
         } catch (SerializerException $th) {
             throw new UnexpectedResponseException('The Redmine server responded with an unexpected body.', $th->getCode(), $th);
         }
@@ -64,7 +64,7 @@ class IssueCategory extends AbstractApi
      */
     public function all($project, array $params = [])
     {
-        @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::listByProject()` instead.', E_USER_DEPRECATED);
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.4.0, use `' . __CLASS__ . '::listByProject()` instead.', E_USER_DEPRECATED);
 
         try {
             return $this->listByProject(strval($project), $params);
@@ -131,7 +131,7 @@ class IssueCategory extends AbstractApi
      */
     public function show($id)
     {
-        return $this->get('/issue_categories/'.urlencode($id).'.json');
+        return $this->get('/issue_categories/' . urlencode($id) . '.json');
     }
 
     /**
@@ -161,7 +161,7 @@ class IssueCategory extends AbstractApi
         }
 
         return $this->post(
-            '/projects/'.$project.'/issue_categories.xml',
+            '/projects/' . $project . '/issue_categories.xml',
             XmlSerializer::createFromArray(['issue_category' => $params])->getEncoded()
         );
     }
@@ -184,7 +184,7 @@ class IssueCategory extends AbstractApi
         $params = $this->sanitizeParams($defaults, $params);
 
         return $this->put(
-            '/issue_categories/'.$id.'.xml',
+            '/issue_categories/' . $id . '.xml',
             XmlSerializer::createFromArray(['issue_category' => $params])->getEncoded()
         );
     }
@@ -204,7 +204,7 @@ class IssueCategory extends AbstractApi
     public function remove($id, array $params = [])
     {
         return $this->delete(
-            PathSerializer::create('/issue_categories/'.$id.'.xml', $params)->getPath()
+            PathSerializer::create('/issue_categories/' . $id . '.xml', $params)->getPath()
         );
     }
 }

--- a/src/Redmine/Api/IssuePriority.php
+++ b/src/Redmine/Api/IssuePriority.php
@@ -50,7 +50,7 @@ class IssuePriority extends AbstractApi
      */
     public function all(array $params = [])
     {
-        @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::list()` instead.', E_USER_DEPRECATED);
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.4.0, use `' . __CLASS__ . '::list()` instead.', E_USER_DEPRECATED);
 
         try {
             $this->issuePriorities = $this->list($params);

--- a/src/Redmine/Api/IssueRelation.php
+++ b/src/Redmine/Api/IssueRelation.php
@@ -33,7 +33,7 @@ class IssueRelation extends AbstractApi
     final public function listByIssueId(int $issueId, array $params = []): array
     {
         try {
-            return $this->retrieveData('/issues/'.strval($issueId).'/relations.json', $params);
+            return $this->retrieveData('/issues/' . strval($issueId) . '/relations.json', $params);
         } catch (SerializerException $th) {
             throw new UnexpectedResponseException('The Redmine server responded with an unexpected body.', $th->getCode(), $th);
         }
@@ -53,7 +53,7 @@ class IssueRelation extends AbstractApi
      */
     public function all($issueId, array $params = [])
     {
-        @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::listByIssueId()` instead.', E_USER_DEPRECATED);
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.4.0, use `' . __CLASS__ . '::listByIssueId()` instead.', E_USER_DEPRECATED);
 
         try {
             $this->relations = $this->listByIssueId($issueId, $params);
@@ -83,7 +83,7 @@ class IssueRelation extends AbstractApi
      */
     public function show($id)
     {
-        $ret = $this->get('/relations/'.urlencode($id).'.json');
+        $ret = $this->get('/relations/' . urlencode($id) . '.json');
         if (false === $ret) {
             return [];
         }
@@ -102,7 +102,7 @@ class IssueRelation extends AbstractApi
      */
     public function remove($id)
     {
-        return $this->delete('/relations/'.$id.'.xml');
+        return $this->delete('/relations/' . $id . '.xml');
     }
 
     /**
@@ -126,7 +126,7 @@ class IssueRelation extends AbstractApi
         $params = $this->sanitizeParams($defaults, $params);
 
         $response = $this->post(
-            '/issues/'.urlencode($issueId).'/relations.json',
+            '/issues/' . urlencode($issueId) . '/relations.json',
             JsonSerializer::createFromArray(['relation' => $params])->getEncoded()
         );
 

--- a/src/Redmine/Api/IssueStatus.php
+++ b/src/Redmine/Api/IssueStatus.php
@@ -50,7 +50,7 @@ class IssueStatus extends AbstractApi
      */
     public function all(array $params = [])
     {
-        @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::list()` instead.', E_USER_DEPRECATED);
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.4.0, use `' . __CLASS__ . '::list()` instead.', E_USER_DEPRECATED);
 
         try {
             $this->issueStatuses = $this->list($params);

--- a/src/Redmine/Api/Membership.php
+++ b/src/Redmine/Api/Membership.php
@@ -43,7 +43,7 @@ class Membership extends AbstractApi
         }
 
         try {
-            return $this->retrieveData('/projects/'.strval($projectIdentifier).'/memberships.json', $params);
+            return $this->retrieveData('/projects/' . strval($projectIdentifier) . '/memberships.json', $params);
         } catch (SerializerException $th) {
             throw new UnexpectedResponseException('The Redmine server responded with an unexpected body.', $th->getCode(), $th);
         }
@@ -63,7 +63,7 @@ class Membership extends AbstractApi
      */
     public function all($project, array $params = [])
     {
-        @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::listByProject()` instead.', E_USER_DEPRECATED);
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.4.0, use `' . __CLASS__ . '::listByProject()` instead.', E_USER_DEPRECATED);
 
         try {
             $this->memberships = $this->listByProject(strval($project), $params);
@@ -107,7 +107,7 @@ class Membership extends AbstractApi
         }
 
         return $this->post(
-            '/projects/'.$project.'/memberships.xml',
+            '/projects/' . $project . '/memberships.xml',
             XmlSerializer::createFromArray(['membership' => $params])->getEncoded()
         );
     }
@@ -136,7 +136,7 @@ class Membership extends AbstractApi
         }
 
         return $this->put(
-            '/memberships/'.$id.'.xml',
+            '/memberships/' . $id . '.xml',
             XmlSerializer::createFromArray(['membership' => $params])->getEncoded()
         );
     }
@@ -152,7 +152,7 @@ class Membership extends AbstractApi
      */
     public function remove($id)
     {
-        return $this->delete('/memberships/'.$id.'.xml');
+        return $this->delete('/memberships/' . $id . '.xml');
     }
 
     /**

--- a/src/Redmine/Api/News.php
+++ b/src/Redmine/Api/News.php
@@ -39,7 +39,7 @@ class News extends AbstractApi
         }
 
         try {
-            return $this->retrieveData('/projects/'.strval($projectIdentifier).'/news.json', $params);
+            return $this->retrieveData('/projects/' . strval($projectIdentifier) . '/news.json', $params);
         } catch (SerializerException $th) {
             throw new UnexpectedResponseException('The Redmine server responded with an unexpected body.', $th->getCode(), $th);
         }
@@ -79,7 +79,7 @@ class News extends AbstractApi
      */
     public function all($project = null, array $params = [])
     {
-        @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::list()` or `'.__CLASS__.'::listByProject()` instead.', E_USER_DEPRECATED);
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.4.0, use `' . __CLASS__ . '::list()` or `' . __CLASS__ . '::listByProject()` instead.', E_USER_DEPRECATED);
 
         try {
             if (null === $project) {

--- a/src/Redmine/Api/Project.php
+++ b/src/Redmine/Api/Project.php
@@ -53,7 +53,7 @@ class Project extends AbstractApi
      */
     public function all(array $params = [])
     {
-        @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::list()` instead.', E_USER_DEPRECATED);
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.4.0, use `' . __CLASS__ . '::list()` instead.', E_USER_DEPRECATED);
 
         try {
             $this->projects = $this->list($params);
@@ -132,7 +132,7 @@ class Project extends AbstractApi
         }
 
         return $this->get(
-            PathSerializer::create('/projects/'.urlencode($id).'.json', $params)->getPath()
+            PathSerializer::create('/projects/' . urlencode($id) . '.json', $params)->getPath()
         );
     }
 
@@ -189,7 +189,7 @@ class Project extends AbstractApi
         $params = $this->sanitizeParams($defaults, $params);
 
         return $this->put(
-            '/projects/'.$id.'.xml',
+            '/projects/' . $id . '.xml',
             XmlSerializer::createFromArray(['project' => $params])->getEncoded()
         );
     }
@@ -203,7 +203,7 @@ class Project extends AbstractApi
      */
     protected function prepareParamsXml($params)
     {
-        @trigger_error('`'.__METHOD__.'()` is deprecated since v2.3.0, use `\Redmine\Serializer\XmlSerializer::createFromArray()` instead.', E_USER_DEPRECATED);
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.3.0, use `\Redmine\Serializer\XmlSerializer::createFromArray()` instead.', E_USER_DEPRECATED);
 
         return new \SimpleXMLElement(
             XmlSerializer::createFromArray(['project' => $params])->getEncoded()
@@ -221,6 +221,6 @@ class Project extends AbstractApi
      */
     public function remove($id)
     {
-        return $this->delete('/projects/'.$id.'.xml');
+        return $this->delete('/projects/' . $id . '.xml');
     }
 }

--- a/src/Redmine/Api/Query.php
+++ b/src/Redmine/Api/Query.php
@@ -50,7 +50,7 @@ class Query extends AbstractApi
      */
     public function all(array $params = [])
     {
-        @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::list()` instead.', E_USER_DEPRECATED);
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.4.0, use `' . __CLASS__ . '::list()` instead.', E_USER_DEPRECATED);
 
         try {
             $this->query = $this->list($params);

--- a/src/Redmine/Api/Role.php
+++ b/src/Redmine/Api/Role.php
@@ -50,7 +50,7 @@ class Role extends AbstractApi
      */
     public function all(array $params = [])
     {
-        @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::list()` instead.', E_USER_DEPRECATED);
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.4.0, use `' . __CLASS__ . '::list()` instead.', E_USER_DEPRECATED);
 
         try {
             $this->roles = $this->list($params);
@@ -100,6 +100,6 @@ class Role extends AbstractApi
      */
     public function show($id)
     {
-        return $this->get('/roles/'.urlencode($id).'.json');
+        return $this->get('/roles/' . urlencode($id) . '.json');
     }
 }

--- a/src/Redmine/Api/Search.php
+++ b/src/Redmine/Api/Search.php
@@ -50,7 +50,7 @@ class Search extends AbstractApi
      */
     public function search($query, array $params = [])
     {
-        @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::listByQuery()` instead.', E_USER_DEPRECATED);
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.4.0, use `' . __CLASS__ . '::listByQuery()` instead.', E_USER_DEPRECATED);
 
         try {
             $this->results = $this->listByQuery($query, $params);

--- a/src/Redmine/Api/TimeEntry.php
+++ b/src/Redmine/Api/TimeEntry.php
@@ -52,7 +52,7 @@ class TimeEntry extends AbstractApi
      */
     public function all(array $params = [])
     {
-        @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::list()` instead.', E_USER_DEPRECATED);
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.4.0, use `' . __CLASS__ . '::list()` instead.', E_USER_DEPRECATED);
 
         try {
             $this->timeEntries = $this->list($params);
@@ -82,7 +82,7 @@ class TimeEntry extends AbstractApi
      */
     public function show($id)
     {
-        return $this->get('/time_entries/'.urlencode($id).'.json');
+        return $this->get('/time_entries/' . urlencode($id) . '.json');
     }
 
     /**
@@ -144,7 +144,7 @@ class TimeEntry extends AbstractApi
         $params = $this->sanitizeParams($defaults, $params);
 
         return $this->put(
-            '/time_entries/'.$id.'.xml',
+            '/time_entries/' . $id . '.xml',
             XmlSerializer::createFromArray(['time_entry' => $params])->getEncoded()
         );
     }
@@ -160,6 +160,6 @@ class TimeEntry extends AbstractApi
      */
     public function remove($id)
     {
-        return $this->delete('/time_entries/'.$id.'.xml');
+        return $this->delete('/time_entries/' . $id . '.xml');
     }
 }

--- a/src/Redmine/Api/TimeEntryActivity.php
+++ b/src/Redmine/Api/TimeEntryActivity.php
@@ -46,7 +46,7 @@ class TimeEntryActivity extends AbstractApi
      */
     public function all(array $params = [])
     {
-        @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::list()` instead.', E_USER_DEPRECATED);
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.4.0, use `' . __CLASS__ . '::list()` instead.', E_USER_DEPRECATED);
 
         try {
             $this->timeEntryActivities = $this->list($params);

--- a/src/Redmine/Api/Tracker.php
+++ b/src/Redmine/Api/Tracker.php
@@ -50,7 +50,7 @@ class Tracker extends AbstractApi
      */
     public function all(array $params = [])
     {
-        @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::list()` instead.', E_USER_DEPRECATED);
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.4.0, use `' . __CLASS__ . '::list()` instead.', E_USER_DEPRECATED);
 
         try {
             $this->trackers = $this->list($params);

--- a/src/Redmine/Api/User.php
+++ b/src/Redmine/Api/User.php
@@ -53,7 +53,7 @@ class User extends AbstractApi
      */
     public function all(array $params = [])
     {
-        @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::list()` instead.', E_USER_DEPRECATED);
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.4.0, use `' . __CLASS__ . '::list()` instead.', E_USER_DEPRECATED);
 
         try {
             $this->users = $this->list($params);
@@ -159,7 +159,7 @@ class User extends AbstractApi
         $params['include'] = implode(',', $params['include']);
 
         return $this->get(
-            PathSerializer::create('/users/'.urlencode($id).'.json', $params)->getPath()
+            PathSerializer::create('/users/' . urlencode($id) . '.json', $params)->getPath()
         );
     }
 
@@ -222,7 +222,7 @@ class User extends AbstractApi
         $params = $this->sanitizeParams($defaults, $params);
 
         return $this->put(
-            '/users/'.$id.'.xml',
+            '/users/' . $id . '.xml',
             XmlSerializer::createFromArray(['user' => $params])->getEncoded()
         );
     }
@@ -238,6 +238,6 @@ class User extends AbstractApi
      */
     public function remove($id)
     {
-        return $this->delete('/users/'.$id.'.xml');
+        return $this->delete('/users/' . $id . '.xml');
     }
 }

--- a/src/Redmine/Api/Version.php
+++ b/src/Redmine/Api/Version.php
@@ -42,7 +42,7 @@ class Version extends AbstractApi
         }
 
         try {
-            return $this->retrieveData('/projects/'.strval($projectIdentifier).'/versions.json', $params);
+            return $this->retrieveData('/projects/' . strval($projectIdentifier) . '/versions.json', $params);
         } catch (SerializerException $th) {
             throw new UnexpectedResponseException('The Redmine server responded with an unexpected body.', $th->getCode(), $th);
         }
@@ -62,7 +62,7 @@ class Version extends AbstractApi
      */
     public function all($project, array $params = [])
     {
-        @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::listByProject()` instead.', E_USER_DEPRECATED);
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.4.0, use `' . __CLASS__ . '::listByProject()` instead.', E_USER_DEPRECATED);
 
         try {
             $this->versions = $this->listByProject(strval($project), $params);
@@ -134,7 +134,7 @@ class Version extends AbstractApi
      */
     public function show($id)
     {
-        return $this->get('/versions/'.urlencode($id).'.json');
+        return $this->get('/versions/' . urlencode($id) . '.json');
     }
 
     /**
@@ -169,7 +169,7 @@ class Version extends AbstractApi
         $this->validateSharing($params);
 
         return $this->post(
-            '/projects/'.$project.'/versions.xml',
+            '/projects/' . $project . '/versions.xml',
             XmlSerializer::createFromArray(['version' => $params])->getEncoded()
         );
     }
@@ -197,7 +197,7 @@ class Version extends AbstractApi
         $this->validateSharing($params);
 
         return $this->put(
-            '/versions/'.$id.'.xml',
+            '/versions/' . $id . '.xml',
             XmlSerializer::createFromArray(['version' => $params])->getEncoded()
         );
     }
@@ -210,7 +210,7 @@ class Version extends AbstractApi
             'closed',
         ];
         if (isset($params['status']) && !in_array($params['status'], $arrStatus)) {
-            throw new InvalidParameterException('Possible values for status : '.implode(', ', $arrStatus));
+            throw new InvalidParameterException('Possible values for status : ' . implode(', ', $arrStatus));
         }
     }
 
@@ -224,7 +224,7 @@ class Version extends AbstractApi
             'system' => 'With all projects',
         ];
         if (isset($params['sharing']) && !isset($arrSharing[$params['sharing']])) {
-            throw new InvalidParameterException('Possible values for sharing : '.implode(', ', array_keys($arrSharing)));
+            throw new InvalidParameterException('Possible values for sharing : ' . implode(', ', array_keys($arrSharing)));
         }
     }
 
@@ -239,6 +239,6 @@ class Version extends AbstractApi
      */
     public function remove($id)
     {
-        return $this->delete('/versions/'.$id.'.xml');
+        return $this->delete('/versions/' . $id . '.xml');
     }
 }

--- a/src/Redmine/Api/Wiki.php
+++ b/src/Redmine/Api/Wiki.php
@@ -42,7 +42,7 @@ class Wiki extends AbstractApi
         }
 
         try {
-            return $this->retrieveData('/projects/'.strval($projectIdentifier).'/wiki/index.json', $params);
+            return $this->retrieveData('/projects/' . strval($projectIdentifier) . '/wiki/index.json', $params);
         } catch (SerializerException $th) {
             throw new UnexpectedResponseException('The Redmine server responded with an unexpected body.', $th->getCode(), $th);
         }
@@ -62,7 +62,7 @@ class Wiki extends AbstractApi
      */
     public function all($project, array $params = [])
     {
-        @trigger_error('`'.__METHOD__.'()` is deprecated since v2.4.0, use `'.__CLASS__.'::listByProject()` instead.', E_USER_DEPRECATED);
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.4.0, use `' . __CLASS__ . '::listByProject()` instead.', E_USER_DEPRECATED);
 
         try {
             $this->wikiPages = $this->listByProject(strval($project), $params);
@@ -100,9 +100,9 @@ class Wiki extends AbstractApi
         ];
 
         if (null === $version) {
-            $path = '/projects/'.$project.'/wiki/'.$page.'.json';
+            $path = '/projects/' . $project . '/wiki/' . $page . '.json';
         } else {
-            $path = '/projects/'.$project.'/wiki/'.$page.'/'.$version.'.json';
+            $path = '/projects/' . $project . '/wiki/' . $page . '/' . $version . '.json';
         }
 
         return $this->get(
@@ -129,7 +129,7 @@ class Wiki extends AbstractApi
         $params = $this->sanitizeParams($defaults, $params);
 
         return $this->put(
-            '/projects/'.$project.'/wiki/'.$page.'.xml',
+            '/projects/' . $project . '/wiki/' . $page . '.xml',
             XmlSerializer::createFromArray(['wiki_page' => $params])->getEncoded()
         );
     }
@@ -160,6 +160,6 @@ class Wiki extends AbstractApi
      */
     public function remove($project, $page)
     {
-        return $this->delete('/projects/'.$project.'/wiki/'.$page.'.xml');
+        return $this->delete('/projects/' . $project . '/wiki/' . $page . '.xml');
     }
 }

--- a/src/Redmine/Client/ClientApiTrait.php
+++ b/src/Redmine/Client/ClientApiTrait.php
@@ -48,7 +48,7 @@ trait ClientApiTrait
         if (isset($this->apiInstances[$name])) {
             return $this->apiInstances[$name];
         }
-        $class = 'Redmine\Api\\'.$this->apiClassnames[$name];
+        $class = 'Redmine\Api\\' . $this->apiClassnames[$name];
         $this->apiInstances[$name] = new $class($this);
 
         return $this->apiInstances[$name];

--- a/src/Redmine/Client/NativeCurlClient.php
+++ b/src/Redmine/Client/NativeCurlClient.php
@@ -261,7 +261,7 @@ final class NativeCurlClient implements Client
         $curlOptions = array_replace($curlOptions, $this->curlOptions);
 
         // Host and request options
-        $curlOptions[CURLOPT_URL] = $this->url.$path;
+        $curlOptions[CURLOPT_URL] = $this->url . $path;
 
         // Set the HTTP request headers
         $curlOptions[CURLOPT_HTTPHEADER] = $this->createHttpHeader($path);
@@ -323,19 +323,19 @@ final class NativeCurlClient implements Client
 
         // Redmine specific headers
         if (null !== $this->impersonateUser && !array_key_exists(strtolower('X-Redmine-Switch-User'), $this->httpHeadersNames)) {
-            $httpHeaders[] = 'X-Redmine-Switch-User: '.$this->impersonateUser;
+            $httpHeaders[] = 'X-Redmine-Switch-User: ' . $this->impersonateUser;
         }
 
         // Set Authentication header
         // @see https://www.redmine.org/projects/redmine/wiki/Rest_api#Authentication
         if (null === $this->password && !array_key_exists(strtolower('X-Redmine-API-Key'), $this->httpHeadersNames)) {
-            $httpHeaders[] = 'X-Redmine-API-Key: '.$this->apikeyOrUsername;
+            $httpHeaders[] = 'X-Redmine-API-Key: ' . $this->apikeyOrUsername;
         } else {
             if (!array_key_exists(strtolower('Authorization'), $this->httpHeadersNames)) {
                 // Setting Header "Authorization: Basic base64" is the same as
                 // $this->setCurlOption(CURLOPT_USERPWD, "$username:$password")
                 // @see https://stackoverflow.com/a/26285941
-                $httpHeaders[] = 'Authorization: Basic '.base64_encode($this->apikeyOrUsername.':'.$this->password);
+                $httpHeaders[] = 'Authorization: Basic ' . base64_encode($this->apikeyOrUsername . ':' . $this->password);
             }
         }
 
@@ -343,7 +343,7 @@ final class NativeCurlClient implements Client
         $customHttpHeaders = [];
 
         foreach ($this->httpHeaders as $headerName => $headerValue) {
-            $customHttpHeaders[] = $headerName.': '.$headerValue;
+            $customHttpHeaders[] = $headerName . ': ' . $headerValue;
         }
 
         // Merge custom headers
@@ -352,7 +352,7 @@ final class NativeCurlClient implements Client
         // Now set or reset mandatory headers
 
         // Content type headers
-        $tmp = parse_url($this->url.$path);
+        $tmp = parse_url($this->url . $path);
 
         if ($this->isUploadCall($path)) {
             $httpHeaders[] = 'Content-Type: application/octet-stream';

--- a/src/Redmine/Client/Psr18Client.php
+++ b/src/Redmine/Client/Psr18Client.php
@@ -7,9 +7,9 @@ namespace Redmine\Client;
 use Exception;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
-use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Redmine\Exception\ClientException;
@@ -184,7 +184,7 @@ final class Psr18Client implements Client
     {
         $request = $this->requestFactory->createRequest(
             $method,
-            $this->url.$path
+            $this->url . $path
         );
 
         // Set Authentication header
@@ -192,7 +192,7 @@ final class Psr18Client implements Client
         if (null !== $this->password) {
             $request = $request->withHeader(
                 'Authorization',
-                'Basic '.base64_encode($this->apikeyOrUsername.':'.$this->password)
+                'Basic ' . base64_encode($this->apikeyOrUsername . ':' . $this->password)
             );
         } else {
             $request = $request->withHeader('X-Redmine-API-Key', $this->apikeyOrUsername);
@@ -228,7 +228,7 @@ final class Psr18Client implements Client
         }
 
         // set Content-Type header
-        $tmp = parse_url($this->url.$path);
+        $tmp = parse_url($this->url . $path);
 
         if ($this->isUploadCall($path)) {
             $request = $request->withHeader('Content-Type', 'application/octet-stream');
@@ -246,8 +246,7 @@ final class Psr18Client implements Client
      */
     private function handleServerRequestFactory(ServerRequestFactoryInterface $factory): RequestFactoryInterface
     {
-        return new class($factory) implements RequestFactoryInterface
-        {
+        return new class ($factory) implements RequestFactoryInterface {
             private ServerRequestFactoryInterface $factory;
 
             public function __construct(ServerRequestFactoryInterface $factory)

--- a/src/Redmine/Exception.php
+++ b/src/Redmine/Exception.php
@@ -4,6 +4,4 @@ namespace Redmine;
 
 use Throwable;
 
-interface Exception extends Throwable
-{
-}
+interface Exception extends Throwable {}

--- a/src/Redmine/Exception/ClientException.php
+++ b/src/Redmine/Exception/ClientException.php
@@ -5,6 +5,4 @@ namespace Redmine\Exception;
 use Exception;
 use Redmine\Exception as RedmineException;
 
-class ClientException extends Exception implements RedmineException
-{
-}
+class ClientException extends Exception implements RedmineException {}

--- a/src/Redmine/Exception/InvalidApiNameException.php
+++ b/src/Redmine/Exception/InvalidApiNameException.php
@@ -5,6 +5,4 @@ namespace Redmine\Exception;
 use InvalidArgumentException;
 use Redmine\Exception as RedmineException;
 
-class InvalidApiNameException extends InvalidArgumentException implements RedmineException
-{
-}
+class InvalidApiNameException extends InvalidArgumentException implements RedmineException {}

--- a/src/Redmine/Exception/InvalidParameterException.php
+++ b/src/Redmine/Exception/InvalidParameterException.php
@@ -5,6 +5,4 @@ namespace Redmine\Exception;
 use InvalidArgumentException;
 use Redmine\Exception as RedmineException;
 
-class InvalidParameterException extends InvalidArgumentException implements RedmineException
-{
-}
+class InvalidParameterException extends InvalidArgumentException implements RedmineException {}

--- a/src/Redmine/Exception/MissingParameterException.php
+++ b/src/Redmine/Exception/MissingParameterException.php
@@ -5,6 +5,4 @@ namespace Redmine\Exception;
 use InvalidArgumentException;
 use Redmine\Exception as RedmineException;
 
-class MissingParameterException extends InvalidArgumentException implements RedmineException
-{
-}
+class MissingParameterException extends InvalidArgumentException implements RedmineException {}

--- a/src/Redmine/Exception/SerializerException.php
+++ b/src/Redmine/Exception/SerializerException.php
@@ -5,6 +5,4 @@ namespace Redmine\Exception;
 use Redmine\Exception as RedmineException;
 use RuntimeException;
 
-class SerializerException extends RuntimeException implements RedmineException
-{
-}
+class SerializerException extends RuntimeException implements RedmineException {}

--- a/src/Redmine/Exception/UnexpectedResponseException.php
+++ b/src/Redmine/Exception/UnexpectedResponseException.php
@@ -14,6 +14,4 @@ use RuntimeException;
  * - Redmine\Client\Client::getLastResponseContentType()
  * - Redmine\Client\Client::getLastResponseBody()
  */
-final class UnexpectedResponseException extends RuntimeException implements RedmineException
-{
-}
+final class UnexpectedResponseException extends RuntimeException implements RedmineException {}

--- a/src/Redmine/Serializer/JsonSerializer.php
+++ b/src/Redmine/Serializer/JsonSerializer.php
@@ -73,7 +73,7 @@ final class JsonSerializer implements Stringable
                 \JSON_THROW_ON_ERROR
             );
         } catch (JsonException $e) {
-            throw new SerializerException('Catched error "'.$e->getMessage().'" while decoding JSON: '.$encoded, $e->getCode(), $e);
+            throw new SerializerException('Catched error "' . $e->getMessage() . '" while decoding JSON: ' . $encoded, $e->getCode(), $e);
         }
     }
 

--- a/src/Redmine/Serializer/PathSerializer.php
+++ b/src/Redmine/Serializer/PathSerializer.php
@@ -32,13 +32,13 @@ final class PathSerializer implements Stringable
         $queryString = '';
 
         if (!empty($this->queryParams)) {
-            $queryString = '?'.\http_build_query($this->queryParams);
+            $queryString = '?' . \http_build_query($this->queryParams);
 
             // @see #154: replace every encoded array (`foo[0]=`, `foo[1]=`, etc with `foo[]=`)
             $queryString = preg_replace('/%5B[0-9]+%5D/simU', '%5B%5D', $queryString);
         }
 
-        return $this->path.$queryString;
+        return $this->path . $queryString;
     }
 
     public function __toString(): string

--- a/src/Redmine/Serializer/XmlSerializer.php
+++ b/src/Redmine/Serializer/XmlSerializer.php
@@ -99,7 +99,7 @@ final class XmlSerializer implements Stringable
         try {
             $serialized = json_encode($deserialized, \JSON_THROW_ON_ERROR);
         } catch (JsonException $e) {
-            throw new SerializerException('Catched error "'.$e->getMessage().'" while encoding SimpleXMLElement', $e->getCode(), $e);
+            throw new SerializerException('Catched error "' . $e->getMessage() . '" while encoding SimpleXMLElement', $e->getCode(), $e);
         }
 
         $this->normalized = JsonSerializer::createFromString($serialized)->getNormalized();
@@ -143,7 +143,7 @@ final class XmlSerializer implements Stringable
             $value = $params;
         }
 
-        $xml = new SimpleXMLElement('<?xml version="1.0"?><'.$rootElementName.'>'.$value.'</'.$rootElementName.'>');
+        $xml = new SimpleXMLElement('<?xml version="1.0"?><' . $rootElementName . '>' . $value . '</' . $rootElementName . '>');
 
         if (is_array($params)) {
             foreach ($params as $k => $v) {

--- a/tests/Fixtures/MockClient.php
+++ b/tests/Fixtures/MockClient.php
@@ -39,8 +39,7 @@ final class MockClient implements Client
     public $responseCodeMock;
     public $responseContentTypeMock;
 
-    private function __construct() {
-    }
+    private function __construct() {}
 
     /**
      * Sets to an existing username so api calls can be

--- a/tests/Integration/Psr18ClientRequestGenerationTest.php
+++ b/tests/Integration/Psr18ClientRequestGenerationTest.php
@@ -8,8 +8,8 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Utils;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Client\ClientInterface;
-use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Redmine\Client\Psr18Client;
@@ -23,8 +23,13 @@ class Psr18ClientRequestGenerationTest extends TestCase
      * @dataProvider createdGetRequestsData
      */
     public function testPsr18ClientCreatesCorrectRequests(
-        string $url, string $apikeyOrUsername, $pwd, $impersonateUser,
-        string $method, string $path, $data,
+        string $url,
+        string $apikeyOrUsername,
+        $pwd,
+        $impersonateUser,
+        string $method,
+        string $path,
+        $data,
         $expectedOutput
     ) {
         $response = $this->createMock(ResponseInterface::class);
@@ -38,16 +43,18 @@ class Psr18ClientRequestGenerationTest extends TestCase
                 $headers = '';
 
                 foreach ($request->getHeaders() as $k => $v) {
-                    $headers .= $k.': '.$request->getHeaderLine($k).\PHP_EOL;
+                    $headers .= $k . ': ' . $request->getHeaderLine($k) . \PHP_EOL;
                 }
 
-                $fullRequest = sprintf(
-                        '%s %s HTTP/%s',
-                        $request->getMethod(),
-                        $request->getUri()->__toString(),
-                        $request->getProtocolVersion()
-                    ).\PHP_EOL.
-                    $headers.\PHP_EOL.
+                $statusLine = sprintf(
+                    '%s %s HTTP/%s',
+                    $request->getMethod(),
+                    $request->getUri()->__toString(),
+                    $request->getProtocolVersion()
+                );
+
+                $fullRequest = $statusLine . \PHP_EOL .
+                    $headers . \PHP_EOL .
                     $content
                 ;
 
@@ -64,7 +71,7 @@ class Psr18ClientRequestGenerationTest extends TestCase
             })
         );
 
-        $streamFactory = new class() implements StreamFactoryInterface {
+        $streamFactory = new class () implements StreamFactoryInterface {
             public function createStream(string $content = ''): StreamInterface
             {
                 return Utils::streamFor($content);
@@ -103,98 +110,98 @@ class Psr18ClientRequestGenerationTest extends TestCase
             'Test username/password in auth header' => [
                 'http://test.local', 'username', 'password', null,
                 'requestGet', '/path', null,
-                'GET http://test.local/path HTTP/1.1'.\PHP_EOL.
-                'Host: test.local'.\PHP_EOL.
-                'Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ='.\PHP_EOL.
+                'GET http://test.local/path HTTP/1.1' . \PHP_EOL .
+                'Host: test.local' . \PHP_EOL .
+                'Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=' . \PHP_EOL .
                 \PHP_EOL,
             ],
             'Test access token in X-Redmine-API-Key header' => [
                 'http://test.local', 'access_token', null, null,
                 'requestGet', '/path', null,
-                'GET http://test.local/path HTTP/1.1'.\PHP_EOL.
-                'Host: test.local'.\PHP_EOL.
-                'X-Redmine-API-Key: access_token'.\PHP_EOL.
+                'GET http://test.local/path HTTP/1.1' . \PHP_EOL .
+                'Host: test.local' . \PHP_EOL .
+                'X-Redmine-API-Key: access_token' . \PHP_EOL .
                 \PHP_EOL,
             ],
             'Test user impersonate in X-Redmine-Switch-User header' => [
                 'http://test.local', 'access_token', null, 'Robin',
                 'requestGet', '/path', null,
-                'GET http://test.local/path HTTP/1.1'.\PHP_EOL.
-                'Host: test.local'.\PHP_EOL.
-                'X-Redmine-API-Key: access_token'.\PHP_EOL.
-                'X-Redmine-Switch-User: Robin'.\PHP_EOL.
+                'GET http://test.local/path HTTP/1.1' . \PHP_EOL .
+                'Host: test.local' . \PHP_EOL .
+                'X-Redmine-API-Key: access_token' . \PHP_EOL .
+                'X-Redmine-Switch-User: Robin' . \PHP_EOL .
                 \PHP_EOL,
             ],
             'Test POST' => [
                 'http://test.local', 'access_token', null, null,
                 'requestPost', '/path.json', '{"foo":"bar"}',
-                'POST http://test.local/path.json HTTP/1.1'.\PHP_EOL.
-                'Host: test.local'.\PHP_EOL.
-                'X-Redmine-API-Key: access_token'.\PHP_EOL.
-                'Content-Type: application/json'.\PHP_EOL.
-                \PHP_EOL.
+                'POST http://test.local/path.json HTTP/1.1' . \PHP_EOL .
+                'Host: test.local' . \PHP_EOL .
+                'X-Redmine-API-Key: access_token' . \PHP_EOL .
+                'Content-Type: application/json' . \PHP_EOL .
+                \PHP_EOL .
                 '{"foo":"bar"}',
             ],
             'Test fileupload with file content' => [
                 // @see https://www.redmine.org/projects/redmine/wiki/Rest_api#Attaching-files
                 'http://test.local', 'access_token', null, null,
                 'requestPost', '/uploads.json?filename=textfile.md', 'The content of the file',
-                'POST http://test.local/uploads.json?filename=textfile.md HTTP/1.1'.\PHP_EOL.
-                'Host: test.local'.\PHP_EOL.
-                'X-Redmine-API-Key: access_token'.\PHP_EOL.
-                'Content-Type: application/octet-stream'.\PHP_EOL.
-                \PHP_EOL.
+                'POST http://test.local/uploads.json?filename=textfile.md HTTP/1.1' . \PHP_EOL .
+                'Host: test.local' . \PHP_EOL .
+                'X-Redmine-API-Key: access_token' . \PHP_EOL .
+                'Content-Type: application/octet-stream' . \PHP_EOL .
+                \PHP_EOL .
                 'The content of the file',
             ],
             'Test fileupload with file path' => [
                 // @see https://www.redmine.org/projects/redmine/wiki/Rest_api#Attaching-files
                 'http://test.local', 'access_token', null, null,
-                'requestPost', '/uploads.json?filename=textfile.md', realpath(__DIR__.'/../Fixtures/testfile_01.txt'),
-                'POST http://test.local/uploads.json?filename=textfile.md HTTP/1.1'.\PHP_EOL.
-                'Host: test.local'.\PHP_EOL.
-                'X-Redmine-API-Key: access_token'.\PHP_EOL.
-                'Content-Type: application/octet-stream'.\PHP_EOL.
-                \PHP_EOL.
-                'This is a test file.'."\n".
-                'It will be needed for testing file uploads.'."\n",
+                'requestPost', '/uploads.json?filename=textfile.md', realpath(__DIR__ . '/../Fixtures/testfile_01.txt'),
+                'POST http://test.local/uploads.json?filename=textfile.md HTTP/1.1' . \PHP_EOL .
+                'Host: test.local' . \PHP_EOL .
+                'X-Redmine-API-Key: access_token' . \PHP_EOL .
+                'Content-Type: application/octet-stream' . \PHP_EOL .
+                \PHP_EOL .
+                'This is a test file.' . "\n" .
+                'It will be needed for testing file uploads.' . "\n",
             ],
             'Test fileupload with file path to image' => [
                 // @see https://www.redmine.org/projects/redmine/wiki/Rest_api#Attaching-files
                 'http://test.local', 'access_token', null, null,
-                'requestPost', '/uploads.json?filename=1x1.png', realpath(__DIR__.'/../Fixtures/FF4D00-1.png'),
-                'POST http://test.local/uploads.json?filename=1x1.png HTTP/1.1'.\PHP_EOL.
-                'Host: test.local'.\PHP_EOL.
-                'X-Redmine-API-Key: access_token'.\PHP_EOL.
-                'Content-Type: application/octet-stream'.\PHP_EOL.
-                \PHP_EOL.
+                'requestPost', '/uploads.json?filename=1x1.png', realpath(__DIR__ . '/../Fixtures/FF4D00-1.png'),
+                'POST http://test.local/uploads.json?filename=1x1.png HTTP/1.1' . \PHP_EOL .
+                'Host: test.local' . \PHP_EOL .
+                'X-Redmine-API-Key: access_token' . \PHP_EOL .
+                'Content-Type: application/octet-stream' . \PHP_EOL .
+                \PHP_EOL .
                 base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEX/TQBcNTh/AAAACklEQVR4nGNiAAAABgADNjd8qAAAAABJRU5ErkJggg=='),
             ],
             'Test PUT' => [
                 'http://test.local', 'access_token', null, null,
                 'requestPut', '/path.json', '{"foo":"bar"}',
-                'PUT http://test.local/path.json HTTP/1.1'.\PHP_EOL.
-                'Host: test.local'.\PHP_EOL.
-                'X-Redmine-API-Key: access_token'.\PHP_EOL.
-                'Content-Type: application/json'.\PHP_EOL.
-                \PHP_EOL.
+                'PUT http://test.local/path.json HTTP/1.1' . \PHP_EOL .
+                'Host: test.local' . \PHP_EOL .
+                'X-Redmine-API-Key: access_token' . \PHP_EOL .
+                'Content-Type: application/json' . \PHP_EOL .
+                \PHP_EOL .
                 '{"foo":"bar"}',
             ],
             'Test DELETE' => [
                 'http://test.local', 'access_token', null, null,
                 'requestDelete', '/path.json', '{"foo":"bar"}',
-                'DELETE http://test.local/path.json HTTP/1.1'.\PHP_EOL.
-                'Host: test.local'.\PHP_EOL.
-                'X-Redmine-API-Key: access_token'.\PHP_EOL.
-                'Content-Type: application/json'.\PHP_EOL.
+                'DELETE http://test.local/path.json HTTP/1.1' . \PHP_EOL .
+                'Host: test.local' . \PHP_EOL .
+                'X-Redmine-API-Key: access_token' . \PHP_EOL .
+                'Content-Type: application/json' . \PHP_EOL .
                 \PHP_EOL,
             ],
             'Test body will be ignored on DELETE' => [
                 'http://test.local', 'access_token', null, null,
                 'requestDelete', '/path.json', '{"foo":"bar"}',
-                'DELETE http://test.local/path.json HTTP/1.1'.\PHP_EOL.
-                'Host: test.local'.\PHP_EOL.
-                'X-Redmine-API-Key: access_token'.\PHP_EOL.
-                'Content-Type: application/json'.\PHP_EOL.
+                'DELETE http://test.local/path.json HTTP/1.1' . \PHP_EOL .
+                'Host: test.local' . \PHP_EOL .
+                'X-Redmine-API-Key: access_token' . \PHP_EOL .
+                'Content-Type: application/json' . \PHP_EOL .
                 \PHP_EOL,
             ],
         ];

--- a/tests/Integration/UrlTest.php
+++ b/tests/Integration/UrlTest.php
@@ -290,7 +290,7 @@ class UrlTest extends TestCase
 
         $res = $api->show(1);
 
-        $this->assertEquals($res['path'], '/projects/1.json?include='.urlencode('trackers,issue_categories,attachments,relations'));
+        $this->assertEquals($res['path'], '/projects/1.json?include=' . urlencode('trackers,issue_categories,attachments,relations'));
         $this->assertEquals('GET', $res['method']);
 
         $res = $api->remove(1);
@@ -423,22 +423,22 @@ class UrlTest extends TestCase
 
         $res = $api->show(1);
 
-        $this->assertEquals($res['path'], '/users/1.json?include='.urlencode('memberships,groups'));
+        $this->assertEquals($res['path'], '/users/1.json?include=' . urlencode('memberships,groups'));
         $this->assertEquals('GET', $res['method']);
 
         $res = $api->show(1, ['include' => ['memberships', 'groups']]);
 
-        $this->assertEquals($res['path'], '/users/1.json?include='.urlencode('memberships,groups'));
+        $this->assertEquals($res['path'], '/users/1.json?include=' . urlencode('memberships,groups'));
         $this->assertEquals('GET', $res['method']);
 
         $res = $api->show(1, ['include' => ['memberships', 'groups', 'parameter1']]);
 
-        $this->assertEquals($res['path'], '/users/1.json?include='.urlencode('memberships,groups,parameter1'));
+        $this->assertEquals($res['path'], '/users/1.json?include=' . urlencode('memberships,groups,parameter1'));
         $this->assertEquals('GET', $res['method']);
 
         $res = $api->show(1, ['include' => ['parameter1', 'memberships', 'groups']]);
 
-        $this->assertEquals($res['path'], '/users/1.json?include='.urlencode('parameter1,memberships,groups'));
+        $this->assertEquals($res['path'], '/users/1.json?include=' . urlencode('parameter1,memberships,groups'));
         $this->assertEquals('GET', $res['method']);
 
         $res = $api->remove(1);

--- a/tests/Unit/Api/AbstractApiTest.php
+++ b/tests/Unit/Api/AbstractApiTest.php
@@ -22,7 +22,7 @@ class AbstractApiTest extends TestCase
     {
         $client = $this->createMock(Client::class);
 
-        $api = new class($client) extends AbstractApi {};
+        $api = new class ($client) extends AbstractApi {};
 
         $method = new ReflectionMethod($api, 'isNotNull');
         $method->setAccessible(true);
@@ -62,7 +62,7 @@ class AbstractApiTest extends TestCase
         $client = $this->createMock(Client::class);
         $client->method('getLastResponseStatusCode')->willReturn($statusCode);
 
-        $api = new class($client) extends AbstractApi {};
+        $api = new class ($client) extends AbstractApi {};
 
         $this->assertSame($expectedBoolean, $api->lastCallFailed());
     }
@@ -148,7 +148,7 @@ class AbstractApiTest extends TestCase
         $client->method('getLastResponseBody')->willReturn($response);
         $client->method('getLastResponseContentType')->willReturn('application/json');
 
-        $api = new class($client) extends AbstractApi {};
+        $api = new class ($client) extends AbstractApi {};
 
         $method = new ReflectionMethod($api, 'get');
         $method->setAccessible(true);
@@ -184,7 +184,7 @@ class AbstractApiTest extends TestCase
         $client->method('getLastResponseBody')->willReturn($response);
         $client->method('getLastResponseContentType')->willReturn('application/xml');
 
-        $api = new class($client) extends AbstractApi {};
+        $api = new class ($client) extends AbstractApi {};
 
         $method = new ReflectionMethod($api, $methodName);
         $method->setAccessible(true);
@@ -231,7 +231,7 @@ class AbstractApiTest extends TestCase
         $client->method('getLastResponseBody')->willReturn($response);
         $client->method('getLastResponseContentType')->willReturn($contentType);
 
-        $api = new class($client) extends AbstractApi {};
+        $api = new class ($client) extends AbstractApi {};
 
         $method = new ReflectionMethod($api, 'retrieveData');
         $method->setAccessible(true);
@@ -258,7 +258,7 @@ class AbstractApiTest extends TestCase
         $client->method('getLastResponseBody')->willReturn($response);
         $client->method('getLastResponseContentType')->willReturn($contentType);
 
-        $api = new class($client) extends AbstractApi {};
+        $api = new class ($client) extends AbstractApi {};
 
         $method = new ReflectionMethod($api, 'retrieveData');
         $method->setAccessible(true);
@@ -288,7 +288,7 @@ class AbstractApiTest extends TestCase
         $client->method('getLastResponseBody')->willReturn($content);
         $client->method('getLastResponseContentType')->willReturn($contentType);
 
-        $api = new class($client) extends AbstractApi {};
+        $api = new class ($client) extends AbstractApi {};
 
         $method = new ReflectionMethod($api, 'retrieveAll');
         $method->setAccessible(true);
@@ -312,7 +312,7 @@ class AbstractApiTest extends TestCase
     {
         $client = $this->createMock(Client::class);
 
-        $api = new class($client) extends AbstractApi {};
+        $api = new class ($client) extends AbstractApi {};
 
         $method = new ReflectionMethod($api, 'attachCustomFieldXML');
         $method->setAccessible(true);

--- a/tests/Unit/Api/IssueCategoryTest.php
+++ b/tests/Unit/Api/IssueCategoryTest.php
@@ -421,8 +421,8 @@ class IssueCategoryTest extends TestCase
             ->with(
                 '/projects/5/issue_categories.xml',
                 $this->logicalAnd(
-                    $this->stringStartsWith('<?xml version="1.0"?>'."\n".'<issue_category>'),
-                    $this->stringEndsWith('</issue_category>'."\n"),
+                    $this->stringStartsWith('<?xml version="1.0"?>' . "\n" . '<issue_category>'),
+                    $this->stringEndsWith('</issue_category>' . "\n"),
                     $this->stringContains('<name>Test Category</name>'),
                     $this->stringContains('<assigned_to_id>2</assigned_to_id>')
                 )
@@ -462,8 +462,8 @@ class IssueCategoryTest extends TestCase
             ->with(
                 '/issue_categories/5.xml',
                 $this->logicalAnd(
-                    $this->stringStartsWith('<?xml version="1.0"?>'."\n".'<issue_category>'),
-                    $this->stringEndsWith('</issue_category>'."\n"),
+                    $this->stringStartsWith('<?xml version="1.0"?>' . "\n" . '<issue_category>'),
+                    $this->stringEndsWith('</issue_category>' . "\n"),
                     $this->stringContains('<name>Test Category</name>'),
                     $this->stringContains('<assigned_to_id>2</assigned_to_id>')
                 )

--- a/tests/Unit/Api/IssueTest.php
+++ b/tests/Unit/Api/IssueTest.php
@@ -351,7 +351,7 @@ class IssueTest extends TestCase
             ->method('requestPost')
             ->with(
                 $this->stringStartsWith('/issues/5/watchers.xml'),
-                $this->stringEndsWith('<user_id>10</user_id>'."\n")
+                $this->stringEndsWith('<user_id>10</user_id>' . "\n")
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))
@@ -414,7 +414,7 @@ class IssueTest extends TestCase
             ->method('requestPost')
             ->with(
                 '/issues.xml',
-                '<?xml version="1.0"?>'."\n".'<issue/>'."\n"
+                '<?xml version="1.0"?>' . "\n" . '<issue/>' . "\n"
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))
@@ -480,8 +480,8 @@ class IssueTest extends TestCase
             ->with(
                 '/issues.xml',
                 $this->logicalAnd(
-                    $this->stringStartsWith('<?xml version="1.0"?>'."\n".'<issue>'),
-                    $this->stringEndsWith('</issue>'."\n"),
+                    $this->stringStartsWith('<?xml version="1.0"?>' . "\n" . '<issue>'),
+                    $this->stringEndsWith('</issue>' . "\n"),
                     $this->stringContains('<project_id>cleanedValue</project_id>'),
                     $this->stringContains('<category_id>cleanedValue</category_id>'),
                     $this->stringContains('<status_id>cleanedValue</status_id>'),
@@ -541,7 +541,7 @@ class IssueTest extends TestCase
                     $this->stringContains('<value>3</value>'),
                     $this->stringContains('</custom_field>'),
                     $this->stringContains('</custom_fields>'),
-                    $this->stringEndsWith('</issue>'."\n")
+                    $this->stringEndsWith('</issue>' . "\n")
                 )
             )
             ->willReturn(true);
@@ -575,7 +575,7 @@ class IssueTest extends TestCase
             ->method('requestPut')
             ->with(
                 '/issues/5.xml',
-                '<?xml version="1.0"?>'."\n".'<issue><id>5</id></issue>'."\n"
+                '<?xml version="1.0"?>' . "\n" . '<issue><id>5</id></issue>' . "\n"
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))
@@ -641,8 +641,8 @@ class IssueTest extends TestCase
             ->with(
                 '/issues/5.xml',
                 $this->logicalAnd(
-                    $this->stringStartsWith('<?xml version="1.0"?>'."\n".'<issue>'),
-                    $this->stringEndsWith('</issue>'."\n"),
+                    $this->stringStartsWith('<?xml version="1.0"?>' . "\n" . '<issue>'),
+                    $this->stringEndsWith('</issue>' . "\n"),
                     $this->stringContains('<id>5</id>'),
                     $this->stringContains('<project_id>cleanedValue</project_id>'),
                     $this->stringContains('<category_id>cleanedValue</category_id>'),
@@ -692,8 +692,8 @@ class IssueTest extends TestCase
             ->with(
                 '/issues/5.xml',
                 $this->logicalAnd(
-                    $this->stringStartsWith('<?xml version="1.0"?>'."\n".'<issue>'),
-                    $this->stringEndsWith('</issue>'."\n"),
+                    $this->stringStartsWith('<?xml version="1.0"?>' . "\n" . '<issue>'),
+                    $this->stringEndsWith('</issue>' . "\n"),
                     $this->stringContains('<id>5</id>'),
                     $this->stringContains('<status_id>123</status_id>')
                 )
@@ -728,8 +728,8 @@ class IssueTest extends TestCase
             ->with(
                 '/issues/5.xml',
                 $this->logicalAnd(
-                    $this->stringStartsWith('<?xml version="1.0"?>'."\n".'<issue>'),
-                    $this->stringEndsWith('</issue>'."\n"),
+                    $this->stringStartsWith('<?xml version="1.0"?>' . "\n" . '<issue>'),
+                    $this->stringEndsWith('</issue>' . "\n"),
                     $this->stringContains('<id>5</id>'),
                     $this->stringContains('<notes>Note content</notes>')
                 )
@@ -769,8 +769,8 @@ class IssueTest extends TestCase
             ->with(
                 '/issues.xml',
                 $this->logicalAnd(
-                    $this->stringStartsWith('<?xml version="1.0"?>'."\n".'<issue>'),
-                    $this->stringEndsWith('</issue>'."\n"),
+                    $this->stringStartsWith('<?xml version="1.0"?>' . "\n" . '<issue>'),
+                    $this->stringEndsWith('</issue>' . "\n"),
                     $this->stringContains('<custom_fields type="array">'),
                     $this->stringContains('</custom_fields>'),
                     $this->stringContains('<custom_field id="225"><value>One Custom Field</value></custom_field>'),
@@ -805,8 +805,8 @@ class IssueTest extends TestCase
             ->with(
                 '/issues.xml',
                 $this->logicalAnd(
-                    $this->stringStartsWith('<?xml version="1.0"?>'."\n".'<issue>'),
-                    $this->stringEndsWith('</issue>'."\n"),
+                    $this->stringStartsWith('<?xml version="1.0"?>' . "\n" . '<issue>'),
+                    $this->stringEndsWith('</issue>' . "\n"),
                     $this->stringContains('<watcher_user_ids type="array">'),
                     $this->stringContains('</watcher_user_ids>'),
                     $this->stringContains('<watcher_user_id>5</watcher_user_id>'),
@@ -852,24 +852,24 @@ class IssueTest extends TestCase
             ->with(
                 '/issues.xml',
                 $this->logicalAnd(
-                    $this->stringStartsWith('<?xml version="1.0"?>'."\n".'<issue>'),
-                    $this->stringEndsWith('</issue>'."\n"),
+                    $this->stringStartsWith('<?xml version="1.0"?>' . "\n" . '<issue>'),
+                    $this->stringEndsWith('</issue>' . "\n"),
                     $this->stringContains('<uploads type="array">'),
                     $this->stringContains('</uploads>'),
                     $this->stringContains(
                         '<upload>'
-                        .'<token>first-token</token>'
-                        .'<filename>SomeRandomFile.txt</filename>'
-                        .'<description>Simple description</description>'
-                        .'<content_type>text/plain</content_type>'
-                        .'</upload>'
+                        . '<token>first-token</token>'
+                        . '<filename>SomeRandomFile.txt</filename>'
+                        . '<description>Simple description</description>'
+                        . '<content_type>text/plain</content_type>'
+                        . '</upload>'
                     ),
                     $this->stringContains(
                         '<upload>'
-                        .'<token>second-token</token>'
-                        .'<filename>An-Other-File.css</filename>'
-                        .'<content_type>text/css</content_type>'
-                        .'</upload>'
+                        . '<token>second-token</token>'
+                        . '<filename>An-Other-File.css</filename>'
+                        . '<content_type>text/css</content_type>'
+                        . '</upload>'
                     )
                 )
             );
@@ -913,23 +913,23 @@ class IssueTest extends TestCase
             ->with(
                 '/issues.xml',
                 $this->logicalAnd(
-                    $this->stringStartsWith('<?xml version="1.0"?>'."\n".'<issue>'),
-                    $this->stringEndsWith('</issue>'."\n"),
+                    $this->stringStartsWith('<?xml version="1.0"?>' . "\n" . '<issue>'),
+                    $this->stringEndsWith('</issue>' . "\n"),
                     $this->stringContains('<watcher_user_ids type="array">'),
                     $this->stringContains('</watcher_user_ids>'),
                     $this->stringContains('<watcher_user_id>5</watcher_user_id>'),
                     $this->stringContains(
                         '<upload>'
-                        .'<token>first-token</token>'
-                        .'<filename>SomeRandomFile.txt</filename>'
-                        .'<description>Simple description</description>'
-                        .'<content_type>text/plain</content_type>'
-                        .'</upload>'
+                        . '<token>first-token</token>'
+                        . '<filename>SomeRandomFile.txt</filename>'
+                        . '<description>Simple description</description>'
+                        . '<content_type>text/plain</content_type>'
+                        . '</upload>'
                     ),
                     $this->stringContains(
                         '<custom_field id="25">'
-                        .'<value>Second Custom Field</value>'
-                        .'</custom_field>'
+                        . '<value>Second Custom Field</value>'
+                        . '</custom_field>'
                     ),
                     $this->stringContains('<subject>Issue subject with some xml entities: &amp; &lt; &gt; " \' </subject>'),
                     $this->stringContains('<description>Description with some xml entities: &amp; &lt; &gt; " \' </description>')
@@ -962,9 +962,9 @@ class IssueTest extends TestCase
             ->with(
                 '/issues/5.xml',
                 $this->logicalAnd(
-                    $this->stringStartsWith('<?xml version="1.0"?>'."\n".'<issue>'),
+                    $this->stringStartsWith('<?xml version="1.0"?>' . "\n" . '<issue>'),
                     $this->stringContains('<assigned_to_id>5</assigned_to_id>'),
-                    $this->stringEndsWith('</issue>'."\n"),
+                    $this->stringEndsWith('</issue>' . "\n"),
                 )
             );
 
@@ -994,9 +994,9 @@ class IssueTest extends TestCase
             ->with(
                 '/issues/5.xml',
                 $this->logicalAnd(
-                    $this->stringStartsWith('<?xml version="1.0"?>'."\n".'<issue>'),
+                    $this->stringStartsWith('<?xml version="1.0"?>' . "\n" . '<issue>'),
                     $this->stringContains('<assigned_to_id></assigned_to_id>'),
-                    $this->stringEndsWith('</issue>'."\n"),
+                    $this->stringEndsWith('</issue>' . "\n"),
                 )
             );
 

--- a/tests/Unit/Api/MembershipTest.php
+++ b/tests/Unit/Api/MembershipTest.php
@@ -334,8 +334,8 @@ class MembershipTest extends TestCase
                     $this->stringEndsWith('.xml')
                 ),
                 $this->logicalAnd(
-                    $this->stringStartsWith('<?xml version="1.0"?>'."\n".'<membership>'),
-                    $this->stringEndsWith('</membership>'."\n")
+                    $this->stringStartsWith('<?xml version="1.0"?>' . "\n" . '<membership>'),
+                    $this->stringEndsWith('</membership>' . "\n")
                 )
             )
             ->willReturn(true);
@@ -375,8 +375,8 @@ class MembershipTest extends TestCase
                     $this->stringEndsWith('.xml')
                 ),
                 $this->logicalAnd(
-                    $this->stringStartsWith('<?xml version="1.0"?>'."\n".'<membership>'),
-                    $this->stringEndsWith('</membership>'."\n"),
+                    $this->stringStartsWith('<?xml version="1.0"?>' . "\n" . '<membership>'),
+                    $this->stringEndsWith('</membership>' . "\n"),
                     $this->stringContains('<role_ids type="array">'),
                     $this->stringContains('<role_id>5</role_id>'),
                     $this->stringContains('<role_id>6</role_id>'),

--- a/tests/Unit/Api/ProjectTest.php
+++ b/tests/Unit/Api/ProjectTest.php
@@ -137,7 +137,7 @@ class ProjectTest extends TestCase
         $client->expects($this->once())
             ->method('requestGet')
             ->with(
-                '/projects/5.json?include='.
+                '/projects/5.json?include=' .
                 urlencode('trackers,issue_categories,attachments,relations')
             )
             ->willReturn(true);
@@ -475,8 +475,8 @@ class ProjectTest extends TestCase
             ->with(
                 '/projects.xml',
                 $this->logicalAnd(
-                    $this->stringStartsWith('<?xml version="1.0"?>'."\n".'<project>'),
-                    $this->stringEndsWith('</project>'."\n"),
+                    $this->stringStartsWith('<?xml version="1.0"?>' . "\n" . '<project>'),
+                    $this->stringEndsWith('</project>' . "\n"),
                     $this->stringContains('<identifier>test-project</identifier>'),
                     $this->stringContains('<name>Test Project with some xml entities: &amp; &lt; &gt; " \' </name>'),
                     $this->stringContains('<description>Description with some xml entities: &amp; &lt; &gt; " \' </description>')
@@ -518,8 +518,8 @@ class ProjectTest extends TestCase
             ->with(
                 '/projects.xml',
                 $this->logicalAnd(
-                    $this->stringStartsWith('<?xml version="1.0"?>'."\n".'<project>'),
-                    $this->stringEndsWith('</project>'."\n"),
+                    $this->stringStartsWith('<?xml version="1.0"?>' . "\n" . '<project>'),
+                    $this->stringEndsWith('</project>' . "\n"),
                     $this->stringContains('<tracker_ids type="array">'),
                     $this->stringContains('<tracker>10</tracker>'),
                     $this->stringContains('<tracker>5</tracker>'),

--- a/tests/Unit/Api/TimeEntryTest.php
+++ b/tests/Unit/Api/TimeEntryTest.php
@@ -304,8 +304,8 @@ class TimeEntryTest extends TestCase
             ->with(
                 '/time_entries.xml',
                 $this->logicalAnd(
-                    $this->stringStartsWith('<?xml version="1.0"?>'."\n".'<time_entry>'),
-                    $this->stringEndsWith('</time_entry>'."\n"),
+                    $this->stringStartsWith('<?xml version="1.0"?>' . "\n" . '<time_entry>'),
+                    $this->stringEndsWith('</time_entry>' . "\n"),
                     $this->stringContains('<issue_id>15</issue_id>'),
                     $this->stringContains('<project_id>25</project_id>'),
                     $this->stringContains('<hours>5.25</hours>'),
@@ -360,8 +360,8 @@ class TimeEntryTest extends TestCase
             ->with(
                 '/time_entries/5.xml',
                 $this->logicalAnd(
-                    $this->stringStartsWith('<?xml version="1.0"?>'."\n".'<time_entry>'),
-                    $this->stringEndsWith('</time_entry>'."\n"),
+                    $this->stringStartsWith('<?xml version="1.0"?>' . "\n" . '<time_entry>'),
+                    $this->stringEndsWith('</time_entry>' . "\n"),
                     $this->stringContains('<hours>10.25</hours>'),
                     $this->stringContains('<custom_fields type="array"><custom_field name="Affected version" id="1"><value>1.0.1</value></custom_field><custom_field name="Resolution" id="2"><value>Fixed</value></custom_field></custom_fields>')
                 )

--- a/tests/Unit/Api/UserTest.php
+++ b/tests/Unit/Api/UserTest.php
@@ -424,8 +424,8 @@ class UserTest extends TestCase
             ->with(
                 '/users.xml',
                 $this->logicalAnd(
-                    $this->stringStartsWith('<?xml version="1.0"?>'."\n".'<user>'),
-                    $this->stringEndsWith('</user>'."\n"),
+                    $this->stringStartsWith('<?xml version="1.0"?>' . "\n" . '<user>'),
+                    $this->stringEndsWith('</user>' . "\n"),
                     $this->stringContains('<login>TestUser</login>'),
                     $this->stringContains('<password>secretPass</password>'),
                     $this->stringContains('<lastname>Last Name</lastname>'),
@@ -476,8 +476,8 @@ class UserTest extends TestCase
             ->with(
                 '/users.xml',
                 $this->logicalAnd(
-                    $this->stringStartsWith('<?xml version="1.0"?>'."\n".'<user>'),
-                    $this->stringEndsWith('</user>'."\n"),
+                    $this->stringStartsWith('<?xml version="1.0"?>' . "\n" . '<user>'),
+                    $this->stringEndsWith('</user>' . "\n"),
                     $this->stringContains('<login>TestUser</login>'),
                     $this->stringContains('<password>secretPass</password>'),
                     $this->stringContains('<lastname>Last Name</lastname>'),
@@ -526,8 +526,8 @@ class UserTest extends TestCase
             ->with(
                 '/users/5.xml',
                 $this->logicalAnd(
-                    $this->stringStartsWith('<?xml version="1.0"?>'."\n".'<user>'),
-                    $this->stringEndsWith('</user>'."\n"),
+                    $this->stringStartsWith('<?xml version="1.0"?>' . "\n" . '<user>'),
+                    $this->stringEndsWith('</user>' . "\n"),
                     $this->stringContains('<mail>user@example.com</mail>')
                 )
             )
@@ -569,8 +569,8 @@ class UserTest extends TestCase
             ->with(
                 '/users/5.xml',
                 $this->logicalAnd(
-                    $this->stringStartsWith('<?xml version="1.0"?>'."\n".'<user>'),
-                    $this->stringEndsWith('</user>'."\n"),
+                    $this->stringStartsWith('<?xml version="1.0"?>' . "\n" . '<user>'),
+                    $this->stringEndsWith('</user>' . "\n"),
                     $this->stringContains('<custom_fields type="array">'),
                     $this->stringContains('</custom_fields>'),
                     $this->stringContains('<custom_field name="CF Name" id="13">'),

--- a/tests/Unit/Api/VersionTest.php
+++ b/tests/Unit/Api/VersionTest.php
@@ -346,8 +346,8 @@ class VersionTest extends TestCase
             ->with(
                 '/projects/5/versions.xml',
                 $this->logicalAnd(
-                    $this->stringStartsWith('<?xml version="1.0"?>'."\n".'<version>'),
-                    $this->stringEndsWith('</version>'."\n"),
+                    $this->stringStartsWith('<?xml version="1.0"?>' . "\n" . '<version>'),
+                    $this->stringEndsWith('</version>' . "\n"),
                     $this->stringContains('<name>Test version</name>')
                 )
             )
@@ -387,8 +387,8 @@ class VersionTest extends TestCase
             ->with(
                 '/projects/5/versions.xml',
                 $this->logicalAnd(
-                    $this->stringStartsWith('<?xml version="1.0"?>'."\n".'<version>'),
-                    $this->stringEndsWith('</version>'."\n"),
+                    $this->stringStartsWith('<?xml version="1.0"?>' . "\n" . '<version>'),
+                    $this->stringEndsWith('</version>' . "\n"),
                     $this->stringContains('<name>Test version</name>'),
                     $this->stringContains('<status>locked</status>')
                 )
@@ -456,8 +456,8 @@ class VersionTest extends TestCase
             ->with(
                 '/versions/test.xml',
                 $this->logicalAnd(
-                    $this->stringStartsWith('<?xml version="1.0"?>'."\n".'<version>'),
-                    $this->stringEndsWith('</version>'."\n"),
+                    $this->stringStartsWith('<?xml version="1.0"?>' . "\n" . '<version>'),
+                    $this->stringEndsWith('</version>' . "\n"),
                     $this->stringContains('<name>Test version</name>')
                 )
             )
@@ -497,8 +497,8 @@ class VersionTest extends TestCase
             ->with(
                 '/versions/test.xml',
                 $this->logicalAnd(
-                    $this->stringStartsWith('<?xml version="1.0"?>'."\n".'<version>'),
-                    $this->stringEndsWith('</version>'."\n"),
+                    $this->stringStartsWith('<?xml version="1.0"?>' . "\n" . '<version>'),
+                    $this->stringEndsWith('</version>' . "\n"),
                     $this->stringContains('<name>Test version</name>'),
                     $this->stringContains('<status>locked</status>')
                 )
@@ -718,8 +718,8 @@ class VersionTest extends TestCase
             ->with(
                 '/projects/test/versions.xml',
                 $this->logicalAnd(
-                    $this->stringStartsWith('<?xml version="1.0"?>'."\n".'<version>'),
-                    $this->stringEndsWith('</version>'."\n"),
+                    $this->stringStartsWith('<?xml version="1.0"?>' . "\n" . '<version>'),
+                    $this->stringEndsWith('</version>' . "\n"),
                     $this->stringContains('<name>Test version</name>'),
                     $this->stringContains($sharingXmlElement)
                 )
@@ -762,8 +762,8 @@ class VersionTest extends TestCase
             ->with(
                 '/projects/test/versions.xml',
                 $this->logicalAnd(
-                    $this->stringStartsWith('<?xml version="1.0"?>'."\n".'<version>'),
-                    $this->stringEndsWith('</version>'."\n"),
+                    $this->stringStartsWith('<?xml version="1.0"?>' . "\n" . '<version>'),
+                    $this->stringEndsWith('</version>' . "\n"),
                     $this->stringContains('<name>Test version</name>'),
                     $this->logicalNot(
                         $this->stringContains('<sharing')
@@ -841,8 +841,8 @@ class VersionTest extends TestCase
             ->with(
                 '/versions/test.xml',
                 $this->logicalAnd(
-                    $this->stringStartsWith('<?xml version="1.0"?>'."\n".'<version>'),
-                    $this->stringEndsWith('</version>'."\n"),
+                    $this->stringStartsWith('<?xml version="1.0"?>' . "\n" . '<version>'),
+                    $this->stringEndsWith('</version>' . "\n"),
                     $this->stringContains('<name>Test version</name>'),
                     $this->stringContains($sharingXmlElement)
                 )
@@ -885,8 +885,8 @@ class VersionTest extends TestCase
             ->with(
                 '/versions/test.xml',
                 $this->logicalAnd(
-                    $this->stringStartsWith('<?xml version="1.0"?>'."\n".'<version>'),
-                    $this->stringEndsWith('</version>'."\n"),
+                    $this->stringStartsWith('<?xml version="1.0"?>' . "\n" . '<version>'),
+                    $this->stringEndsWith('</version>' . "\n"),
                     $this->stringContains('<name>Test version</name>'),
                     $this->logicalNot(
                         $this->stringContains('<sharing')

--- a/tests/Unit/Api/WikiTest.php
+++ b/tests/Unit/Api/WikiTest.php
@@ -283,7 +283,7 @@ class WikiTest extends TestCase
             ->method('requestPut')
             ->with(
                 '/projects/5/wiki/test.xml',
-                '<?xml version="1.0"?>'."\n".'<wiki_page/>'."\n"
+                '<?xml version="1.0"?>' . "\n" . '<wiki_page/>' . "\n"
             )
             ->willReturn(true);
         $client->expects($this->once())
@@ -321,8 +321,8 @@ class WikiTest extends TestCase
             ->with(
                 '/projects/5/wiki/test.xml',
                 $this->logicalAnd(
-                    $this->stringStartsWith('<?xml version="1.0"?>'."\n".'<wiki_page>'),
-                    $this->stringEndsWith('</wiki_page>'."\n"),
+                    $this->stringStartsWith('<?xml version="1.0"?>' . "\n" . '<wiki_page>'),
+                    $this->stringEndsWith('</wiki_page>' . "\n"),
                     $this->stringContains('<title>Test Wikipage with xml entities: &amp; &lt; &gt; " \' </title>'),
                     $this->stringContains('<comments>Initial Edit with xml entities: &amp; &lt; &gt; " \' </comments>'),
                     $this->stringContains('<text>Some page text with xml entities: &amp; &lt; &gt; " \' </text>')
@@ -358,7 +358,7 @@ class WikiTest extends TestCase
             ->method('requestPut')
             ->with(
                 '/projects/5/wiki/test.xml',
-                '<?xml version="1.0"?>'."\n".'<wiki_page/>'."\n"
+                '<?xml version="1.0"?>' . "\n" . '<wiki_page/>' . "\n"
             )
             ->willReturn(true);
         $client->expects($this->once())
@@ -396,8 +396,8 @@ class WikiTest extends TestCase
             ->with(
                 '/projects/5/wiki/test.xml',
                 $this->logicalAnd(
-                    $this->stringStartsWith('<?xml version="1.0"?>'."\n".'<wiki_page>'),
-                    $this->stringEndsWith('</wiki_page>'."\n"),
+                    $this->stringStartsWith('<?xml version="1.0"?>' . "\n" . '<wiki_page>'),
+                    $this->stringEndsWith('</wiki_page>' . "\n"),
                     $this->stringContains('<title>Test Wikipage</title>'),
                     $this->stringContains('<comments>Initial Edit</comments>'),
                     $this->stringContains('<text>Some page text</text>')

--- a/tests/Unit/Serializer/XmlSerializerTest.php
+++ b/tests/Unit/Serializer/XmlSerializerTest.php
@@ -79,19 +79,19 @@ class XmlSerializerTest extends TestCase
                 '',
             ],
             'wrong start tag' => [
-                'Catched errors: "Start tag expected, \'<\' not found'."\n".'" while decoding XML: <?xml version="1.0" encoding="UTF-8"?>',
+                'Catched errors: "Start tag expected, \'<\' not found' . "\n" . '" while decoding XML: <?xml version="1.0" encoding="UTF-8"?>',
                 '<?xml version="1.0" encoding="UTF-8"?>',
             ],
             'invalid element name as start tag' => [
-                'Catched errors: "StartTag: invalid element name'."\n".'", "Extra content at the end of the document'."\n".'" while decoding XML: <?xml version="1.0" encoding="UTF-8"?><>',
+                'Catched errors: "StartTag: invalid element name' . "\n" . '", "Extra content at the end of the document' . "\n" . '" while decoding XML: <?xml version="1.0" encoding="UTF-8"?><>',
                 '<?xml version="1.0" encoding="UTF-8"?><>',
             ],
             'Premature end of data' => [
-                'Catched errors: "Premature end of data in tag a line 1'."\n".'" while decoding XML: <?xml version="1.0" encoding="UTF-8"?><a>',
+                'Catched errors: "Premature end of data in tag a line 1' . "\n" . '" while decoding XML: <?xml version="1.0" encoding="UTF-8"?><a>',
                 '<?xml version="1.0" encoding="UTF-8"?><a>',
             ],
             'invalid element name as start tag 2' => [
-                'Catched errors: "StartTag: invalid element name'."\n".'", "Extra content at the end of the document'."\n".'" while decoding XML: <?xml version="1.0" encoding="UTF-8"?></>',
+                'Catched errors: "StartTag: invalid element name' . "\n" . '", "Extra content at the end of the document' . "\n" . '" while decoding XML: <?xml version="1.0" encoding="UTF-8"?></>',
                 '<?xml version="1.0" encoding="UTF-8"?></>',
             ],
         ];
@@ -203,7 +203,7 @@ class XmlSerializerTest extends TestCase
     {
         return[
             'invalid element name as start tag' => [
-                'Could not create XML from array: "StartTag: invalid element name'."\n".'", "Extra content at the end of the document'."\n".'"',
+                'Could not create XML from array: "StartTag: invalid element name' . "\n" . '", "Extra content at the end of the document' . "\n" . '"',
                 ['0' => ['foobar']],
             ]
         ];


### PR DESCRIPTION
The symfony code style for this project was applied in 2017, see #194. 

In april 2023 the [PER Coding Style 2.0](https://www.php-fig.org/per/coding-style/) was released and in PHP-CS-Fixer we now have a ruleset for this code style.

This PR changes the ruleset for PHP-CS-Fixer to `@PER-CS2.0` and adds a new composer script to run php-cs-fixer. It also applies the new code style to all PHP files.