### PR TITLE
Introduce end to end tests

### DIFF
--- a/.docker/PHP83-Dockerfile
+++ b/.docker/PHP83-Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.3-fpm
+FROM php:8.3.1-fpm
 
 RUN apt-get update
 RUN apt-get --yes --no-install-recommends install \

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,7 @@
     "scripts": {
         "codestyle": "php-cs-fixer fix",
         "coverage": "phpunit --coverage-html=\".phpunit.cache/code-coverage\"",
+        "end2end": "phpunit -- tests/End2End",
         "phpstan": "phpstan analyze --memory-limit 512M --configuration .phpstan.neon",
         "phpunit": "phpunit",
         "test": [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,25 +17,8 @@ services:
         ports:
             - "3000:3000"
         environment:
-            REDMINE_DB_MYSQL: "mariadb"
-            REDMINE_DB_PORT: ""
-            REDMINE_DB_USERNAME: "redmine"
-            REDMINE_DB_PASSWORD: "redmine"
-            REDMINE_DB_DATABASE: "redmine"
             REDMINE_SECRET_KEY_BASE: supersecretkey
             REDMINE_PLUGINS_MIGRATE: true
-        depends_on:
-            - mariadb
         volumes:
-            - ./.docker/redmine_data:/usr/src/redmine/files
-
-    mariadb:
-        image: mariadb:11.2
-        environment:
-            MYSQL_ROOT_PASSWORD: "root"
-            MYSQL_DATABASE: "redmine"
-            MYSQL_USER: "redmine"
-            MYSQL_PASSWORD: "redmine"
-        volumes:
-            - ./.docker/mariadb_data:/var/lib/mysql
-
+            - ./.docker/redmine_data/files:/usr/src/redmine/files
+            - ./.docker/redmine_data/sqlite:/usr/src/redmine/sqlite

--- a/tests/End2End/ClientTestCase.php
+++ b/tests/End2End/ClientTestCase.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Redmine\Tests\End2End;
+
+use PDO;
+use PHPUnit\Framework\TestCase;
+use Redmine\Client\NativeCurlClient;
+
+class ClientTestCase extends TestCase
+{
+    private $apiKey;
+
+    private $sqliteFile;
+
+    private $sqliteBackup;
+
+    public function setUp(): void
+    {
+        $this->sqliteFile = dirname(__FILE__, 3) . '/.docker/redmine_data/sqlite/redmine.db';
+        $this->sqliteBackup = dirname(__FILE__, 3) . '/.docker/redmine_data/sqlite/redmine.db.bak';
+
+        // Create backup of database
+        copy($this->sqliteFile, $this->sqliteBackup);
+
+        $pdo = new PDO('sqlite:' . $this->sqliteFile);
+
+        // Get admin user to check sqlite connection
+        $stmt = $pdo->prepare('SELECT * FROM users WHERE login = :login;');
+        $stmt->execute([':login' => 'admin']);
+        $adminUser = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        // Update admin user
+        $stmt = $pdo->prepare('UPDATE users SET must_change_passwd = :must_change_passwd WHERE id = :id;');
+        $stmt->execute([':id' => $adminUser['id'], ':must_change_passwd' => 0]);
+
+        // Enable rest api
+        $stmt = $pdo->prepare('INSERT INTO settings(name, value) VALUES(:name, :value);');
+        $stmt->execute([':name' => 'rest_api_enabled', ':value' => 1]);
+
+        $this->apiKey = sha1((string) time());
+
+        // Create api token for admin user
+        $stmt = $pdo->prepare('INSERT INTO tokens(user_id, action, value, created_on, updated_on) VALUES(:user_id, :action, :value, :created_on, :updated_on);');
+        $stmt->execute([
+            ':user_id' => $adminUser['id'],
+            ':action' => 'api',
+            ':value' => $this->apiKey,
+            ':created_on' => $adminUser['last_login_on'],
+            ':updated_on' => $adminUser['last_login_on'],
+        ]);
+    }
+
+    public function tearDown(): void
+    {
+        // Restore database from backup
+        copy($this->sqliteBackup, $this->sqliteFile);
+    }
+
+    protected function getNativeCurlClient(): NativeCurlClient
+    {
+        return new NativeCurlClient(
+            'http://redmine:3000',
+            $this->apiKey
+        );
+    }
+}

--- a/tests/End2End/ClientTestCase.php
+++ b/tests/End2End/ClientTestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Redmine\Tests\End2End;
 
+use DateTimeImmutable;
 use PDO;
 use PHPUnit\Framework\TestCase;
 use Redmine\Client\NativeCurlClient;
@@ -24,6 +25,7 @@ class ClientTestCase extends TestCase
         // Create backup of database
         copy($this->sqliteFile, $this->sqliteBackup);
 
+        $now = new DateTimeImmutable();
         $pdo = new PDO('sqlite:' . $this->sqliteFile);
 
         // Get admin user to check sqlite connection
@@ -36,8 +38,12 @@ class ClientTestCase extends TestCase
         $stmt->execute([':id' => $adminUser['id'], ':must_change_passwd' => 0]);
 
         // Enable rest api
-        $stmt = $pdo->prepare('INSERT INTO settings(name, value) VALUES(:name, :value);');
-        $stmt->execute([':name' => 'rest_api_enabled', ':value' => 1]);
+        $stmt = $pdo->prepare('INSERT INTO settings(name, value, updated_on) VALUES(:name, :value, :updated_on);');
+        $stmt->execute([
+            ':name' => 'rest_api_enabled',
+            ':value' => 1,
+            ':updated_on' => $now->format('Y-m-d H:i:s.u'),
+        ]);
 
         $this->apiKey = sha1((string) time());
 
@@ -47,8 +53,8 @@ class ClientTestCase extends TestCase
             ':user_id' => $adminUser['id'],
             ':action' => 'api',
             ':value' => $this->apiKey,
-            ':created_on' => $adminUser['last_login_on'],
-            ':updated_on' => $adminUser['last_login_on'],
+            ':created_on' => $now->format('Y-m-d H:i:s.u'),
+            ':updated_on' => $now->format('Y-m-d H:i:s.u'),
         ]);
     }
 

