### PR TITLE
Add `Request` interface and rename `Response::getBody()`

### DIFF
--- a/src/Redmine/Api/AbstractApi.php
+++ b/src/Redmine/Api/AbstractApi.php
@@ -110,7 +110,7 @@ abstract class AbstractApi implements Api
     {
         $this->lastResponse = $this->getHttpClient()->request('GET', strval($path));
 
-        $body = $this->lastResponse->getBody();
+        $body = $this->lastResponse->getContent();
         $contentType = $this->lastResponse->getContentType();
 
         // if response is XML, return a SimpleXMLElement object
@@ -141,7 +141,7 @@ abstract class AbstractApi implements Api
     {
         $this->lastResponse = $this->getHttpClient()->request('POST', strval($path), $data);
 
-        $body = $this->lastResponse->getBody();
+        $body = $this->lastResponse->getContent();
         $contentType = $this->lastResponse->getContentType();
 
         // if response is XML, return a SimpleXMLElement object
@@ -164,7 +164,7 @@ abstract class AbstractApi implements Api
     {
         $this->lastResponse = $this->getHttpClient()->request('PUT', strval($path), $data);
 
-        $body = $this->lastResponse->getBody();
+        $body = $this->lastResponse->getContent();
         $contentType = $this->lastResponse->getContentType();
 
         // if response is XML, return a SimpleXMLElement object
@@ -186,7 +186,7 @@ abstract class AbstractApi implements Api
     {
         $this->lastResponse = $this->getHttpClient()->request('DELETE', strval($path));
 
-        return $this->lastResponse->getBody();
+        return $this->lastResponse->getContent();
     }
 
     /**
@@ -234,7 +234,7 @@ abstract class AbstractApi implements Api
         try {
             $data = $this->retrieveData(strval($endpoint), $params);
         } catch (Exception $e) {
-            if ($this->getLastResponse()->getBody() === '') {
+            if ($this->getLastResponse()->getContent() === '') {
                 return false;
             }
 
@@ -368,7 +368,7 @@ abstract class AbstractApi implements Api
      */
     private function getResponseAsArray(Response $response): array
     {
-        $body = $response->getBody();
+        $body = $response->getContent();
         $contentType = $response->getContentType();
         $returnData = null;
 
@@ -445,7 +445,7 @@ abstract class AbstractApi implements Api
                 return $this->contentType;
             }
 
-            public function getBody(): string
+            public function getContent(): string
             {
                 return $this->body;
             }

--- a/src/Redmine/Api/AbstractApi.php
+++ b/src/Redmine/Api/AbstractApi.php
@@ -9,6 +9,7 @@ use Redmine\Client\Client;
 use Redmine\Exception;
 use Redmine\Exception\SerializerException;
 use Redmine\Http\HttpClient;
+use Redmine\Http\Request;
 use Redmine\Http\Response;
 use Redmine\Serializer\JsonSerializer;
 use Redmine\Serializer\PathSerializer;
@@ -108,7 +109,11 @@ abstract class AbstractApi implements Api
      */
     protected function get($path, $decodeIfJson = true)
     {
-        $this->lastResponse = $this->getHttpClient()->request('GET', strval($path));
+        $this->lastResponse = $this->getHttpClient()->request($this->createRequest(
+            'GET',
+            strval($path),
+            $this->getContentTypeFromPath(strval($path))
+        ));
 
         $body = $this->lastResponse->getContent();
         $contentType = $this->lastResponse->getContentType();
@@ -139,7 +144,12 @@ abstract class AbstractApi implements Api
      */
     protected function post($path, $data)
     {
-        $this->lastResponse = $this->getHttpClient()->request('POST', strval($path), $data);
+        $this->lastResponse = $this->getHttpClient()->request($this->createRequest(
+            'POST',
+            strval($path),
+            $this->getContentTypeFromPath(strval($path)),
+            $data
+        ));
 
         $body = $this->lastResponse->getContent();
         $contentType = $this->lastResponse->getContentType();
@@ -162,7 +172,12 @@ abstract class AbstractApi implements Api
      */
     protected function put($path, $data)
     {
-        $this->lastResponse = $this->getHttpClient()->request('PUT', strval($path), $data);
+        $this->lastResponse = $this->getHttpClient()->request($this->createRequest(
+            'PUT',
+            strval($path),
+            $this->getContentTypeFromPath(strval($path)),
+            $data
+        ));
 
         $body = $this->lastResponse->getContent();
         $contentType = $this->lastResponse->getContentType();
@@ -184,7 +199,11 @@ abstract class AbstractApi implements Api
      */
     protected function delete($path)
     {
-        $this->lastResponse = $this->getHttpClient()->request('DELETE', strval($path));
+        $this->lastResponse = $this->getHttpClient()->request($this->createRequest(
+            'DELETE',
+            strval($path),
+            $this->getContentTypeFromPath(strval($path))
+        ));
 
         return $this->lastResponse->getContent();
     }
@@ -258,7 +277,11 @@ abstract class AbstractApi implements Api
     protected function retrieveData(string $endpoint, array $params = []): array
     {
         if (empty($params)) {
-            $this->lastResponse = $this->getHttpClient()->request('GET', strval($endpoint));
+            $this->lastResponse = $this->getHttpClient()->request($this->createRequest(
+                'GET',
+                strval($endpoint),
+                $this->getContentTypeFromPath(strval($endpoint))
+            ));
 
             return $this->getResponseAsArray($this->lastResponse);
         }
@@ -287,10 +310,11 @@ abstract class AbstractApi implements Api
             $params['limit'] = $_limit;
             $params['offset'] = $offset;
 
-            $this->lastResponse = $this->getHttpClient()->request(
+            $this->lastResponse = $this->getHttpClient()->request($this->createRequest(
                 'GET',
-                PathSerializer::create($endpoint, $params)->getPath()
-            );
+                PathSerializer::create($endpoint, $params)->getPath(),
+                $this->getContentTypeFromPath($endpoint)
+            ));
 
             $newDataSet = $this->getResponseAsArray($this->lastResponse);
 
@@ -400,16 +424,16 @@ abstract class AbstractApi implements Api
                 $this->responseFactory = $responseFactory;
             }
 
-            public function request(string $method, string $path, string $body = ''): Response
+            public function request(Request $request): Response
             {
-                if ($method === 'POST') {
-                    $this->client->requestPost($path, $body);
-                } elseif ($method === 'PUT') {
-                    $this->client->requestPut($path, $body);
-                } elseif ($method === 'DELETE') {
-                    $this->client->requestDelete($path);
+                if ($request->getMethod() === 'POST') {
+                    $this->client->requestPost($request->getPath(), $request->getContent());
+                } elseif ($request->getMethod() === 'PUT') {
+                    $this->client->requestPut($request->getPath(), $request->getContent());
+                } elseif ($request->getMethod() === 'DELETE') {
+                    $this->client->requestDelete($request->getPath());
                 } else {
-                    $this->client->requestGet($path);
+                    $this->client->requestGet($request->getPath());
                 }
 
                 return ($this->responseFactory)(
@@ -450,5 +474,60 @@ abstract class AbstractApi implements Api
                 return $this->body;
             }
         };
+    }
+
+    private function createRequest(string $method, string $path, string $contentType, string $content = ''): Request
+    {
+        return new class ($method, $path, $contentType, $content) implements Request {
+            private $method;
+            private $path;
+            private $contentType;
+            private $content;
+
+            public function __construct(string $method, string $path, string $contentType, string $content)
+            {
+                $this->method = $method;
+                $this->path = $path;
+                $this->contentType = $contentType;
+                $this->content = $content;
+            }
+
+            public function getMethod(): string
+            {
+                return $this->method;
+            }
+
+            public function getPath(): string
+            {
+                return $this->path;
+            }
+
+            public function getContentType(): string
+            {
+                return $this->contentType;
+            }
+
+            public function getContent(): string
+            {
+                return $this->content;
+            }
+        };
+    }
+
+    private function getContentTypeFromPath(string $path): string
+    {
+        $tmp = parse_url($path);
+
+        $path = strtolower($path);
+
+        if (false !== strpos($path, '/uploads.json') || false !== strpos($path, '/uploads.xml')) {
+            return 'application/octet-stream';
+        } elseif ('json' === substr($tmp['path'], -4)) {
+            return 'application/json';
+        } elseif ('xml' === substr($tmp['path'], -3)) {
+            return 'application/xml';
+        } else {
+            return '';
+        }
     }
 }

--- a/src/Redmine/Api/CustomField.php
+++ b/src/Redmine/Api/CustomField.php
@@ -55,7 +55,7 @@ class CustomField extends AbstractApi
         try {
             $this->customFields = $this->list($params);
         } catch (Exception $e) {
-            if ($this->getLastResponse()->getBody() === '') {
+            if ($this->getLastResponse()->getContent() === '') {
                 return false;
             }
 

--- a/src/Redmine/Api/Group.php
+++ b/src/Redmine/Api/Group.php
@@ -59,7 +59,7 @@ class Group extends AbstractApi
         try {
             $this->groups = $this->list($params);
         } catch (Exception $e) {
-            if ($this->getLastResponse()->getBody() === '') {
+            if ($this->getLastResponse()->getContent() === '') {
                 return false;
             }
 

--- a/src/Redmine/Api/Issue.php
+++ b/src/Redmine/Api/Issue.php
@@ -110,7 +110,7 @@ class Issue extends AbstractApi
         try {
             return $this->list($params);
         } catch (Exception $e) {
-            if ($this->getLastResponse()->getBody() === '') {
+            if ($this->getLastResponse()->getContent() === '') {
                 return false;
             }
 

--- a/src/Redmine/Api/IssueCategory.php
+++ b/src/Redmine/Api/IssueCategory.php
@@ -69,7 +69,7 @@ class IssueCategory extends AbstractApi
         try {
             return $this->listByProject(strval($project), $params);
         } catch (Exception $e) {
-            if ($this->getLastResponse()->getBody() === '') {
+            if ($this->getLastResponse()->getContent() === '') {
                 return false;
             }
 

--- a/src/Redmine/Api/IssuePriority.php
+++ b/src/Redmine/Api/IssuePriority.php
@@ -55,7 +55,7 @@ class IssuePriority extends AbstractApi
         try {
             $this->issuePriorities = $this->list($params);
         } catch (Exception $e) {
-            if ($this->getLastResponse()->getBody() === '') {
+            if ($this->getLastResponse()->getContent() === '') {
                 return false;
             }
 

--- a/src/Redmine/Api/IssueRelation.php
+++ b/src/Redmine/Api/IssueRelation.php
@@ -58,7 +58,7 @@ class IssueRelation extends AbstractApi
         try {
             $this->relations = $this->listByIssueId($issueId, $params);
         } catch (Exception $e) {
-            if ($this->getLastResponse()->getBody() === '') {
+            if ($this->getLastResponse()->getContent() === '') {
                 return false;
             }
 

--- a/src/Redmine/Api/IssueStatus.php
+++ b/src/Redmine/Api/IssueStatus.php
@@ -55,7 +55,7 @@ class IssueStatus extends AbstractApi
         try {
             $this->issueStatuses = $this->list($params);
         } catch (Exception $e) {
-            if ($this->getLastResponse()->getBody() === '') {
+            if ($this->getLastResponse()->getContent() === '') {
                 return false;
             }
 

--- a/src/Redmine/Api/Membership.php
+++ b/src/Redmine/Api/Membership.php
@@ -68,7 +68,7 @@ class Membership extends AbstractApi
         try {
             $this->memberships = $this->listByProject(strval($project), $params);
         } catch (Exception $e) {
-            if ($this->getLastResponse()->getBody() === '') {
+            if ($this->getLastResponse()->getContent() === '') {
                 return false;
             }
 

--- a/src/Redmine/Api/News.php
+++ b/src/Redmine/Api/News.php
@@ -88,7 +88,7 @@ class News extends AbstractApi
                 $this->news = $this->listByProject(strval($project), $params);
             }
         } catch (Exception $e) {
-            if ($this->getLastResponse()->getBody() === '') {
+            if ($this->getLastResponse()->getContent() === '') {
                 return false;
             }
 

--- a/src/Redmine/Api/Project.php
+++ b/src/Redmine/Api/Project.php
@@ -58,7 +58,7 @@ class Project extends AbstractApi
         try {
             $this->projects = $this->list($params);
         } catch (Exception $e) {
-            if ($this->getLastResponse()->getBody() === '') {
+            if ($this->getLastResponse()->getContent() === '') {
                 return false;
             }
 

--- a/src/Redmine/Api/Query.php
+++ b/src/Redmine/Api/Query.php
@@ -55,7 +55,7 @@ class Query extends AbstractApi
         try {
             $this->query = $this->list($params);
         } catch (Exception $e) {
-            if ($this->getLastResponse()->getBody() === '') {
+            if ($this->getLastResponse()->getContent() === '') {
                 return false;
             }
 

--- a/src/Redmine/Api/Role.php
+++ b/src/Redmine/Api/Role.php
@@ -55,7 +55,7 @@ class Role extends AbstractApi
         try {
             $this->roles = $this->list($params);
         } catch (Exception $e) {
-            if ($this->getLastResponse()->getBody() === '') {
+            if ($this->getLastResponse()->getContent() === '') {
                 return false;
             }
 

--- a/src/Redmine/Api/Search.php
+++ b/src/Redmine/Api/Search.php
@@ -55,7 +55,7 @@ class Search extends AbstractApi
         try {
             $this->results = $this->listByQuery($query, $params);
         } catch (Exception $e) {
-            if ($this->getLastResponse()->getBody() === '') {
+            if ($this->getLastResponse()->getContent() === '') {
                 return false;
             }
 

--- a/src/Redmine/Api/TimeEntry.php
+++ b/src/Redmine/Api/TimeEntry.php
@@ -57,7 +57,7 @@ class TimeEntry extends AbstractApi
         try {
             $this->timeEntries = $this->list($params);
         } catch (Exception $e) {
-            if ($this->getLastResponse()->getBody() === '') {
+            if ($this->getLastResponse()->getContent() === '') {
                 return false;
             }
 

--- a/src/Redmine/Api/TimeEntryActivity.php
+++ b/src/Redmine/Api/TimeEntryActivity.php
@@ -51,7 +51,7 @@ class TimeEntryActivity extends AbstractApi
         try {
             $this->timeEntryActivities = $this->list($params);
         } catch (Exception $e) {
-            if ($this->getLastResponse()->getBody() === '') {
+            if ($this->getLastResponse()->getContent() === '') {
                 return false;
             }
 

--- a/src/Redmine/Api/Tracker.php
+++ b/src/Redmine/Api/Tracker.php
@@ -55,7 +55,7 @@ class Tracker extends AbstractApi
         try {
             $this->trackers = $this->list($params);
         } catch (Exception $e) {
-            if ($this->getLastResponse()->getBody() === '') {
+            if ($this->getLastResponse()->getContent() === '') {
                 return false;
             }
 

--- a/src/Redmine/Api/User.php
+++ b/src/Redmine/Api/User.php
@@ -58,7 +58,7 @@ class User extends AbstractApi
         try {
             $this->users = $this->list($params);
         } catch (Exception $e) {
-            if ($this->getLastResponse()->getBody() === '') {
+            if ($this->getLastResponse()->getContent() === '') {
                 return false;
             }
 

--- a/src/Redmine/Api/Version.php
+++ b/src/Redmine/Api/Version.php
@@ -67,7 +67,7 @@ class Version extends AbstractApi
         try {
             $this->versions = $this->listByProject(strval($project), $params);
         } catch (Exception $e) {
-            if ($this->getLastResponse()->getBody() === '') {
+            if ($this->getLastResponse()->getContent() === '') {
                 return false;
             }
 

--- a/src/Redmine/Api/Wiki.php
+++ b/src/Redmine/Api/Wiki.php
@@ -67,7 +67,7 @@ class Wiki extends AbstractApi
         try {
             $this->wikiPages = $this->listByProject(strval($project), $params);
         } catch (Exception $e) {
-            if ($this->getLastResponse()->getBody() === '') {
+            if ($this->getLastResponse()->getContent() === '') {
                 return false;
             }
 

--- a/src/Redmine/Http/HttpClient.php
+++ b/src/Redmine/Http/HttpClient.php
@@ -20,9 +20,7 @@ interface HttpClient
     /**
      * Create and send a HTTP request and return the response
      *
-     * @param string $body must be empty string on 'GET' request
-     *
      * @throws ClientException If anything goes wrong on creating or sending the request
      */
-    public function request(string $method, string $path, string $body = ''): Response;
+    public function request(Request $request): Response;
 }

--- a/src/Redmine/Http/HttpClient.php
+++ b/src/Redmine/Http/HttpClient.php
@@ -14,6 +14,8 @@ use Redmine\Exception\ClientException;
  *
  * The client is responsible for ensuring that all data is sent in the correct form and
  * that received data is processed correctly.
+ *
+ * @internal
  */
 interface HttpClient
 {

--- a/src/Redmine/Http/Request.php
+++ b/src/Redmine/Http/Request.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Redmine\Http;
+
+/**
+ * Request interface.
+ *
+ * The method signatures are defined with the intention that an implementing class
+ * can implment this interface and also the PSR-7 `\Psr\Http\Message\RequestInterface`
+ */
+interface Request
+{
+    /**
+     * Returns the http method.
+     */
+    public function getMethod(): string;
+
+    /**
+     * Returns the path with optional attached query string.
+     */
+    public function getPath(): string;
+
+    /**
+     * Returns content type.
+     */
+    public function getContentType(): string;
+
+    /**
+     * Returns the body content.
+     */
+    public function getContent(): string;
+}

--- a/src/Redmine/Http/Request.php
+++ b/src/Redmine/Http/Request.php
@@ -9,6 +9,8 @@ namespace Redmine\Http;
  *
  * The method signatures are defined with the intention that an implementing class
  * can implment this interface and also the PSR-7 `\Psr\Http\Message\RequestInterface`
+ *
+ * @internal
  */
 interface Request
 {

--- a/src/Redmine/Http/Response.php
+++ b/src/Redmine/Http/Response.php
@@ -9,6 +9,8 @@ namespace Redmine\Http;
  *
  * The method signatures are defined with the intention that an implementing class
  * can implment this interface and also the PSR-7 `\Psr\Http\Message\ResponseInterface`
+ *
+ * @internal
  */
 interface Response
 {

--- a/src/Redmine/Http/Response.php
+++ b/src/Redmine/Http/Response.php
@@ -26,7 +26,7 @@ interface Response
     public function getContentType(): string;
 
     /**
-     * Returns the body.
+     * Returns the body content.
      */
-    public function getBody(): string;
+    public function getContent(): string;
 }

--- a/tests/Fixtures/AssertingHttpClient.php
+++ b/tests/Fixtures/AssertingHttpClient.php
@@ -88,7 +88,7 @@ final class AssertingHttpClient implements HttpClient
 
         if ($data['content'] !== '' && $data['contentType'] === 'application/xml') {
             $this->testCase->assertXmlStringEqualsXmlString($data['content'], $request->getContent());
-        } else if ($data['content'] !== '' && $data['contentType'] === 'application/json') {
+        } elseif ($data['content'] !== '' && $data['contentType'] === 'application/json') {
             $this->testCase->assertJsonStringEqualsJsonString($data['content'], $request->getContent());
         } else {
             $this->testCase->assertSame($data['content'], $request->getContent());

--- a/tests/Fixtures/AssertingHttpClient.php
+++ b/tests/Fixtures/AssertingHttpClient.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Redmine\Tests\Fixtures;
+
+use PHPUnit\Framework\TestCase;
+use Redmine\Http\HttpClient;
+use Redmine\Http\Request;
+use Redmine\Http\Response;
+
+/**
+ * Asserting http client.
+ *
+ * The reqeust method of this client class can be configured with asserting requests and responses.
+ */
+final class AssertingHttpClient implements HttpClient
+{
+    public static function create(TestCase $testCase, array $dataSet, ...$dataSets): self
+    {
+        $dataSets = array_merge([$dataSet], $dataSets);
+
+        /** @var \PHPUnit\Framework\MockObject\MockObject&HttpClient */
+        $mock = $testCase->getMockBuilder(HttpClient::class)->getMock();
+        $mock->expects($testCase->exactly(count($dataSets)))->method('request');
+
+        $client = new self($testCase, $mock);
+
+        foreach ($dataSets as $data) {
+            $client->assertRequestData(...$data);
+        }
+
+        return $client;
+    }
+
+    private $testCase;
+    private $client;
+    private $fifoStack = [];
+
+    private function __construct(TestCase $testCase, HttpClient $client)
+    {
+        $this->testCase = $testCase;
+        $this->client = $client;
+    }
+
+    private function assertRequestData(
+        string $method,
+        string $path,
+        string $contentType,
+        string $content = '',
+        int $responseCode = 200,
+        string $responseContentType = '',
+        string $responseContent = '',
+    ) {
+        if ($responseContentType === '') {
+            $responseContentType = $contentType;
+        }
+
+        array_push($this->fifoStack, [
+            'method' => $method,
+            'path' => $path,
+            'contentType' => $contentType,
+            'content' => $content,
+            'responseCode' => $responseCode,
+            'responseContentType' => $responseContentType,
+            'responseContent' => $responseContent,
+        ]);
+    }
+
+    public function request(Request $request): Response
+    {
+        $this->client->request($request);
+
+        $data = array_shift($this->fifoStack);
+
+        if (! is_array($data)) {
+            throw new \Exception(sprintf(
+                'Mssing request data for Request "%s %s" with Content-Type "%s".',
+                $request->getMethod(),
+                $request->getPath(),
+                $request->getContentType()
+            ));
+        }
+
+        $this->testCase->assertSame($data['method'], $request->getMethod());
+        $this->testCase->assertSame($data['path'], $request->getPath());
+        $this->testCase->assertSame($data['contentType'], $request->getContentType());
+
+        if ($data['content'] !== '' && $data['contentType'] === 'application/xml') {
+            $this->testCase->assertXmlStringEqualsXmlString($data['content'], $request->getContent());
+        } else if ($data['content'] !== '' && $data['contentType'] === 'application/json') {
+            $this->testCase->assertJsonStringEqualsJsonString($data['content'], $request->getContent());
+        } else {
+            $this->testCase->assertSame($data['content'], $request->getContent());
+        }
+
+        /** @var \PHPUnit\Framework\MockObject\MockObject&Response */
+        $response = $this->testCase->getMockBuilder(Response::class)->getMock();
+
+        $response->method('getStatusCode')->willReturn($data['responseCode']);
+        $response->method('getContentType')->willReturn($data['responseContentType']);
+        $response->method('getContent')->willReturn($data['responseContent']);
+
+        return $response;
+    }
+}

--- a/tests/Fixtures/AssertingHttpClient.php
+++ b/tests/Fixtures/AssertingHttpClient.php
@@ -50,7 +50,7 @@ final class AssertingHttpClient implements HttpClient
         string $content = '',
         int $responseCode = 200,
         string $responseContentType = '',
-        string $responseContent = '',
+        string $responseContent = ''
     ) {
         if ($responseContentType === '') {
             $responseContentType = $contentType;

--- a/tests/Unit/Api/AbstractApi/DeleteTest.php
+++ b/tests/Unit/Api/AbstractApi/DeleteTest.php
@@ -7,10 +7,8 @@ namespace Redmine\Tests\Unit\Api\AbstractApi;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\AbstractApi;
 use Redmine\Client\Client;
-use Redmine\Http\HttpClient;
-use Redmine\Http\Response;
+use Redmine\Tests\Fixtures\AssertingHttpClient;
 use ReflectionMethod;
-use SimpleXMLElement;
 
 /**
  * @covers \Redmine\Api\AbstractApi::delete
@@ -19,13 +17,18 @@ class DeleteTest extends TestCase
 {
     public function testDeleteWithHttpClient()
     {
-        $response = $this->createMock(Response::class);
-        $response->expects($this->any())->method('getStatusCode')->willReturn(200);
-        $response->expects($this->any())->method('getContentType')->willReturn('application/xml');
-        $response->expects($this->any())->method('getContent')->willReturn('<?xml version="1.0"?><issue/>');
-
-        $client = $this->createMock(HttpClient::class);
-        $client->expects($this->exactly(1))->method('request')->with('DELETE', 'path.xml', '')->willReturn($response);
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'DELETE',
+                'path.xml',
+                'application/xml',
+                '',
+                200,
+                'application/xml',
+                '<?xml version="1.0"?><issue/>'
+            ]
+        );
 
         $api = new class ($client) extends AbstractApi {};
 

--- a/tests/Unit/Api/AbstractApi/DeleteTest.php
+++ b/tests/Unit/Api/AbstractApi/DeleteTest.php
@@ -22,7 +22,7 @@ class DeleteTest extends TestCase
         $response = $this->createMock(Response::class);
         $response->expects($this->any())->method('getStatusCode')->willReturn(200);
         $response->expects($this->any())->method('getContentType')->willReturn('application/xml');
-        $response->expects($this->any())->method('getBody')->willReturn('<?xml version="1.0"?><issue/>');
+        $response->expects($this->any())->method('getContent')->willReturn('<?xml version="1.0"?><issue/>');
 
         $client = $this->createMock(HttpClient::class);
         $client->expects($this->exactly(1))->method('request')->with('DELETE', 'path.xml', '')->willReturn($response);

--- a/tests/Unit/Api/AbstractApi/GetTest.php
+++ b/tests/Unit/Api/AbstractApi/GetTest.php
@@ -7,8 +7,7 @@ namespace Redmine\Tests\Unit\Api\AbstractApi;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\AbstractApi;
 use Redmine\Client\Client;
-use Redmine\Http\HttpClient;
-use Redmine\Http\Response;
+use Redmine\Tests\Fixtures\AssertingHttpClient;
 use ReflectionMethod;
 use SimpleXMLElement;
 
@@ -19,13 +18,18 @@ class GetTest extends TestCase
 {
     public function testGetWithHttpClient()
     {
-        $response = $this->createMock(Response::class);
-        $response->expects($this->any())->method('getStatusCode')->willReturn(200);
-        $response->expects($this->any())->method('getContentType')->willReturn('application/json');
-        $response->expects($this->any())->method('getContent')->willReturn('{"foo_bar": 12345}');
-
-        $client = $this->createMock(HttpClient::class);
-        $client->expects($this->exactly(1))->method('request')->with('GET', 'path.json')->willReturn($response);
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'GET',
+                'path.json',
+                'application/json',
+                '',
+                200,
+                'application/json',
+                '{"foo_bar": 12345}'
+            ]
+        );
 
         $api = new class ($client) extends AbstractApi {};
 

--- a/tests/Unit/Api/AbstractApi/GetTest.php
+++ b/tests/Unit/Api/AbstractApi/GetTest.php
@@ -22,7 +22,7 @@ class GetTest extends TestCase
         $response = $this->createMock(Response::class);
         $response->expects($this->any())->method('getStatusCode')->willReturn(200);
         $response->expects($this->any())->method('getContentType')->willReturn('application/json');
-        $response->expects($this->any())->method('getBody')->willReturn('{"foo_bar": 12345}');
+        $response->expects($this->any())->method('getContent')->willReturn('{"foo_bar": 12345}');
 
         $client = $this->createMock(HttpClient::class);
         $client->expects($this->exactly(1))->method('request')->with('GET', 'path.json')->willReturn($response);

--- a/tests/Unit/Api/AbstractApi/PostTest.php
+++ b/tests/Unit/Api/AbstractApi/PostTest.php
@@ -22,7 +22,7 @@ class PostTest extends TestCase
         $response = $this->createMock(Response::class);
         $response->expects($this->any())->method('getStatusCode')->willReturn(200);
         $response->expects($this->any())->method('getContentType')->willReturn('application/xml');
-        $response->expects($this->any())->method('getBody')->willReturn('<?xml version="1.0"?><issue/>');
+        $response->expects($this->any())->method('getContent')->willReturn('<?xml version="1.0"?><issue/>');
 
         $client = $this->createMock(HttpClient::class);
         $client->expects($this->exactly(1))->method('request')->with('POST', 'path.xml', '')->willReturn($response);

--- a/tests/Unit/Api/AbstractApi/PostTest.php
+++ b/tests/Unit/Api/AbstractApi/PostTest.php
@@ -7,8 +7,7 @@ namespace Redmine\Tests\Unit\Api\AbstractApi;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\AbstractApi;
 use Redmine\Client\Client;
-use Redmine\Http\HttpClient;
-use Redmine\Http\Response;
+use Redmine\Tests\Fixtures\AssertingHttpClient;
 use ReflectionMethod;
 use SimpleXMLElement;
 
@@ -19,13 +18,18 @@ class PostTest extends TestCase
 {
     public function testPostWithHttpClient()
     {
-        $response = $this->createMock(Response::class);
-        $response->expects($this->any())->method('getStatusCode')->willReturn(200);
-        $response->expects($this->any())->method('getContentType')->willReturn('application/xml');
-        $response->expects($this->any())->method('getContent')->willReturn('<?xml version="1.0"?><issue/>');
-
-        $client = $this->createMock(HttpClient::class);
-        $client->expects($this->exactly(1))->method('request')->with('POST', 'path.xml', '')->willReturn($response);
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'POST',
+                'path.xml',
+                'application/xml',
+                '',
+                200,
+                'application/xml',
+                '<?xml version="1.0"?><issue/>'
+            ]
+        );
 
         $api = new class ($client) extends AbstractApi {};
 

--- a/tests/Unit/Api/AbstractApi/PutTest.php
+++ b/tests/Unit/Api/AbstractApi/PutTest.php
@@ -7,8 +7,7 @@ namespace Redmine\Tests\Unit\Api\AbstractApi;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\AbstractApi;
 use Redmine\Client\Client;
-use Redmine\Http\HttpClient;
-use Redmine\Http\Response;
+use Redmine\Tests\Fixtures\AssertingHttpClient;
 use ReflectionMethod;
 use SimpleXMLElement;
 
@@ -19,13 +18,18 @@ class PutTest extends TestCase
 {
     public function testPutWithHttpClient()
     {
-        $response = $this->createMock(Response::class);
-        $response->expects($this->any())->method('getStatusCode')->willReturn(200);
-        $response->expects($this->any())->method('getContentType')->willReturn('application/xml');
-        $response->expects($this->any())->method('getContent')->willReturn('<?xml version="1.0"?><issue/>');
-
-        $client = $this->createMock(HttpClient::class);
-        $client->expects($this->exactly(1))->method('request')->with('PUT', 'path.xml', '')->willReturn($response);
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'PUT',
+                'path.xml',
+                'application/xml',
+                '',
+                200,
+                'application/xml',
+                '<?xml version="1.0"?><issue/>'
+            ]
+        );
 
         $api = new class ($client) extends AbstractApi {};
 

--- a/tests/Unit/Api/AbstractApi/PutTest.php
+++ b/tests/Unit/Api/AbstractApi/PutTest.php
@@ -22,7 +22,7 @@ class PutTest extends TestCase
         $response = $this->createMock(Response::class);
         $response->expects($this->any())->method('getStatusCode')->willReturn(200);
         $response->expects($this->any())->method('getContentType')->willReturn('application/xml');
-        $response->expects($this->any())->method('getBody')->willReturn('<?xml version="1.0"?><issue/>');
+        $response->expects($this->any())->method('getContent')->willReturn('<?xml version="1.0"?><issue/>');
 
         $client = $this->createMock(HttpClient::class);
         $client->expects($this->exactly(1))->method('request')->with('PUT', 'path.xml', '')->willReturn($response);

--- a/tests/Unit/Api/AbstractApiTest.php
+++ b/tests/Unit/Api/AbstractApiTest.php
@@ -8,7 +8,6 @@ use Redmine\Api\AbstractApi;
 use Redmine\Client\Client;
 use Redmine\Exception\SerializerException;
 use Redmine\Http\HttpClient;
-use Redmine\Http\Request;
 use Redmine\Http\Response;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 use ReflectionMethod;

--- a/tests/Unit/Api/Group/CreateTest.php
+++ b/tests/Unit/Api/Group/CreateTest.php
@@ -30,7 +30,7 @@ class CreateTest extends TestCase
                     Response::class,
                     [
                         'getContentType' => 'application/xml',
-                        'getBody' => '<?xml version="1.0"?><group></group>',
+                        'getContent' => '<?xml version="1.0"?><group></group>',
                     ]
                 );
             });
@@ -62,7 +62,7 @@ class CreateTest extends TestCase
                     Response::class,
                     [
                         'getContentType' => 'application/xml',
-                        'getBody' => '<?xml version="1.0"?><group></group>',
+                        'getContent' => '<?xml version="1.0"?><group></group>',
                     ]
                 );
             });
@@ -94,7 +94,7 @@ class CreateTest extends TestCase
                     Response::class,
                     [
                         'getContentType' => 'application/xml',
-                        'getBody' => '<?xml version="1.0"?><group></group>',
+                        'getContent' => '<?xml version="1.0"?><group></group>',
                     ]
                 );
             });

--- a/tests/Unit/Api/Group/CreateTest.php
+++ b/tests/Unit/Api/Group/CreateTest.php
@@ -8,8 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Redmine\Api\Group;
 use Redmine\Exception\MissingParameterException;
 use Redmine\Http\HttpClient;
-use Redmine\Http\Request;
-use Redmine\Http\Response;
+use Redmine\Tests\Fixtures\AssertingHttpClient;
 use SimpleXMLElement;
 
 /**
@@ -19,23 +18,18 @@ class CreateTest extends TestCase
 {
     public function testCreateWithNameCreatesGroup()
     {
-        $client = $this->createMock(HttpClient::class);
-        $client->expects($this->exactly(1))
-            ->method('request')
-            ->willReturnCallback(function (Request $request) {
-                $this->assertSame('POST', $request->getMethod());
-                $this->assertSame('/groups.xml', $request->getPath());
-                $this->assertSame('application/xml', $request->getContentType());
-                $this->assertXmlStringEqualsXmlString('<?xml version="1.0"?><group><name>Group Name</name></group>', $request->getContent());
-
-                return $this->createConfiguredMock(
-                    Response::class,
-                    [
-                        'getContentType' => 'application/xml',
-                        'getContent' => '<?xml version="1.0"?><group></group>',
-                    ]
-                );
-            });
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'POST',
+                '/groups.xml',
+                'application/xml',
+                '<?xml version="1.0"?><group><name>Group Name</name></group>',
+                200,
+                'application/xml',
+                '<?xml version="1.0"?><group></group>'
+            ]
+        );
 
         // Create the object under test
         $api = new Group($client);
@@ -52,23 +46,18 @@ class CreateTest extends TestCase
 
     public function testCreateWithNameAndUserIdsCreatesGroup()
     {
-        $client = $this->createMock(HttpClient::class);
-        $client->expects($this->exactly(1))
-            ->method('request')
-            ->willReturnCallback(function (Request $request) {
-                $this->assertSame('POST', $request->getMethod());
-                $this->assertSame('/groups.xml', $request->getPath());
-                $this->assertSame('application/xml', $request->getContentType());
-                $this->assertXmlStringEqualsXmlString('<?xml version="1.0"?><group><name>Group Name</name><user_ids type="array"><user_id>1</user_id><user_id>2</user_id><user_id>3</user_id></user_ids></group>', $request->getContent());
-
-                return $this->createConfiguredMock(
-                    Response::class,
-                    [
-                        'getContentType' => 'application/xml',
-                        'getContent' => '<?xml version="1.0"?><group></group>',
-                    ]
-                );
-            });
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'POST',
+                '/groups.xml',
+                'application/xml',
+                '<?xml version="1.0"?><group><name>Group Name</name><user_ids type="array"><user_id>1</user_id><user_id>2</user_id><user_id>3</user_id></user_ids></group>',
+                200,
+                'application/xml',
+                '<?xml version="1.0"?><group></group>'
+            ]
+        );
 
         // Create the object under test
         $api = new Group($client);
@@ -85,23 +74,18 @@ class CreateTest extends TestCase
 
     public function testCreateWithNameAndCustomFieldsCreatesGroup()
     {
-        $client = $this->createMock(HttpClient::class);
-        $client->expects($this->exactly(1))
-            ->method('request')
-            ->willReturnCallback(function (Request $request) {
-                $this->assertSame('POST', $request->getMethod());
-                $this->assertSame('/groups.xml', $request->getPath());
-                $this->assertSame('application/xml', $request->getContentType());
-                $this->assertXmlStringEqualsXmlString('<?xml version="1.0"?><group><name>Group Name</name><custom_fields type="array"><custom_field id="1"><value>5</value></custom_field></custom_fields></group>', $request->getContent());
-
-                return $this->createConfiguredMock(
-                    Response::class,
-                    [
-                        'getContentType' => 'application/xml',
-                        'getContent' => '<?xml version="1.0"?><group></group>',
-                    ]
-                );
-            });
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'POST',
+                '/groups.xml',
+                'application/xml',
+                '<?xml version="1.0"?><group><name>Group Name</name><custom_fields type="array"><custom_field id="1"><value>5</value></custom_field></custom_fields></group>',
+                200,
+                'application/xml',
+                '<?xml version="1.0"?><group></group>'
+            ]
+        );
 
         // Create the object under test
         $api = new Group($client);

--- a/tests/Unit/Api/Group/CreateTest.php
+++ b/tests/Unit/Api/Group/CreateTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Redmine\Api\Group;
 use Redmine\Exception\MissingParameterException;
 use Redmine\Http\HttpClient;
+use Redmine\Http\Request;
 use Redmine\Http\Response;
 use SimpleXMLElement;
 
@@ -21,10 +22,11 @@ class CreateTest extends TestCase
         $client = $this->createMock(HttpClient::class);
         $client->expects($this->exactly(1))
             ->method('request')
-            ->willReturnCallback(function (string $method, string $path, string $body = '') {
-                $this->assertSame('POST', $method);
-                $this->assertSame('/groups.xml', $path);
-                $this->assertXmlStringEqualsXmlString('<?xml version="1.0"?><group><name>Group Name</name></group>', $body);
+            ->willReturnCallback(function (Request $request) {
+                $this->assertSame('POST', $request->getMethod());
+                $this->assertSame('/groups.xml', $request->getPath());
+                $this->assertSame('application/xml', $request->getContentType());
+                $this->assertXmlStringEqualsXmlString('<?xml version="1.0"?><group><name>Group Name</name></group>', $request->getContent());
 
                 return $this->createConfiguredMock(
                     Response::class,
@@ -53,10 +55,11 @@ class CreateTest extends TestCase
         $client = $this->createMock(HttpClient::class);
         $client->expects($this->exactly(1))
             ->method('request')
-            ->willReturnCallback(function (string $method, string $path, string $body = '') {
-                $this->assertSame('POST', $method);
-                $this->assertSame('/groups.xml', $path);
-                $this->assertXmlStringEqualsXmlString('<?xml version="1.0"?><group><name>Group Name</name><user_ids type="array"><user_id>1</user_id><user_id>2</user_id><user_id>3</user_id></user_ids></group>', $body);
+            ->willReturnCallback(function (Request $request) {
+                $this->assertSame('POST', $request->getMethod());
+                $this->assertSame('/groups.xml', $request->getPath());
+                $this->assertSame('application/xml', $request->getContentType());
+                $this->assertXmlStringEqualsXmlString('<?xml version="1.0"?><group><name>Group Name</name><user_ids type="array"><user_id>1</user_id><user_id>2</user_id><user_id>3</user_id></user_ids></group>', $request->getContent());
 
                 return $this->createConfiguredMock(
                     Response::class,
@@ -85,10 +88,11 @@ class CreateTest extends TestCase
         $client = $this->createMock(HttpClient::class);
         $client->expects($this->exactly(1))
             ->method('request')
-            ->willReturnCallback(function (string $method, string $path, string $body = '') {
-                $this->assertSame('POST', $method);
-                $this->assertSame('/groups.xml', $path);
-                $this->assertXmlStringEqualsXmlString('<?xml version="1.0"?><group><name>Group Name</name><custom_fields type="array"><custom_field id="1"><value>5</value></custom_field></custom_fields></group>', $body);
+            ->willReturnCallback(function (Request $request) {
+                $this->assertSame('POST', $request->getMethod());
+                $this->assertSame('/groups.xml', $request->getPath());
+                $this->assertSame('application/xml', $request->getContentType());
+                $this->assertXmlStringEqualsXmlString('<?xml version="1.0"?><group><name>Group Name</name><custom_fields type="array"><custom_field id="1"><value>5</value></custom_field></custom_fields></group>', $request->getContent());
 
                 return $this->createConfiguredMock(
                     Response::class,

--- a/tests/Unit/Api/Group/UpdateTest.php
+++ b/tests/Unit/Api/Group/UpdateTest.php
@@ -7,6 +7,7 @@ namespace Redmine\Tests\Unit\Api\Group;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Group;
 use Redmine\Http\HttpClient;
+use Redmine\Http\Request;
 use Redmine\Http\Response;
 use SimpleXMLElement;
 
@@ -20,10 +21,11 @@ class UpdateTest extends TestCase
         $client = $this->createMock(HttpClient::class);
         $client->expects($this->exactly(1))
             ->method('request')
-            ->willReturnCallback(function (string $method, string $path, string $body = '') {
-                $this->assertSame('PUT', $method);
-                $this->assertSame('/groups/1.xml', $path);
-                $this->assertXmlStringEqualsXmlString('<?xml version="1.0"?><group><name>Group Name</name></group>', $body);
+            ->willReturnCallback(function (Request $request) {
+                $this->assertSame('PUT', $request->getMethod());
+                $this->assertSame('/groups/1.xml', $request->getPath());
+                $this->assertSame('application/xml', $request->getContentType());
+                $this->assertXmlStringEqualsXmlString('<?xml version="1.0"?><group><name>Group Name</name></group>', $request->getContent());
 
                 return $this->createConfiguredMock(
                     Response::class,
@@ -48,10 +50,11 @@ class UpdateTest extends TestCase
         $client = $this->createMock(HttpClient::class);
         $client->expects($this->exactly(1))
             ->method('request')
-            ->willReturnCallback(function (string $method, string $path, string $body = '') {
-                $this->assertSame('PUT', $method);
-                $this->assertSame('/groups/1.xml', $path);
-                $this->assertXmlStringEqualsXmlString('<?xml version="1.0"?><group><user_ids type="array"><user_id>1</user_id><user_id>2</user_id><user_id>3</user_id></user_ids></group>', $body);
+            ->willReturnCallback(function (Request $request) {
+                $this->assertSame('PUT', $request->getMethod());
+                $this->assertSame('/groups/1.xml', $request->getPath());
+                $this->assertSame('application/xml', $request->getContentType());
+                $this->assertXmlStringEqualsXmlString('<?xml version="1.0"?><group><user_ids type="array"><user_id>1</user_id><user_id>2</user_id><user_id>3</user_id></user_ids></group>', $request->getContent());
 
                 return $this->createConfiguredMock(
                     Response::class,
@@ -76,10 +79,11 @@ class UpdateTest extends TestCase
         $client = $this->createMock(HttpClient::class);
         $client->expects($this->exactly(1))
             ->method('request')
-            ->willReturnCallback(function (string $method, string $path, string $body = '') {
-                $this->assertSame('PUT', $method);
-                $this->assertSame('/groups/1.xml', $path);
-                $this->assertXmlStringEqualsXmlString('<?xml version="1.0"?><group><custom_fields type="array"><custom_field id="1"><value>5</value></custom_field></custom_fields></group>', $body);
+            ->willReturnCallback(function (Request $request) {
+                $this->assertSame('PUT', $request->getMethod());
+                $this->assertSame('/groups/1.xml', $request->getPath());
+                $this->assertSame('application/xml', $request->getContentType());
+                $this->assertXmlStringEqualsXmlString('<?xml version="1.0"?><group><custom_fields type="array"><custom_field id="1"><value>5</value></custom_field></custom_fields></group>', $request->getContent());
 
                 return $this->createConfiguredMock(
                     Response::class,

--- a/tests/Unit/Api/Group/UpdateTest.php
+++ b/tests/Unit/Api/Group/UpdateTest.php
@@ -29,7 +29,7 @@ class UpdateTest extends TestCase
                     Response::class,
                     [
                         'getContentType' => 'application/xml',
-                        'getBody' => '',
+                        'getContent' => '',
                     ]
                 );
             });
@@ -57,7 +57,7 @@ class UpdateTest extends TestCase
                     Response::class,
                     [
                         'getContentType' => 'application/xml',
-                        'getBody' => '',
+                        'getContent' => '',
                     ]
                 );
             });
@@ -85,7 +85,7 @@ class UpdateTest extends TestCase
                     Response::class,
                     [
                         'getContentType' => 'application/xml',
-                        'getBody' => '',
+                        'getContent' => '',
                     ]
                 );
             });

--- a/tests/Unit/Api/Group/UpdateTest.php
+++ b/tests/Unit/Api/Group/UpdateTest.php
@@ -6,10 +6,7 @@ namespace Redmine\Tests\Unit\Api\Group;
 
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Group;
-use Redmine\Http\HttpClient;
-use Redmine\Http\Request;
-use Redmine\Http\Response;
-use SimpleXMLElement;
+use Redmine\Tests\Fixtures\AssertingHttpClient;
 
 /**
  * @covers \Redmine\Api\Group::update
@@ -18,23 +15,18 @@ class UpdateTest extends TestCase
 {
     public function testUpdateWithNameUpdatesGroup()
     {
-        $client = $this->createMock(HttpClient::class);
-        $client->expects($this->exactly(1))
-            ->method('request')
-            ->willReturnCallback(function (Request $request) {
-                $this->assertSame('PUT', $request->getMethod());
-                $this->assertSame('/groups/1.xml', $request->getPath());
-                $this->assertSame('application/xml', $request->getContentType());
-                $this->assertXmlStringEqualsXmlString('<?xml version="1.0"?><group><name>Group Name</name></group>', $request->getContent());
-
-                return $this->createConfiguredMock(
-                    Response::class,
-                    [
-                        'getContentType' => 'application/xml',
-                        'getContent' => '',
-                    ]
-                );
-            });
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'PUT',
+                '/groups/1.xml',
+                'application/xml',
+                '<?xml version="1.0"?><group><name>Group Name</name></group>',
+                200,
+                'application/xml',
+                ''
+            ]
+        );
 
         // Create the object under test
         $api = new Group($client);
@@ -47,23 +39,18 @@ class UpdateTest extends TestCase
 
     public function testUpdateWithUserIdsUpdatesGroup()
     {
-        $client = $this->createMock(HttpClient::class);
-        $client->expects($this->exactly(1))
-            ->method('request')
-            ->willReturnCallback(function (Request $request) {
-                $this->assertSame('PUT', $request->getMethod());
-                $this->assertSame('/groups/1.xml', $request->getPath());
-                $this->assertSame('application/xml', $request->getContentType());
-                $this->assertXmlStringEqualsXmlString('<?xml version="1.0"?><group><user_ids type="array"><user_id>1</user_id><user_id>2</user_id><user_id>3</user_id></user_ids></group>', $request->getContent());
-
-                return $this->createConfiguredMock(
-                    Response::class,
-                    [
-                        'getContentType' => 'application/xml',
-                        'getContent' => '',
-                    ]
-                );
-            });
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'PUT',
+                '/groups/1.xml',
+                'application/xml',
+                '<?xml version="1.0"?><group><user_ids type="array"><user_id>1</user_id><user_id>2</user_id><user_id>3</user_id></user_ids></group>',
+                200,
+                'application/xml',
+                ''
+            ]
+        );
 
         // Create the object under test
         $api = new Group($client);
@@ -76,23 +63,18 @@ class UpdateTest extends TestCase
 
     public function testUpdateWithCustomFieldsUpdatesGroup()
     {
-        $client = $this->createMock(HttpClient::class);
-        $client->expects($this->exactly(1))
-            ->method('request')
-            ->willReturnCallback(function (Request $request) {
-                $this->assertSame('PUT', $request->getMethod());
-                $this->assertSame('/groups/1.xml', $request->getPath());
-                $this->assertSame('application/xml', $request->getContentType());
-                $this->assertXmlStringEqualsXmlString('<?xml version="1.0"?><group><custom_fields type="array"><custom_field id="1"><value>5</value></custom_field></custom_fields></group>', $request->getContent());
-
-                return $this->createConfiguredMock(
-                    Response::class,
-                    [
-                        'getContentType' => 'application/xml',
-                        'getContent' => '',
-                    ]
-                );
-            });
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'PUT',
+                '/groups/1.xml',
+                'application/xml',
+                '<?xml version="1.0"?><group><custom_fields type="array"><custom_field id="1"><value>5</value></custom_field></custom_fields></group>',
+                200,
+                'application/xml',
+                ''
+            ]
+        );
 
         // Create the object under test
         $api = new Group($client);

--- a/tests/Unit/Api/IssueTest.php
+++ b/tests/Unit/Api/IssueTest.php
@@ -5,9 +5,6 @@ namespace Redmine\Tests\Unit\Api;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Issue;
 use Redmine\Client\Client;
-use Redmine\Http\HttpClient;
-use Redmine\Http\Request;
-use Redmine\Http\Response;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 use Redmine\Tests\Fixtures\MockClient;
 use SimpleXMLElement;
@@ -561,40 +558,27 @@ class IssueTest extends TestCase
      */
     public function testCreateWithHttpClientRetrievesProjectId()
     {
-        $client = $this->createMock(HttpClient::class);
-        $client->expects($this->exactly(2))
-            ->method('request')
-            ->willReturnCallback(function (Request $request) {
-                if ($request->getMethod() === 'GET') {
-                    $this->assertSame('/projects.json', $request->getPath());
-                    $this->assertSame('application/json', $request->getContentType());
-                    $this->assertSame('', $request->getContent());
-
-                    return $this->createConfiguredMock(
-                        Response::class,
-                        [
-                            'getContentType' => 'application/json',
-                            'getContent' => '{"projects":[{"name":"Project Name","id":3}]}',
-                        ]
-                    );
-                }
-
-                if ($request->getMethod() === 'POST') {
-                    $this->assertSame('/issues.xml', $request->getPath());
-                    $this->assertSame('application/xml', $request->getContentType());
-                    $this->assertXmlStringEqualsXmlString('<?xml version="1.0"?><issue><project_id>3</project_id></issue>', $request->getContent());
-
-                    return $this->createConfiguredMock(
-                        Response::class,
-                        [
-                            'getContentType' => 'application/xml',
-                            'getContent' => '<?xml version="1.0"?><issue></issue>',
-                        ]
-                    );
-                }
-
-                throw new \Exception();
-            });
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'GET',
+                '/projects.json',
+                'application/json',
+                '',
+                200,
+                'application/json',
+                '{"projects":[{"name":"Project Name","id":3}]}'
+            ],
+            [
+                'POST',
+                '/issues.xml',
+                'application/xml',
+                '<?xml version="1.0"?><issue><project_id>3</project_id></issue>',
+                200,
+                'application/xml',
+                '<?xml version="1.0"?><issue></issue>'
+            ]
+        );
 
         // Create the object under test
         $api = new Issue($client);
@@ -617,40 +601,27 @@ class IssueTest extends TestCase
      */
     public function testCreateWithHttpClientRetrievesIssueCategoryId()
     {
-        $client = $this->createMock(HttpClient::class);
-        $client->expects($this->exactly(2))
-            ->method('request')
-            ->willReturnCallback(function (Request $request) {
-                if ($request->getMethod() === 'GET') {
-                    $this->assertSame('/projects/3/issue_categories.json', $request->getPath());
-                    $this->assertSame('application/json', $request->getContentType());
-                    $this->assertSame('', $request->getContent());
-
-                    return $this->createConfiguredMock(
-                        Response::class,
-                        [
-                            'getContentType' => 'application/json',
-                            'getContent' => '{"issue_categories":[{"name":"Category Name","id":45}]}',
-                        ]
-                    );
-                }
-
-                if ($request->getMethod() === 'POST') {
-                    $this->assertSame('/issues.xml', $request->getPath());
-                    $this->assertSame('application/xml', $request->getContentType());
-                    $this->assertXmlStringEqualsXmlString('<?xml version="1.0"?><issue><project_id>3</project_id><category_id>45</category_id></issue>', $request->getContent());
-
-                    return $this->createConfiguredMock(
-                        Response::class,
-                        [
-                            'getContentType' => 'application/xml',
-                            'getContent' => '<?xml version="1.0"?><issue></issue>',
-                        ]
-                    );
-                }
-
-                throw new \Exception();
-            });
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'GET',
+                '/projects/3/issue_categories.json',
+                'application/json',
+                '',
+                200,
+                'application/json',
+                '{"issue_categories":[{"name":"Category Name","id":45}]}'
+            ],
+            [
+                'POST',
+                '/issues.xml',
+                'application/xml',
+                '<?xml version="1.0"?><issue><project_id>3</project_id><category_id>45</category_id></issue>',
+                200,
+                'application/xml',
+                '<?xml version="1.0"?><issue></issue>'
+            ]
+        );
 
         // Create the object under test
         $api = new Issue($client);
@@ -673,40 +644,27 @@ class IssueTest extends TestCase
      */
     public function testCreateWithHttpClientRetrievesTrackerId()
     {
-        $client = $this->createMock(HttpClient::class);
-        $client->expects($this->exactly(2))
-            ->method('request')
-            ->willReturnCallback(function (Request $request) {
-                if ($request->getMethod() === 'GET') {
-                    $this->assertSame('/trackers.json', $request->getPath());
-                    $this->assertSame('application/json', $request->getContentType());
-                    $this->assertSame('', $request->getContent());
-
-                    return $this->createConfiguredMock(
-                        Response::class,
-                        [
-                            'getContentType' => 'application/json',
-                            'getContent' => '{"trackers":[{"name":"Tracker Name","id":9}]}',
-                        ]
-                    );
-                }
-
-                if ($request->getMethod() === 'POST') {
-                    $this->assertSame('/issues.xml', $request->getPath());
-                    $this->assertSame('application/xml', $request->getContentType());
-                    $this->assertXmlStringEqualsXmlString('<?xml version="1.0"?><issue><tracker_id>9</tracker_id></issue>', $request->getContent());
-
-                    return $this->createConfiguredMock(
-                        Response::class,
-                        [
-                            'getContentType' => 'application/xml',
-                            'getContent' => '<?xml version="1.0"?><issue></issue>',
-                        ]
-                    );
-                }
-
-                throw new \Exception();
-            });
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'GET',
+                '/trackers.json',
+                'application/json',
+                '',
+                200,
+                'application/json',
+                '{"trackers":[{"name":"Tracker Name","id":9}]}'
+            ],
+            [
+                'POST',
+                '/issues.xml',
+                'application/xml',
+                '<?xml version="1.0"?><issue><tracker_id>9</tracker_id></issue>',
+                200,
+                'application/xml',
+                '<?xml version="1.0"?><issue></issue>'
+            ]
+        );
 
         // Create the object under test
         $api = new Issue($client);
@@ -729,40 +687,27 @@ class IssueTest extends TestCase
      */
     public function testCreateWithHttpClientRetrievesUserId()
     {
-        $client = $this->createMock(HttpClient::class);
-        $client->expects($this->exactly(2))
-            ->method('request')
-            ->willReturnCallback(function (Request $request) {
-                if ($request->getMethod() === 'GET') {
-                    $this->assertSame('/users.json', $request->getPath());
-                    $this->assertSame('application/json', $request->getContentType());
-                    $this->assertSame('', $request->getContent());
-
-                    return $this->createConfiguredMock(
-                        Response::class,
-                        [
-                            'getContentType' => 'application/json',
-                            'getContent' => '{"users":[{"login":"Author Name","id":5},{"login":"Assigned to User Name","id":6}]}',
-                        ]
-                    );
-                }
-
-                if ($request->getMethod() === 'POST') {
-                    $this->assertSame('/issues.xml', $request->getPath());
-                    $this->assertSame('application/xml', $request->getContentType());
-                    $this->assertXmlStringEqualsXmlString('<?xml version="1.0"?><issue><assigned_to_id>6</assigned_to_id><author_id>5</author_id></issue>', $request->getContent());
-
-                    return $this->createConfiguredMock(
-                        Response::class,
-                        [
-                            'getContentType' => 'application/xml',
-                            'getContent' => '<?xml version="1.0"?><issue></issue>',
-                        ]
-                    );
-                }
-
-                throw new \Exception();
-            });
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'GET',
+                '/users.json',
+                'application/json',
+                '',
+                200,
+                'application/json',
+                '{"users":[{"login":"Author Name","id":5},{"login":"Assigned to User Name","id":6}]}'
+            ],
+            [
+                'POST',
+                '/issues.xml',
+                'application/xml',
+                '<?xml version="1.0"?><issue><assigned_to_id>6</assigned_to_id><author_id>5</author_id></issue>',
+                200,
+                'application/xml',
+                '<?xml version="1.0"?><issue></issue>'
+            ]
+        );
 
         // Create the object under test
         $api = new Issue($client);
@@ -993,40 +938,27 @@ class IssueTest extends TestCase
      */
     public function testSetIssueStatusWithHttpClient()
     {
-        $client = $this->createMock(HttpClient::class);
-        $client->expects($this->exactly(2))
-            ->method('request')
-            ->willReturnCallback(function (Request $request) {
-                if ($request->getMethod() === 'GET') {
-                    $this->assertSame('/issue_statuses.json', $request->getPath());
-                    $this->assertSame('application/json', $request->getContentType());
-                    $this->assertSame('', $request->getContent());
-
-                    return $this->createConfiguredMock(
-                        Response::class,
-                        [
-                            'getContentType' => 'application/json',
-                            'getContent' => '{"issue_statuses":[{"name":"Status Name","id":123}]}',
-                        ]
-                    );
-                }
-
-                if ($request->getMethod() === 'PUT') {
-                    $this->assertSame('/issues/5.xml', $request->getPath());
-                    $this->assertSame('application/xml', $request->getContentType());
-                    $this->assertXmlStringEqualsXmlString('<?xml version="1.0"?><issue><id>5</id><status_id>123</status_id></issue>', $request->getContent());
-
-                    return $this->createConfiguredMock(
-                        Response::class,
-                        [
-                            'getContentType' => 'application/xml',
-                            'getContent' => '<?xml version="1.0"?><issue></issue>',
-                        ]
-                    );
-                }
-
-                throw new \Exception();
-            });
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'GET',
+                '/issue_statuses.json',
+                'application/json',
+                '',
+                200,
+                'application/json',
+                '{"issue_statuses":[{"name":"Status Name","id":123}]}'
+            ],
+            [
+                'PUT',
+                '/issues/5.xml',
+                'application/xml',
+                '<?xml version="1.0"?><issue><id>5</id><status_id>123</status_id></issue>',
+                200,
+                'application/xml',
+                '<?xml version="1.0"?><issue></issue>'
+            ]
+        );
 
         // Create the object under test
         $api = new Issue($client);

--- a/tests/Unit/Api/IssueTest.php
+++ b/tests/Unit/Api/IssueTest.php
@@ -6,7 +6,9 @@ use PHPUnit\Framework\TestCase;
 use Redmine\Api\Issue;
 use Redmine\Client\Client;
 use Redmine\Http\HttpClient;
+use Redmine\Http\Request;
 use Redmine\Http\Response;
+use Redmine\Tests\Fixtures\AssertingHttpClient;
 use Redmine\Tests\Fixtures\MockClient;
 use SimpleXMLElement;
 
@@ -516,38 +518,27 @@ class IssueTest extends TestCase
      */
     public function testCreateWithHttpClientRetrievesIssueStatusId()
     {
-        $client = $this->createMock(HttpClient::class);
-        $client->expects($this->exactly(2))
-            ->method('request')
-            ->willReturnCallback(function (string $method, string $path, string $body = '') {
-                if ($method === 'GET') {
-                    $this->assertSame('/issue_statuses.json', $path);
-                    $this->assertSame('', $body);
-
-                    return $this->createConfiguredMock(
-                        Response::class,
-                        [
-                            'getContentType' => 'application/json',
-                            'getContent' => '{"issue_statuses":[{"name":"Status Name","id":123}]}',
-                        ]
-                    );
-                }
-
-                if ($method === 'POST') {
-                    $this->assertSame('/issues.xml', $path);
-                    $this->assertXmlStringEqualsXmlString('<?xml version="1.0"?><issue><status_id>123</status_id></issue>', $body);
-
-                    return $this->createConfiguredMock(
-                        Response::class,
-                        [
-                            'getContentType' => 'application/xml',
-                            'getContent' => '<?xml version="1.0"?><issue></issue>',
-                        ]
-                    );
-                }
-
-                throw new \Exception();
-            });
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'GET',
+                '/issue_statuses.json',
+                'application/json',
+                '',
+                200,
+                'application/json',
+                '{"issue_statuses":[{"name":"Status Name","id":123}]}'
+            ],
+            [
+                'POST',
+                '/issues.xml',
+                'application/xml',
+                '<?xml version="1.0"?><issue><status_id>123</status_id></issue>',
+                200,
+                'application/xml',
+                '<?xml version="1.0"?><issue></issue>'
+            ]
+        );
 
         // Create the object under test
         $api = new Issue($client);
@@ -573,10 +564,11 @@ class IssueTest extends TestCase
         $client = $this->createMock(HttpClient::class);
         $client->expects($this->exactly(2))
             ->method('request')
-            ->willReturnCallback(function (string $method, string $path, string $body = '') {
-                if ($method === 'GET') {
-                    $this->assertSame('/projects.json', $path);
-                    $this->assertSame('', $body);
+            ->willReturnCallback(function (Request $request) {
+                if ($request->getMethod() === 'GET') {
+                    $this->assertSame('/projects.json', $request->getPath());
+                    $this->assertSame('application/json', $request->getContentType());
+                    $this->assertSame('', $request->getContent());
 
                     return $this->createConfiguredMock(
                         Response::class,
@@ -587,9 +579,10 @@ class IssueTest extends TestCase
                     );
                 }
 
-                if ($method === 'POST') {
-                    $this->assertSame('/issues.xml', $path);
-                    $this->assertXmlStringEqualsXmlString('<?xml version="1.0"?><issue><project_id>3</project_id></issue>', $body);
+                if ($request->getMethod() === 'POST') {
+                    $this->assertSame('/issues.xml', $request->getPath());
+                    $this->assertSame('application/xml', $request->getContentType());
+                    $this->assertXmlStringEqualsXmlString('<?xml version="1.0"?><issue><project_id>3</project_id></issue>', $request->getContent());
 
                     return $this->createConfiguredMock(
                         Response::class,
@@ -627,10 +620,11 @@ class IssueTest extends TestCase
         $client = $this->createMock(HttpClient::class);
         $client->expects($this->exactly(2))
             ->method('request')
-            ->willReturnCallback(function (string $method, string $path, string $body = '') {
-                if ($method === 'GET') {
-                    $this->assertSame('/projects/3/issue_categories.json', $path);
-                    $this->assertSame('', $body);
+            ->willReturnCallback(function (Request $request) {
+                if ($request->getMethod() === 'GET') {
+                    $this->assertSame('/projects/3/issue_categories.json', $request->getPath());
+                    $this->assertSame('application/json', $request->getContentType());
+                    $this->assertSame('', $request->getContent());
 
                     return $this->createConfiguredMock(
                         Response::class,
@@ -641,9 +635,10 @@ class IssueTest extends TestCase
                     );
                 }
 
-                if ($method === 'POST') {
-                    $this->assertSame('/issues.xml', $path);
-                    $this->assertXmlStringEqualsXmlString('<?xml version="1.0"?><issue><project_id>3</project_id><category_id>45</category_id></issue>', $body);
+                if ($request->getMethod() === 'POST') {
+                    $this->assertSame('/issues.xml', $request->getPath());
+                    $this->assertSame('application/xml', $request->getContentType());
+                    $this->assertXmlStringEqualsXmlString('<?xml version="1.0"?><issue><project_id>3</project_id><category_id>45</category_id></issue>', $request->getContent());
 
                     return $this->createConfiguredMock(
                         Response::class,
@@ -681,10 +676,11 @@ class IssueTest extends TestCase
         $client = $this->createMock(HttpClient::class);
         $client->expects($this->exactly(2))
             ->method('request')
-            ->willReturnCallback(function (string $method, string $path, string $body = '') {
-                if ($method === 'GET') {
-                    $this->assertSame('/trackers.json', $path);
-                    $this->assertSame('', $body);
+            ->willReturnCallback(function (Request $request) {
+                if ($request->getMethod() === 'GET') {
+                    $this->assertSame('/trackers.json', $request->getPath());
+                    $this->assertSame('application/json', $request->getContentType());
+                    $this->assertSame('', $request->getContent());
 
                     return $this->createConfiguredMock(
                         Response::class,
@@ -695,9 +691,10 @@ class IssueTest extends TestCase
                     );
                 }
 
-                if ($method === 'POST') {
-                    $this->assertSame('/issues.xml', $path);
-                    $this->assertXmlStringEqualsXmlString('<?xml version="1.0"?><issue><tracker_id>9</tracker_id></issue>', $body);
+                if ($request->getMethod() === 'POST') {
+                    $this->assertSame('/issues.xml', $request->getPath());
+                    $this->assertSame('application/xml', $request->getContentType());
+                    $this->assertXmlStringEqualsXmlString('<?xml version="1.0"?><issue><tracker_id>9</tracker_id></issue>', $request->getContent());
 
                     return $this->createConfiguredMock(
                         Response::class,
@@ -735,10 +732,11 @@ class IssueTest extends TestCase
         $client = $this->createMock(HttpClient::class);
         $client->expects($this->exactly(2))
             ->method('request')
-            ->willReturnCallback(function (string $method, string $path, string $body = '') {
-                if ($method === 'GET') {
-                    $this->assertSame('/users.json', $path);
-                    $this->assertSame('', $body);
+            ->willReturnCallback(function (Request $request) {
+                if ($request->getMethod() === 'GET') {
+                    $this->assertSame('/users.json', $request->getPath());
+                    $this->assertSame('application/json', $request->getContentType());
+                    $this->assertSame('', $request->getContent());
 
                     return $this->createConfiguredMock(
                         Response::class,
@@ -749,9 +747,10 @@ class IssueTest extends TestCase
                     );
                 }
 
-                if ($method === 'POST') {
-                    $this->assertSame('/issues.xml', $path);
-                    $this->assertXmlStringEqualsXmlString('<?xml version="1.0"?><issue><assigned_to_id>6</assigned_to_id><author_id>5</author_id></issue>', $body);
+                if ($request->getMethod() === 'POST') {
+                    $this->assertSame('/issues.xml', $request->getPath());
+                    $this->assertSame('application/xml', $request->getContentType());
+                    $this->assertXmlStringEqualsXmlString('<?xml version="1.0"?><issue><assigned_to_id>6</assigned_to_id><author_id>5</author_id></issue>', $request->getContent());
 
                     return $this->createConfiguredMock(
                         Response::class,
@@ -997,10 +996,11 @@ class IssueTest extends TestCase
         $client = $this->createMock(HttpClient::class);
         $client->expects($this->exactly(2))
             ->method('request')
-            ->willReturnCallback(function (string $method, string $path, string $body = '') {
-                if ($method === 'GET') {
-                    $this->assertSame('/issue_statuses.json', $path);
-                    $this->assertSame('', $body);
+            ->willReturnCallback(function (Request $request) {
+                if ($request->getMethod() === 'GET') {
+                    $this->assertSame('/issue_statuses.json', $request->getPath());
+                    $this->assertSame('application/json', $request->getContentType());
+                    $this->assertSame('', $request->getContent());
 
                     return $this->createConfiguredMock(
                         Response::class,
@@ -1011,9 +1011,10 @@ class IssueTest extends TestCase
                     );
                 }
 
-                if ($method === 'PUT') {
-                    $this->assertSame('/issues/5.xml', $path);
-                    $this->assertXmlStringEqualsXmlString('<?xml version="1.0"?><issue><id>5</id><status_id>123</status_id></issue>', $body);
+                if ($request->getMethod() === 'PUT') {
+                    $this->assertSame('/issues/5.xml', $request->getPath());
+                    $this->assertSame('application/xml', $request->getContentType());
+                    $this->assertXmlStringEqualsXmlString('<?xml version="1.0"?><issue><id>5</id><status_id>123</status_id></issue>', $request->getContent());
 
                     return $this->createConfiguredMock(
                         Response::class,

--- a/tests/Unit/Api/IssueTest.php
+++ b/tests/Unit/Api/IssueTest.php
@@ -528,7 +528,7 @@ class IssueTest extends TestCase
                         Response::class,
                         [
                             'getContentType' => 'application/json',
-                            'getBody' => '{"issue_statuses":[{"name":"Status Name","id":123}]}',
+                            'getContent' => '{"issue_statuses":[{"name":"Status Name","id":123}]}',
                         ]
                     );
                 }
@@ -541,7 +541,7 @@ class IssueTest extends TestCase
                         Response::class,
                         [
                             'getContentType' => 'application/xml',
-                            'getBody' => '<?xml version="1.0"?><issue></issue>',
+                            'getContent' => '<?xml version="1.0"?><issue></issue>',
                         ]
                     );
                 }
@@ -582,7 +582,7 @@ class IssueTest extends TestCase
                         Response::class,
                         [
                             'getContentType' => 'application/json',
-                            'getBody' => '{"projects":[{"name":"Project Name","id":3}]}',
+                            'getContent' => '{"projects":[{"name":"Project Name","id":3}]}',
                         ]
                     );
                 }
@@ -595,7 +595,7 @@ class IssueTest extends TestCase
                         Response::class,
                         [
                             'getContentType' => 'application/xml',
-                            'getBody' => '<?xml version="1.0"?><issue></issue>',
+                            'getContent' => '<?xml version="1.0"?><issue></issue>',
                         ]
                     );
                 }
@@ -636,7 +636,7 @@ class IssueTest extends TestCase
                         Response::class,
                         [
                             'getContentType' => 'application/json',
-                            'getBody' => '{"issue_categories":[{"name":"Category Name","id":45}]}',
+                            'getContent' => '{"issue_categories":[{"name":"Category Name","id":45}]}',
                         ]
                     );
                 }
@@ -649,7 +649,7 @@ class IssueTest extends TestCase
                         Response::class,
                         [
                             'getContentType' => 'application/xml',
-                            'getBody' => '<?xml version="1.0"?><issue></issue>',
+                            'getContent' => '<?xml version="1.0"?><issue></issue>',
                         ]
                     );
                 }
@@ -690,7 +690,7 @@ class IssueTest extends TestCase
                         Response::class,
                         [
                             'getContentType' => 'application/json',
-                            'getBody' => '{"trackers":[{"name":"Tracker Name","id":9}]}',
+                            'getContent' => '{"trackers":[{"name":"Tracker Name","id":9}]}',
                         ]
                     );
                 }
@@ -703,7 +703,7 @@ class IssueTest extends TestCase
                         Response::class,
                         [
                             'getContentType' => 'application/xml',
-                            'getBody' => '<?xml version="1.0"?><issue></issue>',
+                            'getContent' => '<?xml version="1.0"?><issue></issue>',
                         ]
                     );
                 }
@@ -744,7 +744,7 @@ class IssueTest extends TestCase
                         Response::class,
                         [
                             'getContentType' => 'application/json',
-                            'getBody' => '{"users":[{"login":"Author Name","id":5},{"login":"Assigned to User Name","id":6}]}',
+                            'getContent' => '{"users":[{"login":"Author Name","id":5},{"login":"Assigned to User Name","id":6}]}',
                         ]
                     );
                 }
@@ -757,7 +757,7 @@ class IssueTest extends TestCase
                         Response::class,
                         [
                             'getContentType' => 'application/xml',
-                            'getBody' => '<?xml version="1.0"?><issue></issue>',
+                            'getContent' => '<?xml version="1.0"?><issue></issue>',
                         ]
                     );
                 }
@@ -1006,7 +1006,7 @@ class IssueTest extends TestCase
                         Response::class,
                         [
                             'getContentType' => 'application/json',
-                            'getBody' => '{"issue_statuses":[{"name":"Status Name","id":123}]}',
+                            'getContent' => '{"issue_statuses":[{"name":"Status Name","id":123}]}',
                         ]
                     );
                 }
@@ -1019,7 +1019,7 @@ class IssueTest extends TestCase
                         Response::class,
                         [
                             'getContentType' => 'application/xml',
-                            'getBody' => '<?xml version="1.0"?><issue></issue>',
+                            'getContent' => '<?xml version="1.0"?><issue></issue>',
                         ]
                     );
                 }

--- a/tests/Unit/Api/Project/ArchiveTest.php
+++ b/tests/Unit/Api/Project/ArchiveTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Project;
 
 use InvalidArgumentException;
@@ -7,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Redmine\Api\Project;
 use Redmine\Exception\UnexpectedResponseException;
 use Redmine\Http\HttpClient;
-use Redmine\Http\Response;
+use Redmine\Tests\Fixtures\AssertingHttpClient;
 
 /**
  * @covers \Redmine\Api\Project::archive
@@ -16,21 +18,16 @@ class ArchiveTest extends TestCase
 {
     public function testArchiveReturnsTrue()
     {
-        $client = $this->createMock(HttpClient::class);
-        $client->expects($this->exactly(1))
-            ->method('request')
-            ->willReturnCallback(function (string $method, string $path, string $body = '') {
-                $this->assertSame('PUT', $method);
-                $this->assertSame('/projects/5/archive.xml', $path);
-                $this->assertSame('', $body);
-
-                return $this->createConfiguredMock(Response::class, [
-                    'getStatusCode' => 204,
-                    'getContentType' => 'application/xml',
-                    'getBody' => '',
-                ]);
-            })
-        ;
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'PUT',
+                '/projects/5/archive.xml',
+                'application/xml',
+                '',
+                204
+            ]
+        );
 
         $api = new Project($client);
 
@@ -39,21 +36,16 @@ class ArchiveTest extends TestCase
 
     public function testArchiveThrowsUnexpectedResponseException()
     {
-        $client = $this->createMock(HttpClient::class);
-        $client->expects($this->exactly(1))
-            ->method('request')
-            ->willReturnCallback(function (string $method, string $path, string $body = '') {
-                $this->assertSame('PUT', $method);
-                $this->assertSame('/projects/5/archive.xml', $path);
-                $this->assertSame('', $body);
-
-                return $this->createConfiguredMock(Response::class, [
-                    'getStatusCode' => 403,
-                    'getContentType' => 'application/xml',
-                    'getBody' => '',
-                ]);
-            })
-        ;
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'PUT',
+                '/projects/5/archive.xml',
+                'application/xml',
+                '',
+                403
+            ]
+        );
 
         $api = new Project($client);
 

--- a/tests/Unit/Api/Project/CloseTest.php
+++ b/tests/Unit/Api/Project/CloseTest.php
@@ -8,6 +8,7 @@ use Redmine\Api\Project;
 use Redmine\Exception\UnexpectedResponseException;
 use Redmine\Http\HttpClient;
 use Redmine\Http\Response;
+use Redmine\Tests\Fixtures\AssertingHttpClient;
 
 /**
  * @covers \Redmine\Api\Project::close
@@ -16,21 +17,16 @@ class CloseTest extends TestCase
 {
     public function testCloseReturnsTrue()
     {
-        $client = $this->createMock(HttpClient::class);
-        $client->expects($this->exactly(1))
-            ->method('request')
-            ->willReturnCallback(function (string $method, string $path, string $body = '') {
-                $this->assertSame('PUT', $method);
-                $this->assertSame('/projects/5/close.xml', $path);
-                $this->assertSame('', $body);
-
-                return $this->createConfiguredMock(Response::class, [
-                    'getStatusCode' => 204,
-                    'getContentType' => 'application/xml',
-                    'getBody' => '',
-                ]);
-            })
-        ;
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'PUT',
+                '/projects/5/close.xml',
+                'application/xml',
+                '',
+                204
+            ]
+        );
 
         $api = new Project($client);
 
@@ -39,21 +35,16 @@ class CloseTest extends TestCase
 
     public function testCloseThrowsUnexpectedResponseException()
     {
-        $client = $this->createMock(HttpClient::class);
-        $client->expects($this->exactly(1))
-            ->method('request')
-            ->willReturnCallback(function (string $method, string $path, string $body = '') {
-                $this->assertSame('PUT', $method);
-                $this->assertSame('/projects/5/close.xml', $path);
-                $this->assertSame('', $body);
-
-                return $this->createConfiguredMock(Response::class, [
-                    'getStatusCode' => 403,
-                    'getContentType' => 'application/xml',
-                    'getBody' => '',
-                ]);
-            })
-        ;
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'PUT',
+                '/projects/5/close.xml',
+                'application/xml',
+                '',
+                403
+            ]
+        );
 
         $api = new Project($client);
 

--- a/tests/Unit/Api/Project/ReopenTest.php
+++ b/tests/Unit/Api/Project/ReopenTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Redmine\Api\Project;
 use Redmine\Exception\UnexpectedResponseException;
 use Redmine\Http\HttpClient;
-use Redmine\Http\Response;
+use Redmine\Tests\Fixtures\AssertingHttpClient;
 
 /**
  * @covers \Redmine\Api\Project::reopen
@@ -16,21 +16,16 @@ class ReopenTest extends TestCase
 {
     public function testReopenReturnsTrue()
     {
-        $client = $this->createMock(HttpClient::class);
-        $client->expects($this->exactly(1))
-            ->method('request')
-            ->willReturnCallback(function (string $method, string $path, string $body = '') {
-                $this->assertSame('PUT', $method);
-                $this->assertSame('/projects/5/reopen.xml', $path);
-                $this->assertSame('', $body);
-
-                return $this->createConfiguredMock(Response::class, [
-                    'getStatusCode' => 204,
-                    'getContentType' => 'application/xml',
-                    'getBody' => '',
-                ]);
-            })
-        ;
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'PUT',
+                '/projects/5/reopen.xml',
+                'application/xml',
+                '',
+                204
+            ]
+        );
 
         $api = new Project($client);
 
@@ -39,21 +34,16 @@ class ReopenTest extends TestCase
 
     public function testReopenThrowsUnexpectedResponseException()
     {
-        $client = $this->createMock(HttpClient::class);
-        $client->expects($this->exactly(1))
-            ->method('request')
-            ->willReturnCallback(function (string $method, string $path, string $body = '') {
-                $this->assertSame('PUT', $method);
-                $this->assertSame('/projects/5/reopen.xml', $path);
-                $this->assertSame('', $body);
-
-                return $this->createConfiguredMock(Response::class, [
-                    'getStatusCode' => 403,
-                    'getContentType' => 'application/xml',
-                    'getBody' => '',
-                ]);
-            })
-        ;
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'PUT',
+                '/projects/5/reopen.xml',
+                'application/xml',
+                '',
+                403
+            ]
+        );
 
         $api = new Project($client);
 

--- a/tests/Unit/Api/Project/UnarchiveTest.php
+++ b/tests/Unit/Api/Project/UnarchiveTest.php
@@ -8,6 +8,7 @@ use Redmine\Api\Project;
 use Redmine\Exception\UnexpectedResponseException;
 use Redmine\Http\HttpClient;
 use Redmine\Http\Response;
+use Redmine\Tests\Fixtures\AssertingHttpClient;
 
 /**
  * @covers \Redmine\Api\Project::unarchive
@@ -16,21 +17,16 @@ class UnarchiveTest extends TestCase
 {
     public function testUnarchiveReturnsTrue()
     {
-        $client = $this->createMock(HttpClient::class);
-        $client->expects($this->exactly(1))
-            ->method('request')
-            ->willReturnCallback(function (string $method, string $path, string $body = '') {
-                $this->assertSame('PUT', $method);
-                $this->assertSame('/projects/5/unarchive.xml', $path);
-                $this->assertSame('', $body);
-
-                return $this->createConfiguredMock(Response::class, [
-                    'getStatusCode' => 204,
-                    'getContentType' => 'application/xml',
-                    'getBody' => '',
-                ]);
-            })
-        ;
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'PUT',
+                '/projects/5/unarchive.xml',
+                'application/xml',
+                '',
+                204
+            ]
+        );
 
         $api = new Project($client);
 
@@ -39,21 +35,16 @@ class UnarchiveTest extends TestCase
 
     public function testUnarchiveThrowsUnexpectedResponseException()
     {
-        $client = $this->createMock(HttpClient::class);
-        $client->expects($this->exactly(1))
-            ->method('request')
-            ->willReturnCallback(function (string $method, string $path, string $body = '') {
-                $this->assertSame('PUT', $method);
-                $this->assertSame('/projects/5/unarchive.xml', $path);
-                $this->assertSame('', $body);
-
-                return $this->createConfiguredMock(Response::class, [
-                    'getStatusCode' => 403,
-                    'getContentType' => 'application/xml',
-                    'getBody' => '',
-                ]);
-            })
-        ;
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'PUT',
+                '/projects/5/unarchive.xml',
+                'application/xml',
+                '',
+                403
+            ]
+        );
 
         $api = new Project($client);
 


### PR DESCRIPTION
This PR modifies the `HttpClient::request()` method to allow handling implementation of the new `Request` interface, described in #341. It also renames `Response::getBody()` to `Response::getContent()`, see #363.

In the tests I introduced an `AssertingHttpClient` that allows us easily define a `HttpClient` with asserted Requests and expected Responses. This will become very handy while starting deprecating the `Redmine\Client\Client` interface and replacing it in tests.