--- a/tests/End2End/Group/GroupTest.php
+++ b/tests/End2End/Group/GroupTest.php
@@ -4,70 +4,22 @@ declare(strict_types=1);
 
 namespace Redmine\Tests\End2End\Group;
 
-use PDO;
-use PHPUnit\Framework\TestCase;
-use Redmine\Client\NativeCurlClient;
+use DateTimeImmutable;
+use Redmine\Api\Group;
+use Redmine\Tests\End2End\ClientTestCase;
 
-class GroupTest extends TestCase
+class GroupTest extends ClientTestCase
 {
-    private $client;
-
-    private $sqliteFile;
-
-    private $sqliteBackup;
-
-    public function setUp(): void
-    {
-        $this->sqliteFile = dirname(__FILE__, 4) . '/.docker/redmine_data/sqlite/redmine.db';
-        $this->sqliteBackup = dirname(__FILE__, 4) . '/.docker/redmine_data/sqlite/redmine.db.bak';
-
-        // Create backup of database
-        copy($this->sqliteFile, $this->sqliteBackup);
-
-        $pdo = new PDO('sqlite:' . $this->sqliteFile);
-
-        // Get admin user to check sqlite connection
-        $stmt = $pdo->prepare('SELECT * FROM users WHERE login = :login;');
-        $stmt->execute([':login' => 'admin']);
-        $adminUser = $stmt->fetch(PDO::FETCH_ASSOC);
-
-        // Update admin user
-        $stmt = $pdo->prepare('UPDATE users SET must_change_passwd = :must_change_passwd WHERE id = :id;');
-        $stmt->execute([':id' => $adminUser['id'], ':must_change_passwd' => 0]);
-
-        // Enable rest api
-        $stmt = $pdo->prepare('INSERT INTO settings(name, value) VALUES(:name, :value);');
-        $stmt->execute([':name' => 'rest_api_enabled', ':value' => 1]);
-
-        $apiKey = sha1((string) time());
-
-        // Create api token for admin user
-        $stmt = $pdo->prepare('INSERT INTO tokens(user_id, action, value, created_on, updated_on) VALUES(:user_id, :action, :value, :created_on, :updated_on);');
-        $stmt->execute([
-            ':user_id' => $adminUser['id'],
-            ':action' => 'api',
-            ':value' => $apiKey,
-            ':created_on' => $adminUser['last_login_on'],
-            ':updated_on' => $adminUser['last_login_on'],
-        ]);
-
-        $this->client = new NativeCurlClient(
-            'http://redmine:3000',
-            $apiKey
-        );
-    }
-
-    public function tearDown(): void
-    {
-        // Restore database from backup
-        copy($this->sqliteBackup, $this->sqliteFile);
-    }
-
     public function testInteractionWithGroup(): void
     {
+        $client = $this->getNativeCurlClient();
+
+        /** @var Group */
+        $groupApi = $client->getApi('group');
+
         // Create group
-        $xmlData = $this->client->getApi('group')->create([
-            'name' => 'test group ' . (new \DateTimeImmutable())->format('Y-m-d H:i:s'),
+        $xmlData = $groupApi->create([
+            'name' => 'test group ' . (new DateTimeImmutable())->format('Y-m-d H:i:s'),
         ]);
 
         $data = json_decode(json_encode($xmlData), true);

--- a/tests/End2End/Group/GroupTest.php
+++ b/tests/End2End/Group/GroupTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Redmine\Tests\End2End\Group;
+
+use PDO;
+use PHPUnit\Framework\TestCase;
+use Redmine\Client\NativeCurlClient;
+
+class GroupTest extends TestCase
+{
+    private $client;
+
+    private $sqliteFile;
+
+    private $sqliteBackup;
+
+    public function setUp(): void
+    {
+        $this->sqliteFile = dirname(__FILE__, 4) . '/.docker/redmine_data/sqlite/redmine.db';
+        $this->sqliteBackup = dirname(__FILE__, 4) . '/.docker/redmine_data/sqlite/redmine.db.bak';
+
+        // Create backup of database
+        copy($this->sqliteFile, $this->sqliteBackup);
+
+        $pdo = new PDO('sqlite:' . $this->sqliteFile);
+
+        // Get admin user to check sqlite connection
+        $stmt = $pdo->prepare('SELECT * FROM users WHERE login = :login;');
+        $stmt->execute([':login' => 'admin']);
+        $adminUser = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        // Update admin user
+        $stmt = $pdo->prepare('UPDATE users SET must_change_passwd = :must_change_passwd WHERE id = :id;');
+        $stmt->execute([':id' => $adminUser['id'], ':must_change_passwd' => 0]);
+
+        // Enable rest api
+        $stmt = $pdo->prepare('INSERT INTO settings(name, value) VALUES(:name, :value);');
+        $stmt->execute([':name' => 'rest_api_enabled', ':value' => 1]);
+
+        $apiKey = sha1((string) time());
+
+        // Create api token for admin user
+        $stmt = $pdo->prepare('INSERT INTO tokens(user_id, action, value, created_on, updated_on) VALUES(:user_id, :action, :value, :created_on, :updated_on);');
+        $stmt->execute([
+            ':user_id' => $adminUser['id'],
+            ':action' => 'api',
+            ':value' => $apiKey,
+            ':created_on' => $adminUser['last_login_on'],
+            ':updated_on' => $adminUser['last_login_on'],
+        ]);
+
+        $this->client = new NativeCurlClient(
+            'http://redmine:3000',
+            $apiKey
+        );
+    }
+
+    public function tearDown(): void
+    {
+        // Restore database from backup
+        copy($this->sqliteBackup, $this->sqliteFile);
+    }
+
+    public function testInteractionWithGroup(): void
+    {
+        // Create group
+        $xmlData = $this->client->getApi('group')->create([
+            'name' => 'test group ' . (new \DateTimeImmutable())->format('Y-m-d H:i:s'),
+        ]);
+
+        $data = json_decode(json_encode($xmlData), true);
+
+        $this->assertIsArray($data, json_encode($data));
+        $this->assertIsString($data['id']);
+        $this->assertStringStartsWith('test group ', $data['name']);
+    }
+}

--- a/tests/End2End/Group/GroupTest.php
+++ b/tests/End2End/Group/GroupTest.php
@@ -16,16 +16,49 @@ class GroupTest extends ClientTestCase
 
         /** @var Group */
         $groupApi = $client->getApi('group');
+        $now = new DateTimeImmutable();
 
         // Create group
+        $groupName = 'test group ' . $now->format('Y-m-d H:i:s');
+
         $xmlData = $groupApi->create([
-            'name' => 'test group ' . (new DateTimeImmutable())->format('Y-m-d H:i:s'),
+            'name' => $groupName,
         ]);
 
         $data = json_decode(json_encode($xmlData), true);
 
         $this->assertIsArray($data, json_encode($data));
         $this->assertIsString($data['id']);
-        $this->assertStringStartsWith('test group ', $data['name']);
+        $this->assertSame($groupName, $data['name']);
+
+        $groupId = (int) $data['id'];
+
+        // List groups
+        $data = $groupApi->list();
+
+        $this->assertSame(
+            [
+                'groups' => [
+                    [
+                        'id' => $groupId,
+                        'name' => $groupName,
+                    ],
+                ],
+            ],
+            $data
+        );
+
+        // Read group
+        $data = $groupApi->show($groupId);
+
+        $this->assertSame(
+            [
+                'group' => [
+                    'id' => $groupId,
+                    'name' => $groupName,
+                ]
+            ],
+            $data
+        );
     }
 }

--- a/tests/End2End/Group/GroupTest.php
+++ b/tests/End2End/Group/GroupTest.php
@@ -25,17 +25,15 @@ class GroupTest extends ClientTestCase
             'name' => $groupName,
         ]);
 
-        $data = json_decode(json_encode($xmlData), true);
+        $groupData = json_decode(json_encode($xmlData), true);
 
-        $this->assertIsArray($data, json_encode($data));
-        $this->assertIsString($data['id']);
-        $this->assertSame($groupName, $data['name']);
+        $this->assertIsArray($groupData, json_encode($groupData));
+        $this->assertIsString($groupData['id']);
+        $this->assertSame($groupName, $groupData['name']);
 
-        $groupId = (int) $data['id'];
+        $groupId = (int) $groupData['id'];
 
         // List groups
-        $data = $groupApi->list();
-
         $this->assertSame(
             [
                 'groups' => [
@@ -45,12 +43,10 @@ class GroupTest extends ClientTestCase
                     ],
                 ],
             ],
-            $data
+            $groupApi->list()
         );
 
         // Read group
-        $data = $groupApi->show($groupId);
-
         $this->assertSame(
             [
                 'group' => [
@@ -58,7 +54,21 @@ class GroupTest extends ClientTestCase
                     'name' => $groupName,
                 ]
             ],
-            $data
+            $groupApi->show($groupId)
+        );
+
+        // Update group
+        $result = $groupApi->update($groupId, ['name' => 'new group name']);
+        $this->assertSame('', $result);
+
+        $this->assertSame(
+            [
+                'group' => [
+                    'id' => $groupId,
+                    'name' => 'new group name',
+                ]
+            ],
+            $groupApi->show($groupId)
         );
     }
 }


### PR DESCRIPTION
This PR introduces end to end (e2e) tests. This tests allows us to use the locally installed Redmine server from #336 to run API requests against it. This helps us to test, understand and reverse engineer the behavior and responses of different Redmine versions. I've used this method to check the group features in #359. And I will use this tests to implement the new endpoints to close/archive a project (#192).

To run the tests you have to start the docker container. This will setup the Redmine server and database. I switched from MariaDB to SQLite btw.

```bash
docker compose build
docker compose up -d
```

To install all dependencies of php-redmine-api run:

```bash
docker compose exec -u 1000 php composer update
```

The end2end tests can be run with:

```bash
docker compose exec -u 1000 php composer run end2end
```

I was not able to run this tests in Github Actions, so if anybody has some hints for me this would be great.