### PR TITLE
Update all dependencies

### DIFF
--- a/.docker/PHP83-Dockerfile
+++ b/.docker/PHP83-Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.3.1-fpm
+FROM php:8.3.3-fpm
 
 RUN apt-get update
 RUN apt-get --yes --no-install-recommends install \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,9 +77,10 @@ jobs:
 
       - name: Upload coverage reports to Codecov
         if: ${{ matrix.tool == 'code-coverage' }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./.phpunit.cache/clover.xml
           fail_ci_if_error: true
           verbose: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,9 +78,8 @@ jobs:
       - name: Upload coverage reports to Codecov
         if: ${{ matrix.tool == 'code-coverage' }}
         uses: codecov/codecov-action@v4
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./.phpunit.cache/clover.xml
           fail_ci_if_error: true
           verbose: true

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "guzzlehttp/psr7": "^2",
         "php-mock/php-mock-phpunit": "^2.6",
         "phpstan/phpstan": "^1.10",
-        "phpunit/phpunit": "^9 || ^10.5"
+        "phpunit/phpunit": "^9.5 || ^10.5 || ^11.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "guzzlehttp/psr7": "^2",
         "php-mock/php-mock-phpunit": "^2.6",
         "phpstan/phpstan": "^1.10",
-        "phpunit/phpunit": "^9.5 || ^10.5 || ^11.0"
+        "phpunit/phpunit": "^9.5 || ^10.5"
     },
     "autoload": {
         "psr-4": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
             - ./:/var/www/project/ # Location of the project for php-fpm. Note this should be the same for NGINX.*
 
     redmine-dev:
-        image: redmine:5.1.1
+        image: redmine:5.1.2
         user: "1000:1000"
         ports:
             - "3000:3000"
@@ -26,8 +26,8 @@ services:
 
     # Make sure the following services are supported in /tests/RedmineExtension/RedmineInstance.php
 
-    redmine-50101:
-        image: redmine:5.1.1
+    redmine-50102:
+        image: redmine:5.1.2
         user: "1000:1000"
         ports:
             - "5101:3000"
@@ -35,11 +35,11 @@ services:
             REDMINE_SECRET_KEY_BASE: supersecretkey
             REDMINE_PLUGINS_MIGRATE: true
         volumes:
-            - ./.docker/redmine-50101_data/files:/usr/src/redmine/files
-            - ./.docker/redmine-50101_data/sqlite:/usr/src/redmine/sqlite
+            - ./.docker/redmine-50102_data/files:/usr/src/redmine/files
+            - ./.docker/redmine-50102_data/sqlite:/usr/src/redmine/sqlite
 
-    redmine-50007:
-        image: redmine:5.0.7
+    redmine-50008:
+        image: redmine:5.0.8
         user: "1000:1000"
         ports:
             - "5007:3000"
@@ -47,5 +47,5 @@ services:
             REDMINE_SECRET_KEY_BASE: supersecretkey
             REDMINE_PLUGINS_MIGRATE: true
         volumes:
-            - ./.docker/redmine-50007_data/files:/usr/src/redmine/files
-            - ./.docker/redmine-50007_data/sqlite:/usr/src/redmine/sqlite
+            - ./.docker/redmine-50008_data/files:/usr/src/redmine/files
+            - ./.docker/redmine-50008_data/sqlite:/usr/src/redmine/sqlite

--- a/tests/Behat/behat.yml
+++ b/tests/Behat/behat.yml
@@ -1,14 +1,14 @@
 default:
     suites:
-        redmine_50101:
+        redmine_50102:
             paths:
                 - '%paths.base%/features'
             contexts:
                 - Redmine\Tests\Behat\Bootstrap\FeatureContext:
-                    redmineVersion: '5.1.1'
+                    redmineVersion: '5.1.2'
         redmine_50007:
             paths:
                 - '%paths.base%/features'
             contexts:
                 - Redmine\Tests\Behat\Bootstrap\FeatureContext:
-                    redmineVersion: '5.0.7'
+                    redmineVersion: '5.0.8'

--- a/tests/Behat/behat.yml
+++ b/tests/Behat/behat.yml
@@ -6,7 +6,7 @@ default:
             contexts:
                 - Redmine\Tests\Behat\Bootstrap\FeatureContext:
                     redmineVersion: '5.1.2'
-        redmine_50007:
+        redmine_50008:
             paths:
                 - '%paths.base%/features'
             contexts:

--- a/tests/Fixtures/AssertingHttpClient.php
+++ b/tests/Fixtures/AssertingHttpClient.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Redmine\Tests\Fixtures;
 
+use PHPUnit\Framework\MockObject\MockBuilder;
+use PHPUnit\Framework\MockObject\Rule\InvokedCount;
 use PHPUnit\Framework\TestCase;
 use Redmine\Http\HttpClient;
 use Redmine\Http\Request;
@@ -21,8 +23,8 @@ final class AssertingHttpClient implements HttpClient
         $dataSets = array_merge([$dataSet], $dataSets);
 
         /** @var \PHPUnit\Framework\MockObject\MockObject&HttpClient */
-        $mock = $testCase->getMockBuilder(HttpClient::class)->getMock();
-        $mock->expects($testCase->exactly(count($dataSets)))->method('request');
+        $mock = (new MockBuilder($testCase, HttpClient::class))->getMock();
+        $mock->expects(new InvokedCount(count($dataSets)))->method('request');
 
         $client = new self($testCase, $mock);
 
@@ -95,7 +97,7 @@ final class AssertingHttpClient implements HttpClient
         }
 
         /** @var \PHPUnit\Framework\MockObject\MockObject&Response */
-        $response = $this->testCase->getMockBuilder(Response::class)->getMock();
+        $response = (new MockBuilder($this->testCase, Response::class))->getMock();
 
         $response->method('getStatusCode')->willReturn($data['responseCode']);
         $response->method('getContentType')->willReturn($data['responseContentType']);

--- a/tests/Integration/Psr18ClientRequestGenerationTest.php
+++ b/tests/Integration/Psr18ClientRequestGenerationTest.php
@@ -6,6 +6,7 @@ namespace Redmine\Tests\Integration;
 
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Utils;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
@@ -22,6 +23,7 @@ class Psr18ClientRequestGenerationTest extends TestCase
      *
      * @dataProvider createdGetRequestsData
      */
+    #[DataProvider('createdGetRequestsData')]
     public function testPsr18ClientCreatesCorrectRequests(
         string $url,
         string $apikeyOrUsername,

--- a/tests/Integration/Psr18ClientRequestGenerationTest.php
+++ b/tests/Integration/Psr18ClientRequestGenerationTest.php
@@ -35,41 +35,37 @@ class Psr18ClientRequestGenerationTest extends TestCase
         $response = $this->createMock(ResponseInterface::class);
 
         $httpClient = $this->createMock(ClientInterface::class);
-        $httpClient->method('sendRequest')->will(
-            $this->returnCallback(function ($request) use ($response, $expectedOutput) {
-                // Create a text representation of the HTTP request
-                $content = $request->getBody()->__toString();
+        $httpClient->method('sendRequest')->willReturnCallback(function ($request) use ($response, $expectedOutput) {
+            // Create a text representation of the HTTP request
+            $content = $request->getBody()->__toString();
 
-                $headers = '';
+            $headers = '';
 
-                foreach ($request->getHeaders() as $k => $v) {
-                    $headers .= $k . ': ' . $request->getHeaderLine($k) . \PHP_EOL;
-                }
+            foreach ($request->getHeaders() as $k => $v) {
+                $headers .= $k . ': ' . $request->getHeaderLine($k) . \PHP_EOL;
+            }
 
-                $statusLine = sprintf(
-                    '%s %s HTTP/%s',
-                    $request->getMethod(),
-                    $request->getUri()->__toString(),
-                    $request->getProtocolVersion()
-                );
+            $statusLine = sprintf(
+                '%s %s HTTP/%s',
+                $request->getMethod(),
+                $request->getUri()->__toString(),
+                $request->getProtocolVersion()
+            );
 
-                $fullRequest = $statusLine . \PHP_EOL .
-                    $headers . \PHP_EOL .
-                    $content
-                ;
+            $fullRequest = $statusLine . \PHP_EOL .
+                $headers . \PHP_EOL .
+                $content
+            ;
 
-                $this->assertSame($expectedOutput, $fullRequest);
+            $this->assertSame($expectedOutput, $fullRequest);
 
-                return $response;
-            })
-        );
+            return $response;
+        });
 
         $requestFactory = $this->createMock(RequestFactoryInterface::class);
-        $requestFactory->method('createRequest')->will(
-            $this->returnCallback(function ($method, $uri) {
-                return new Request($method, $uri);
-            })
-        );
+        $requestFactory->method('createRequest')->willReturnCallback(function ($method, $uri) {
+            return new Request($method, $uri);
+        });
 
         $streamFactory = new class () implements StreamFactoryInterface {
             public function createStream(string $content = ''): StreamInterface

--- a/tests/Integration/Psr18ClientRequestGenerationTest.php
+++ b/tests/Integration/Psr18ClientRequestGenerationTest.php
@@ -19,7 +19,6 @@ class Psr18ClientRequestGenerationTest extends TestCase
 {
     /**
      * @covers \Redmine\Client\Psr18Client
-     * @test
      *
      * @dataProvider createdGetRequestsData
      */
@@ -36,6 +35,7 @@ class Psr18ClientRequestGenerationTest extends TestCase
     ) {
         $response = $this->createMock(ResponseInterface::class);
 
+        /** @var ClientInterface|\PHPUnit\Framework\MockObject\MockObject */
         $httpClient = $this->createMock(ClientInterface::class);
         $httpClient->method('sendRequest')->willReturnCallback(function ($request) use ($response, $expectedOutput) {
             // Create a text representation of the HTTP request

--- a/tests/Integration/Psr18ClientRequestGenerationTest.php
+++ b/tests/Integration/Psr18ClientRequestGenerationTest.php
@@ -6,6 +6,7 @@ namespace Redmine\Tests\Integration;
 
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Utils;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Client\ClientInterface;
@@ -15,11 +16,10 @@ use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Redmine\Client\Psr18Client;
 
+#[CoversClass(Psr18Client::class)]
 class Psr18ClientRequestGenerationTest extends TestCase
 {
     /**
-     * @covers \Redmine\Client\Psr18Client
-     *
      * @dataProvider createdGetRequestsData
      */
     #[DataProvider('createdGetRequestsData')]

--- a/tests/RedmineExtension/RedmineInstance.php
+++ b/tests/RedmineExtension/RedmineInstance.php
@@ -16,8 +16,8 @@ final class RedmineInstance
     public static function getSupportedVersions(): array
     {
         return [
-            RedmineVersion::V5_1_1,
-            RedmineVersion::V5_0_7,
+            RedmineVersion::V5_1_2,
+            RedmineVersion::V5_0_8,
         ];
     }
 

--- a/tests/RedmineExtension/RedmineVersion.php
+++ b/tests/RedmineExtension/RedmineVersion.php
@@ -7,6 +7,14 @@ namespace Redmine\Tests\RedmineExtension;
 enum RedmineVersion: string
 {
     /**
+     * Redmine 5.1.2
+     *
+     * @link https://www.redmine.org/versions/193
+     * @link https://www.redmine.org/projects/redmine/wiki/Changelog_5_1#512-2024-03-04
+     */
+    case V5_1_2 = '5.1.2';
+
+    /**
      * Redmine 5.1.1
      *
      * @link https://www.redmine.org/versions/191
@@ -21,6 +29,15 @@ enum RedmineVersion: string
      * @link https://www.redmine.org/projects/redmine/wiki/Changelog_5_1#510-2023-10-31
      */
     case V5_1_0 = '5.1.0';
+
+    /**
+     * Redmine 5.0.8
+     *
+     * @link https://www.redmine.org/versions/192
+     * @link https://www.redmine.org/projects/redmine/wiki/Changelog_5_0#508-2024-03-04
+     */
+
+    case V5_0_8 = '5.0.8';
 
     /**
      * Redmine 5.0.7

--- a/tests/Unit/Api/AbstractApi/DeleteTest.php
+++ b/tests/Unit/Api/AbstractApi/DeleteTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Redmine\Tests\Unit\Api\AbstractApi;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\AbstractApi;
@@ -11,9 +12,7 @@ use Redmine\Client\Client;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 use ReflectionMethod;
 
-/**
- * @covers \Redmine\Api\AbstractApi::delete
- */
+#[CoversClass(AbstractApi::class)]
 class DeleteTest extends TestCase
 {
     public function testDeleteWithHttpClient()

--- a/tests/Unit/Api/AbstractApi/DeleteTest.php
+++ b/tests/Unit/Api/AbstractApi/DeleteTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Redmine\Tests\Unit\Api\AbstractApi;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\AbstractApi;
 use Redmine\Client\Client;
@@ -44,6 +45,7 @@ class DeleteTest extends TestCase
     /**
      * @dataProvider getXmlDecodingFromDeleteMethodData
      */
+    #[DataProvider('getXmlDecodingFromDeleteMethodData')]
     public function testXmlDecodingFromDeleteMethod($response, $expected)
     {
         $client = $this->createMock(Client::class);

--- a/tests/Unit/Api/AbstractApi/GetTest.php
+++ b/tests/Unit/Api/AbstractApi/GetTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Redmine\Tests\Unit\Api\AbstractApi;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\AbstractApi;
@@ -12,9 +13,7 @@ use Redmine\Tests\Fixtures\AssertingHttpClient;
 use ReflectionMethod;
 use SimpleXMLElement;
 
-/**
- * @covers \Redmine\Api\AbstractApi::get
- */
+#[CoversClass(AbstractApi::class)]
 class GetTest extends TestCase
 {
     public function testGetWithHttpClient()

--- a/tests/Unit/Api/AbstractApi/GetTest.php
+++ b/tests/Unit/Api/AbstractApi/GetTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Redmine\Tests\Unit\Api\AbstractApi;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\AbstractApi;
 use Redmine\Client\Client;
@@ -46,6 +47,7 @@ class GetTest extends TestCase
     /**
      * @dataProvider getJsonDecodingFromGetMethodData
      */
+    #[DataProvider('getJsonDecodingFromGetMethodData')]
     public function testJsonDecodingFromGetMethod($response, $decode, $expected)
     {
         $client = $this->createMock(Client::class);
@@ -80,6 +82,7 @@ class GetTest extends TestCase
     /**
      * @dataProvider getXmlDecodingFromGetMethodData
      */
+    #[DataProvider('getXmlDecodingFromGetMethodData')]
     public function testXmlDecodingFromGetMethod($response, $decode, $expected)
     {
         $client = $this->createMock(Client::class);

--- a/tests/Unit/Api/AbstractApi/PostTest.php
+++ b/tests/Unit/Api/AbstractApi/PostTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Redmine\Tests\Unit\Api\AbstractApi;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\AbstractApi;
 use Redmine\Client\Client;
@@ -46,6 +47,7 @@ class PostTest extends TestCase
     /**
      * @dataProvider getXmlDecodingFromPostMethodData
      */
+    #[DataProvider('getXmlDecodingFromPostMethodData')]
     public function testXmlDecodingFromPostMethod($response, $expected)
     {
         $client = $this->createMock(Client::class);

--- a/tests/Unit/Api/AbstractApi/PostTest.php
+++ b/tests/Unit/Api/AbstractApi/PostTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Redmine\Tests\Unit\Api\AbstractApi;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\AbstractApi;
@@ -12,9 +13,7 @@ use Redmine\Tests\Fixtures\AssertingHttpClient;
 use ReflectionMethod;
 use SimpleXMLElement;
 
-/**
- * @covers \Redmine\Api\AbstractApi::post
- */
+#[CoversClass(AbstractApi::class)]
 class PostTest extends TestCase
 {
     public function testPostWithHttpClient()

--- a/tests/Unit/Api/AbstractApi/PutTest.php
+++ b/tests/Unit/Api/AbstractApi/PutTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Redmine\Tests\Unit\Api\AbstractApi;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\AbstractApi;
@@ -12,9 +13,7 @@ use Redmine\Tests\Fixtures\AssertingHttpClient;
 use ReflectionMethod;
 use SimpleXMLElement;
 
-/**
- * @covers \Redmine\Api\AbstractApi::put
- */
+#[CoversClass(AbstractApi::class)]
 class PutTest extends TestCase
 {
     public function testPutWithHttpClient()

--- a/tests/Unit/Api/AbstractApi/PutTest.php
+++ b/tests/Unit/Api/AbstractApi/PutTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Redmine\Tests\Unit\Api\AbstractApi;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\AbstractApi;
 use Redmine\Client\Client;
@@ -46,6 +47,7 @@ class PutTest extends TestCase
     /**
      * @dataProvider getXmlDecodingFromPutMethodData
      */
+    #[DataProvider('getXmlDecodingFromPutMethodData')]
     public function testXmlDecodingFromPutMethod($response, $expected)
     {
         $client = $this->createMock(Client::class);

--- a/tests/Unit/Api/AbstractApiTest.php
+++ b/tests/Unit/Api/AbstractApiTest.php
@@ -3,6 +3,7 @@
 namespace Redmine\Tests\Unit\Api;
 
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\AbstractApi;
@@ -14,9 +15,7 @@ use Redmine\Tests\Fixtures\AssertingHttpClient;
 use ReflectionMethod;
 use SimpleXMLElement;
 
-/**
- * @coversDefaultClass \Redmine\Api\AbstractApi
- */
+#[CoversClass(AbstractApi::class)]
 class AbstractApiTest extends TestCase
 {
     public function testCreateWithHttpClientWorks()
@@ -52,9 +51,6 @@ class AbstractApiTest extends TestCase
         new class (new \stdClass()) extends AbstractApi {};
     }
 
-    /**
-     * @covers ::get
-     */
     public function testGetTriggersDeprecationWarning()
     {
         $client = $this->createMock(HttpClient::class);
@@ -83,9 +79,6 @@ class AbstractApiTest extends TestCase
         $api->runGet('/path.json');
     }
 
-    /**
-     * @covers ::getLastResponse
-     */
     public function testGetLastResponseWithHttpClientWorks()
     {
         $client = $this->createMock(HttpClient::class);
@@ -95,9 +88,6 @@ class AbstractApiTest extends TestCase
         $this->assertInstanceOf(Response::class, $api->getLastResponse());
     }
 
-    /**
-     * @covers ::post
-     */
     public function testPostTriggersDeprecationWarning()
     {
         $client = $this->createMock(HttpClient::class);
@@ -164,9 +154,6 @@ class AbstractApiTest extends TestCase
         ];
     }
 
-    /**
-     * @covers ::lastCallFailed
-     */
     public function testLastCallFailedPreventsRaceCondition()
     {
         $client = AssertingHttpClient::create(
@@ -211,7 +198,6 @@ class AbstractApiTest extends TestCase
     }
 
     /**
-     * @covers ::lastCallFailed
      * @dataProvider getLastCallFailedData
      */
     #[DataProvider('getLastCallFailedData')]
@@ -226,7 +212,6 @@ class AbstractApiTest extends TestCase
     }
 
     /**
-     * @covers ::lastCallFailed
      * @dataProvider getLastCallFailedData
      */
     #[DataProvider('getLastCallFailedData')]
@@ -321,8 +306,6 @@ class AbstractApiTest extends TestCase
     }
 
     /**
-     * @covers ::retrieveData
-     *
      * @dataProvider retrieveDataData
      */
     #[DataProvider('retrieveDataData')]
@@ -349,8 +332,6 @@ class AbstractApiTest extends TestCase
     }
 
     /**
-     * @covers ::retrieveData
-     *
      * @dataProvider getRetrieveDataToExceptionData
      */
     #[DataProvider('getRetrieveDataToExceptionData')]
@@ -380,8 +361,6 @@ class AbstractApiTest extends TestCase
     }
 
     /**
-     * @covers ::retrieveAll
-     *
      * @dataProvider getRetrieveAllData
      */
     #[DataProvider('getRetrieveAllData')]
@@ -409,9 +388,6 @@ class AbstractApiTest extends TestCase
         ];
     }
 
-    /**
-     * @covers ::attachCustomFieldXML
-     */
     public function testDeprecatedAttachCustomFieldXML()
     {
         $client = $this->createMock(Client::class);

--- a/tests/Unit/Api/AbstractApiTest.php
+++ b/tests/Unit/Api/AbstractApiTest.php
@@ -127,7 +127,6 @@ class AbstractApiTest extends TestCase
     }
 
     /**
-     * @test
      * @dataProvider getIsNotNullReturnsCorrectBooleanData
      */
     #[DataProvider('getIsNotNullReturnsCorrectBooleanData')]
@@ -213,7 +212,6 @@ class AbstractApiTest extends TestCase
 
     /**
      * @covers ::lastCallFailed
-     * @test
      * @dataProvider getLastCallFailedData
      */
     #[DataProvider('getLastCallFailedData')]
@@ -229,7 +227,6 @@ class AbstractApiTest extends TestCase
 
     /**
      * @covers ::lastCallFailed
-     * @test
      * @dataProvider getLastCallFailedData
      */
     #[DataProvider('getLastCallFailedData')]

--- a/tests/Unit/Api/AbstractApiTest.php
+++ b/tests/Unit/Api/AbstractApiTest.php
@@ -3,6 +3,7 @@
 namespace Redmine\Tests\Unit\Api;
 
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\AbstractApi;
 use Redmine\Client\Client;
@@ -129,6 +130,7 @@ class AbstractApiTest extends TestCase
      * @test
      * @dataProvider getIsNotNullReturnsCorrectBooleanData
      */
+    #[DataProvider('getIsNotNullReturnsCorrectBooleanData')]
     public function testIsNotNullReturnsCorrectBoolean(bool $expected, $value)
     {
         $client = $this->createMock(Client::class);
@@ -214,6 +216,7 @@ class AbstractApiTest extends TestCase
      * @test
      * @dataProvider getLastCallFailedData
      */
+    #[DataProvider('getLastCallFailedData')]
     public function testLastCallFailedWithClientReturnsCorrectBoolean($statusCode, $expectedBoolean)
     {
         $client = $this->createMock(Client::class);
@@ -229,6 +232,7 @@ class AbstractApiTest extends TestCase
      * @test
      * @dataProvider getLastCallFailedData
      */
+    #[DataProvider('getLastCallFailedData')]
     public function testLastCallFailedWithHttpClientReturnsCorrectBoolean($statusCode, $expectedBoolean)
     {
         $response = $this->createMock(Response::class);
@@ -324,6 +328,7 @@ class AbstractApiTest extends TestCase
      *
      * @dataProvider retrieveDataData
      */
+    #[DataProvider('retrieveDataData')]
     public function testRetrieveData($response, $contentType, $expected)
     {
         $client = $this->createMock(Client::class);
@@ -351,6 +356,7 @@ class AbstractApiTest extends TestCase
      *
      * @dataProvider getRetrieveDataToExceptionData
      */
+    #[DataProvider('getRetrieveDataToExceptionData')]
     public function testRetrieveDataThrowsException($response, $contentType, $expectedException, $expectedMessage)
     {
         $client = $this->createMock(Client::class);
@@ -381,6 +387,7 @@ class AbstractApiTest extends TestCase
      *
      * @dataProvider getRetrieveAllData
      */
+    #[DataProvider('getRetrieveAllData')]
     public function testDeprecatedRetrieveAll($content, $contentType, $expected)
     {
         $client = $this->createMock(Client::class);

--- a/tests/Unit/Api/Attachment/DownloadTest.php
+++ b/tests/Unit/Api/Attachment/DownloadTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api\Attachment;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Attachment;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
@@ -14,6 +15,7 @@ class DownloadTest extends TestCase
     /**
      * @dataProvider getDownloadData
      */
+    #[DataProvider('getDownloadData')]
     public function testDownloadReturnsCorrectResponse($id, $expectedPath, $responseCode, $response, $expectedReturn)
     {
         $client = AssertingHttpClient::create(

--- a/tests/Unit/Api/Attachment/DownloadTest.php
+++ b/tests/Unit/Api/Attachment/DownloadTest.php
@@ -2,14 +2,13 @@
 
 namespace Redmine\Tests\Unit\Api\Attachment;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Attachment;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
-/**
- * @covers \Redmine\Api\Attachment::download
- */
+#[CoversClass(Attachment::class)]
 class DownloadTest extends TestCase
 {
     /**

--- a/tests/Unit/Api/Attachment/RemoveTest.php
+++ b/tests/Unit/Api/Attachment/RemoveTest.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace Redmine\Tests\Unit\Api\Attachment;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Attachment;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
-/**
- * @covers \Redmine\Api\Attachment::remove
- */
+#[CoversClass(Attachment::class)]
 class RemoveTest extends TestCase
 {
     public function testRemoveReturnsString()

--- a/tests/Unit/Api/Attachment/ShowTest.php
+++ b/tests/Unit/Api/Attachment/ShowTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api\Attachment;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Attachment;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
@@ -14,6 +15,7 @@ class ShowTest extends TestCase
     /**
      * @dataProvider getShowData
      */
+    #[DataProvider('getShowData')]
     public function testShowReturnsCorrectResponse($id, $expectedPath, $response, $expectedReturn)
     {
         $client = AssertingHttpClient::create(

--- a/tests/Unit/Api/Attachment/ShowTest.php
+++ b/tests/Unit/Api/Attachment/ShowTest.php
@@ -2,14 +2,13 @@
 
 namespace Redmine\Tests\Unit\Api\Attachment;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Attachment;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
-/**
- * @covers \Redmine\Api\Attachment::show
- */
+#[CoversClass(Attachment::class)]
 class ShowTest extends TestCase
 {
     /**

--- a/tests/Unit/Api/Attachment/UploadTest.php
+++ b/tests/Unit/Api/Attachment/UploadTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api\Attachment;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Attachment;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
@@ -14,6 +15,7 @@ class UploadTest extends TestCase
     /**
      * @dataProvider getUploadData
      */
+    #[DataProvider('getUploadData')]
     public function testUploadReturnsCorrectResponse($attachment, $params, $expectedAttachment, $expectedPath, $responseCode, $response, $expectedReturn)
     {
         $client = AssertingHttpClient::create(

--- a/tests/Unit/Api/Attachment/UploadTest.php
+++ b/tests/Unit/Api/Attachment/UploadTest.php
@@ -2,14 +2,13 @@
 
 namespace Redmine\Tests\Unit\Api\Attachment;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Attachment;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
-/**
- * @covers \Redmine\Api\Attachment::upload
- */
+#[CoversClass(Attachment::class)]
 class UploadTest extends TestCase
 {
     /**

--- a/tests/Unit/Api/AttachmentTest.php
+++ b/tests/Unit/Api/AttachmentTest.php
@@ -23,7 +23,6 @@ class AttachmentTest extends TestCase
      *
      * @param int  $responseCode
      * @param bool $hasFailed
-     * @test
      */
     #[DataProvider('responseCodeProvider')]
     public function testLastCallFailedTrue($responseCode, $hasFailed)

--- a/tests/Unit/Api/AttachmentTest.php
+++ b/tests/Unit/Api/AttachmentTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Attachment;
 use Redmine\Client\Client;
@@ -24,6 +25,7 @@ class AttachmentTest extends TestCase
      * @param bool $hasFailed
      * @test
      */
+    #[DataProvider('responseCodeProvider')]
     public function testLastCallFailedTrue($responseCode, $hasFailed)
     {
         // Create the used mock objects

--- a/tests/Unit/Api/AttachmentTest.php
+++ b/tests/Unit/Api/AttachmentTest.php
@@ -11,7 +11,7 @@ use Redmine\Client\Client;
 /**
  * @author     Malte Gerth <mail@malte-gerth.de>
  */
- #[CoversClass(Attachment::class)]
+#[CoversClass(Attachment::class)]
 class AttachmentTest extends TestCase
 {
     /**

--- a/tests/Unit/Api/AttachmentTest.php
+++ b/tests/Unit/Api/AttachmentTest.php
@@ -2,23 +2,21 @@
 
 namespace Redmine\Tests\Unit\Api;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Attachment;
 use Redmine\Client\Client;
 
 /**
- * @coversDefaultClass \Redmine\Api\Attachment
- *
  * @author     Malte Gerth <mail@malte-gerth.de>
  */
+ #[CoversClass(Attachment::class)]
 class AttachmentTest extends TestCase
 {
     /**
      * Test lastCallFailed().
      *
-     * @covers       ::__construct
-     * @covers       ::lastCallFailed
      * @dataProvider responseCodeProvider
      *
      * @param int  $responseCode

--- a/tests/Unit/Api/CustomField/ListTest.php
+++ b/tests/Unit/Api/CustomField/ListTest.php
@@ -2,14 +2,13 @@
 
 namespace Redmine\Tests\Unit\Api\CustomField;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\CustomField;
 use Redmine\Client\Client;
 use Redmine\Exception\UnexpectedResponseException;
 
-/**
- * @covers \Redmine\Api\CustomField::list
- */
+#[CoversClass(CustomField::class)]
 class ListTest extends TestCase
 {
     public function testListWithoutParametersReturnsResponse()

--- a/tests/Unit/Api/CustomFieldTest.php
+++ b/tests/Unit/Api/CustomFieldTest.php
@@ -46,7 +46,6 @@ class CustomFieldTest extends TestCase
      *
      * @covers ::all
      * @dataProvider getAllData
-     * @test
      */
     #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
@@ -84,7 +83,6 @@ class CustomFieldTest extends TestCase
      * Test all().
      *
      * @covers ::all
-     * @test
      */
     public function testAllReturnsClientGetResponseWithParameters()
     {
@@ -119,7 +117,6 @@ class CustomFieldTest extends TestCase
      * Test all().
      *
      * @covers ::all
-     * @test
      */
     public function testAllReturnsClientGetResponseWithHighLimit()
     {
@@ -157,7 +154,6 @@ class CustomFieldTest extends TestCase
      * Test all().
      *
      * @covers ::all
-     * @test
      */
     public function testAllCallsEndpointUntilOffsetIsHigherThanTotalCount()
     {
@@ -200,7 +196,6 @@ class CustomFieldTest extends TestCase
      * Test listing().
      *
      * @covers ::listing
-     * @test
      */
     public function testListingReturnsNameIdArray()
     {
@@ -237,7 +232,6 @@ class CustomFieldTest extends TestCase
      * Test listing().
      *
      * @covers ::listing
-     * @test
      */
     public function testListingCallsGetOnlyTheFirstTime()
     {
@@ -275,7 +269,6 @@ class CustomFieldTest extends TestCase
      * Test listing().
      *
      * @covers ::listing
-     * @test
      */
     public function testListingCallsGetEveryTimeWithForceUpdate()
     {
@@ -313,7 +306,6 @@ class CustomFieldTest extends TestCase
      * Test getIdByName().
      *
      * @covers ::getIdByName
-     * @test
      */
     public function testGetIdByNameMakesGetRequest()
     {

--- a/tests/Unit/Api/CustomFieldTest.php
+++ b/tests/Unit/Api/CustomFieldTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\CustomField;
 use Redmine\Client\Client;
@@ -47,6 +48,7 @@ class CustomFieldTest extends TestCase
      * @dataProvider getAllData
      * @test
      */
+    #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
     {
         // Create the used mock objects

--- a/tests/Unit/Api/CustomFieldTest.php
+++ b/tests/Unit/Api/CustomFieldTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\CustomField;
@@ -9,16 +10,13 @@ use Redmine\Client\Client;
 use Redmine\Tests\Fixtures\MockClient;
 
 /**
- * @coversDefaultClass \Redmine\Api\CustomField
- *
  * @author     Malte Gerth <mail@malte-gerth.de>
  */
+#[CoversClass(CustomField::class)]
 class CustomFieldTest extends TestCase
 {
     /**
      * Test all().
-     *
-     * @covers ::all
      */
     public function testAllTriggersDeprecationWarning()
     {
@@ -44,7 +42,6 @@ class CustomFieldTest extends TestCase
     /**
      * Test all().
      *
-     * @covers ::all
      * @dataProvider getAllData
      */
     #[DataProvider('getAllData')]
@@ -81,8 +78,6 @@ class CustomFieldTest extends TestCase
 
     /**
      * Test all().
-     *
-     * @covers ::all
      */
     public function testAllReturnsClientGetResponseWithParameters()
     {
@@ -115,8 +110,6 @@ class CustomFieldTest extends TestCase
 
     /**
      * Test all().
-     *
-     * @covers ::all
      */
     public function testAllReturnsClientGetResponseWithHighLimit()
     {
@@ -152,8 +145,6 @@ class CustomFieldTest extends TestCase
 
     /**
      * Test all().
-     *
-     * @covers ::all
      */
     public function testAllCallsEndpointUntilOffsetIsHigherThanTotalCount()
     {
@@ -194,8 +185,6 @@ class CustomFieldTest extends TestCase
 
     /**
      * Test listing().
-     *
-     * @covers ::listing
      */
     public function testListingReturnsNameIdArray()
     {
@@ -230,8 +219,6 @@ class CustomFieldTest extends TestCase
 
     /**
      * Test listing().
-     *
-     * @covers ::listing
      */
     public function testListingCallsGetOnlyTheFirstTime()
     {
@@ -267,8 +254,6 @@ class CustomFieldTest extends TestCase
 
     /**
      * Test listing().
-     *
-     * @covers ::listing
      */
     public function testListingCallsGetEveryTimeWithForceUpdate()
     {
@@ -304,8 +289,6 @@ class CustomFieldTest extends TestCase
 
     /**
      * Test getIdByName().
-     *
-     * @covers ::getIdByName
      */
     public function testGetIdByNameMakesGetRequest()
     {

--- a/tests/Unit/Api/Group/AddUserTest.php
+++ b/tests/Unit/Api/Group/AddUserTest.php
@@ -2,15 +2,14 @@
 
 namespace Redmine\Tests\Unit\Api\Group;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Group;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 use SimpleXMLElement;
 
-/**
- * @covers \Redmine\Api\Group::addUser
- */
+#[CoversClass(Group::class)]
 class AddUserTest extends TestCase
 {
     /**

--- a/tests/Unit/Api/Group/AddUserTest.php
+++ b/tests/Unit/Api/Group/AddUserTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api\Group;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Group;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
@@ -15,6 +16,7 @@ class AddUserTest extends TestCase
     /**
      * @dataProvider getAddUserData
      */
+    #[DataProvider('getAddUserData')]
     public function testAddUserReturnsCorrectResponse($groupId, $userId, $expectedPath, $expectedBody, $responseCode, $response)
     {
         $client = AssertingHttpClient::create(

--- a/tests/Unit/Api/Group/CreateTest.php
+++ b/tests/Unit/Api/Group/CreateTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Redmine\Tests\Unit\Api\Group;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Group;
 use Redmine\Exception\MissingParameterException;
@@ -19,6 +20,7 @@ class CreateTest extends TestCase
     /**
      * @dataProvider getCreateData
      */
+    #[DataProvider('getCreateData')]
     public function testCreateReturnsCorrectResponse($parameters, $expectedPath, $expectedBody, $responseCode, $response)
     {
         $client = AssertingHttpClient::create(

--- a/tests/Unit/Api/Group/CreateTest.php
+++ b/tests/Unit/Api/Group/CreateTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Redmine\Tests\Unit\Api\Group;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Group;
@@ -12,9 +13,7 @@ use Redmine\Http\HttpClient;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 use SimpleXMLElement;
 
-/**
- * @covers \Redmine\Api\Group::create
- */
+#[CoversClass(Group::class)]
 class CreateTest extends TestCase
 {
     /**

--- a/tests/Unit/Api/Group/ListTest.php
+++ b/tests/Unit/Api/Group/ListTest.php
@@ -2,14 +2,13 @@
 
 namespace Redmine\Tests\Unit\Api\Group;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Group;
 use Redmine\Client\Client;
 use Redmine\Exception\UnexpectedResponseException;
 
-/**
- * @covers \Redmine\Api\Group::list
- */
+#[CoversClass(Group::class)]
 class ListTest extends TestCase
 {
     public function testListWithoutParametersReturnsResponse()

--- a/tests/Unit/Api/Group/ShowTest.php
+++ b/tests/Unit/Api/Group/ShowTest.php
@@ -2,14 +2,13 @@
 
 namespace Redmine\Tests\Unit\Api\Group;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Group;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
-/**
- * @covers \Redmine\Api\Group::show
- */
+#[CoversClass(Group::class)]
 class ShowTest extends TestCase
 {
     /**

--- a/tests/Unit/Api/Group/ShowTest.php
+++ b/tests/Unit/Api/Group/ShowTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api\Group;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Group;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
@@ -14,6 +15,7 @@ class ShowTest extends TestCase
     /**
      * @dataProvider getShowData
      */
+    #[DataProvider('getShowData')]
     public function testShowReturnsCorrectResponse($groupId, array $params, $expectedPath, $response, $expectedReturn)
     {
         $client = AssertingHttpClient::create(

--- a/tests/Unit/Api/Group/UpdateTest.php
+++ b/tests/Unit/Api/Group/UpdateTest.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace Redmine\Tests\Unit\Api\Group;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Group;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
-/**
- * @covers \Redmine\Api\Group::update
- */
+#[CoversClass(Group::class)]
 class UpdateTest extends TestCase
 {
     public function testUpdateWithNameUpdatesGroup()

--- a/tests/Unit/Api/GroupTest.php
+++ b/tests/Unit/Api/GroupTest.php
@@ -48,7 +48,6 @@ class GroupTest extends TestCase
      *
      * @covers ::all
      * @dataProvider getAllData
-     * @test
      */
     #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
@@ -86,7 +85,6 @@ class GroupTest extends TestCase
      * Test all().
      *
      * @covers ::all
-     * @test
      */
     public function testAllReturnsClientGetResponseWithParameters()
     {
@@ -124,7 +122,6 @@ class GroupTest extends TestCase
      * Test listing().
      *
      * @covers ::listing
-     * @test
      */
     public function testListingReturnsNameIdArray()
     {
@@ -161,7 +158,6 @@ class GroupTest extends TestCase
      * Test listing().
      *
      * @covers ::listing
-     * @test
      */
     public function testListingCallsGetOnlyTheFirstTime()
     {
@@ -199,7 +195,6 @@ class GroupTest extends TestCase
      * Test listing().
      *
      * @covers ::listing
-     * @test
      */
     public function testListingCallsGetEveryTimeWithForceUpdate()
     {
@@ -238,7 +233,6 @@ class GroupTest extends TestCase
      *
      * @covers ::delete
      * @covers ::remove
-     * @test
      */
     public function testRemoveCallsDelete()
     {
@@ -279,7 +273,6 @@ class GroupTest extends TestCase
      *
      * @covers ::delete
      * @covers ::removeUser
-     * @test
      */
     public function testRemoveUserCallsDelete()
     {

--- a/tests/Unit/Api/GroupTest.php
+++ b/tests/Unit/Api/GroupTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Redmine\Tests\Unit\Api;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Group;
 use Redmine\Client\Client;
@@ -49,6 +50,7 @@ class GroupTest extends TestCase
      * @dataProvider getAllData
      * @test
      */
+    #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
     {
         // Create the used mock objects

--- a/tests/Unit/Api/GroupTest.php
+++ b/tests/Unit/Api/GroupTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Redmine\Tests\Unit\Api;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Group;
@@ -11,16 +12,13 @@ use Redmine\Client\Client;
 use Redmine\Tests\Fixtures\MockClient;
 
 /**
- * @coversDefaultClass \Redmine\Api\Group
- *
  * @author     Malte Gerth <mail@malte-gerth.de>
  */
+#[CoversClass(Group::class)]
 class GroupTest extends TestCase
 {
     /**
      * Test all().
-     *
-     * @covers ::all
      */
     public function testAllTriggersDeprecationWarning()
     {
@@ -46,7 +44,6 @@ class GroupTest extends TestCase
     /**
      * Test all().
      *
-     * @covers ::all
      * @dataProvider getAllData
      */
     #[DataProvider('getAllData')]
@@ -83,8 +80,6 @@ class GroupTest extends TestCase
 
     /**
      * Test all().
-     *
-     * @covers ::all
      */
     public function testAllReturnsClientGetResponseWithParameters()
     {
@@ -120,8 +115,6 @@ class GroupTest extends TestCase
 
     /**
      * Test listing().
-     *
-     * @covers ::listing
      */
     public function testListingReturnsNameIdArray()
     {
@@ -156,8 +149,6 @@ class GroupTest extends TestCase
 
     /**
      * Test listing().
-     *
-     * @covers ::listing
      */
     public function testListingCallsGetOnlyTheFirstTime()
     {
@@ -193,8 +184,6 @@ class GroupTest extends TestCase
 
     /**
      * Test listing().
-     *
-     * @covers ::listing
      */
     public function testListingCallsGetEveryTimeWithForceUpdate()
     {
@@ -230,9 +219,6 @@ class GroupTest extends TestCase
 
     /**
      * Test remove().
-     *
-     * @covers ::delete
-     * @covers ::remove
      */
     public function testRemoveCallsDelete()
     {
@@ -270,9 +256,6 @@ class GroupTest extends TestCase
 
     /**
      * Test removeUser().
-     *
-     * @covers ::delete
-     * @covers ::removeUser
      */
     public function testRemoveUserCallsDelete()
     {

--- a/tests/Unit/Api/Issue/AddWatcherTest.php
+++ b/tests/Unit/Api/Issue/AddWatcherTest.php
@@ -2,15 +2,14 @@
 
 namespace Redmine\Tests\Unit\Api\Issue;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Issue;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 use SimpleXMLElement;
 
-/**
- * @covers \Redmine\Api\Issue::addWatcher
- */
+#[CoversClass(Issue::class)]
 class AddWatcherTest extends TestCase
 {
     /**

--- a/tests/Unit/Api/Issue/AddWatcherTest.php
+++ b/tests/Unit/Api/Issue/AddWatcherTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api\Issue;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Issue;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
@@ -15,6 +16,7 @@ class AddWatcherTest extends TestCase
     /**
      * @dataProvider getAddWatcherData
      */
+    #[DataProvider('getAddWatcherData')]
     public function testCreateReturnsCorrectResponse($issueId, $watcherUserId, $expectedPath, $expectedBody, $responseCode, $response)
     {
         $client = AssertingHttpClient::create(

--- a/tests/Unit/Api/Issue/CreateTest.php
+++ b/tests/Unit/Api/Issue/CreateTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api\Issue;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Issue;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
@@ -15,6 +16,7 @@ class CreateTest extends TestCase
     /**
      * @dataProvider getCreateData
      */
+    #[DataProvider('getCreateData')]
     public function testCreateReturnsCorrectResponse($parameters, $expectedPath, $expectedBody, $responseCode, $response)
     {
         $client = AssertingHttpClient::create(

--- a/tests/Unit/Api/Issue/CreateTest.php
+++ b/tests/Unit/Api/Issue/CreateTest.php
@@ -2,15 +2,14 @@
 
 namespace Redmine\Tests\Unit\Api\Issue;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Issue;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 use SimpleXMLElement;
 
-/**
- * @covers \Redmine\Api\Issue::create
- */
+#[CoversClass(Issue::class)]
 class CreateTest extends TestCase
 {
     /**
@@ -257,10 +256,6 @@ class CreateTest extends TestCase
         $this->assertSame('', $return);
     }
 
-    /**
-     * @covers \Redmine\Api\Issue::cleanParams
-     * @covers \Redmine\Api\Issue::getIssueStatusApi
-     */
     public function testCreateWithHttpClientRetrievesIssueStatusId()
     {
         $client = AssertingHttpClient::create(
@@ -298,10 +293,6 @@ class CreateTest extends TestCase
         );
     }
 
-    /**
-     * @covers \Redmine\Api\Issue::cleanParams
-     * @covers \Redmine\Api\Issue::getProjectApi
-     */
     public function testCreateWithHttpClientRetrievesProjectId()
     {
         $client = AssertingHttpClient::create(
@@ -339,10 +330,6 @@ class CreateTest extends TestCase
         );
     }
 
-    /**
-     * @covers \Redmine\Api\Issue::cleanParams
-     * @covers \Redmine\Api\Issue::getIssueCategoryApi
-     */
     public function testCreateWithHttpClientRetrievesIssueCategoryId()
     {
         $client = AssertingHttpClient::create(
@@ -380,10 +367,6 @@ class CreateTest extends TestCase
         );
     }
 
-    /**
-     * @covers \Redmine\Api\Issue::cleanParams
-     * @covers \Redmine\Api\Issue::getTrackerApi
-     */
     public function testCreateWithHttpClientRetrievesTrackerId()
     {
         $client = AssertingHttpClient::create(
@@ -421,10 +404,6 @@ class CreateTest extends TestCase
         );
     }
 
-    /**
-     * @covers \Redmine\Api\Issue::cleanParams
-     * @covers \Redmine\Api\Issue::getUserApi
-     */
     public function testCreateWithHttpClientRetrievesUserId()
     {
         $client = AssertingHttpClient::create(
@@ -464,13 +443,6 @@ class CreateTest extends TestCase
 
     /**
      * Test cleanParams().
-     *
-     * @covers \Redmine\Api\Issue::cleanParams
-     * @covers \Redmine\Api\Issue::getIssueCategoryApi
-     * @covers \Redmine\Api\Issue::getIssueStatusApi
-     * @covers \Redmine\Api\Issue::getProjectApi
-     * @covers \Redmine\Api\Issue::getTrackerApi
-     * @covers \Redmine\Api\Issue::getUserApi
      */
     public function testCreateWithClientCleansParameters()
     {

--- a/tests/Unit/Api/Issue/ListTest.php
+++ b/tests/Unit/Api/Issue/ListTest.php
@@ -2,14 +2,13 @@
 
 namespace Redmine\Tests\Unit\Api\Issue;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Issue;
 use Redmine\Client\Client;
 use Redmine\Exception\UnexpectedResponseException;
 
-/**
- * @covers \Redmine\Api\Issue::list
- */
+#[CoversClass(Issue::class)]
 class ListTest extends TestCase
 {
     public function testListWithoutParametersReturnsResponse()

--- a/tests/Unit/Api/Issue/ShowTest.php
+++ b/tests/Unit/Api/Issue/ShowTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api\Issue;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Issue;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
@@ -14,6 +15,7 @@ class ShowTest extends TestCase
     /**
      * @dataProvider getShowData
      */
+    #[DataProvider('getShowData')]
     public function testShowReturnsCorrectResponse($issueId, array $params, $expectedPath, $response, $expectedReturn)
     {
         $client = AssertingHttpClient::create(

--- a/tests/Unit/Api/Issue/ShowTest.php
+++ b/tests/Unit/Api/Issue/ShowTest.php
@@ -2,14 +2,13 @@
 
 namespace Redmine\Tests\Unit\Api\Issue;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Issue;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
-/**
- * @covers \Redmine\Api\Issue::show
- */
+#[CoversClass(Issue::class)]
 class ShowTest extends TestCase
 {
     /**

--- a/tests/Unit/Api/IssueCategory/CreateTest.php
+++ b/tests/Unit/Api/IssueCategory/CreateTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api\IssueCategory;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\IssueCategory;
 use Redmine\Exception\MissingParameterException;
@@ -17,6 +18,7 @@ class CreateTest extends TestCase
     /**
      * @dataProvider getCreateData
      */
+    #[DataProvider('getCreateData')]
     public function testCreateReturnsCorrectResponse($identifier, $parameters, $expectedPath, $expectedBody, $responseCode, $response)
     {
         $client = AssertingHttpClient::create(
@@ -114,6 +116,7 @@ class CreateTest extends TestCase
     /**
      * @dataProvider incompleteCreateParameterProvider
      */
+    #[DataProvider('incompleteCreateParameterProvider')]
     public function testCreateThrowsExceptionIfMandatoyParametersAreMissing($parameters)
     {
         // Create the used mock objects

--- a/tests/Unit/Api/IssueCategory/CreateTest.php
+++ b/tests/Unit/Api/IssueCategory/CreateTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api\IssueCategory;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\IssueCategory;
@@ -10,9 +11,7 @@ use Redmine\Http\HttpClient;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 use SimpleXMLElement;
 
-/**
- * @covers \Redmine\Api\IssueCategory::create
- */
+#[CoversClass(IssueCategory::class)]
 class CreateTest extends TestCase
 {
     /**

--- a/tests/Unit/Api/IssueCategory/ListByProjectTest.php
+++ b/tests/Unit/Api/IssueCategory/ListByProjectTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api\IssueCategory;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\IssueCategory;
 use Redmine\Client\Client;
@@ -73,6 +74,7 @@ class ListByProjectTest extends TestCase
     /**
      * @dataProvider getInvalidProjectIdentifiers
      */
+    #[DataProvider('getInvalidProjectIdentifiers')]
     public function testListByProjectWithWrongProjectIdentifierThrowsException($projectIdentifier)
     {
         $api = new IssueCategory(MockClient::create());

--- a/tests/Unit/Api/IssueCategory/ListByProjectTest.php
+++ b/tests/Unit/Api/IssueCategory/ListByProjectTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api\IssueCategory;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\IssueCategory;
@@ -11,9 +12,7 @@ use Redmine\Exception\UnexpectedResponseException;
 use Redmine\Tests\Fixtures\MockClient;
 use stdClass;
 
-/**
- * @covers \Redmine\Api\IssueCategory::listByProject
- */
+#[CoversClass(IssueCategory::class)]
 class ListByProjectTest extends TestCase
 {
     public function testListByProjectWithoutParametersReturnsResponse()

--- a/tests/Unit/Api/IssueCategory/ShowTest.php
+++ b/tests/Unit/Api/IssueCategory/ShowTest.php
@@ -2,14 +2,13 @@
 
 namespace Redmine\Tests\Unit\Api\IssueCategory;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\IssueCategory;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
-/**
- * @covers \Redmine\Api\IssueCategory::show
- */
+#[CoversClass(IssueCategory::class)]
 class ShowTest extends TestCase
 {
     /**

--- a/tests/Unit/Api/IssueCategory/ShowTest.php
+++ b/tests/Unit/Api/IssueCategory/ShowTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api\IssueCategory;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\IssueCategory;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
@@ -14,6 +15,7 @@ class ShowTest extends TestCase
     /**
      * @dataProvider getShowData
      */
+    #[DataProvider('getShowData')]
     public function testShowReturnsCorrectResponse($id, $expectedPath, $response, $expectedReturn)
     {
         $client = AssertingHttpClient::create(

--- a/tests/Unit/Api/IssueCategoryTest.php
+++ b/tests/Unit/Api/IssueCategoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\IssueCategory;
 use Redmine\Client\Client;
@@ -48,6 +49,7 @@ class IssueCategoryTest extends TestCase
      * @dataProvider getAllDAta
      * @test
      */
+    #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponseWithProject($response, $responseType, $expectedResponse)
     {
         // Test values

--- a/tests/Unit/Api/IssueCategoryTest.php
+++ b/tests/Unit/Api/IssueCategoryTest.php
@@ -47,7 +47,6 @@ class IssueCategoryTest extends TestCase
      *
      * @covers ::all
      * @dataProvider getAllDAta
-     * @test
      */
     #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponseWithProject($response, $responseType, $expectedResponse)
@@ -88,7 +87,6 @@ class IssueCategoryTest extends TestCase
      * Test all().
      *
      * @covers ::all
-     * @test
      */
     public function testAllReturnsClientGetResponseWithParametersAndProject()
     {
@@ -127,7 +125,6 @@ class IssueCategoryTest extends TestCase
      * Test listing().
      *
      * @covers ::listing
-     * @test
      */
     public function testListingReturnsNameIdArray()
     {
@@ -164,7 +161,6 @@ class IssueCategoryTest extends TestCase
      * Test listing().
      *
      * @covers ::listing
-     * @test
      */
     public function testListingCallsGetOnlyTheFirstTime()
     {
@@ -202,7 +198,6 @@ class IssueCategoryTest extends TestCase
      * Test listing().
      *
      * @covers ::listing
-     * @test
      */
     public function testListingCallsGetEveryTimeWithForceUpdate()
     {
@@ -241,7 +236,6 @@ class IssueCategoryTest extends TestCase
      *
      * @covers ::delete
      * @covers ::remove
-     * @test
      */
     public function testRemoveCallsDelete()
     {
@@ -275,7 +269,6 @@ class IssueCategoryTest extends TestCase
      *
      * @covers ::delete
      * @covers ::remove
-     * @test
      */
     public function testRemoveCallsDeleteWithParameters()
     {
@@ -313,7 +306,6 @@ class IssueCategoryTest extends TestCase
      * Test getIdByName().
      *
      * @covers ::getIdByName
-     * @test
      */
     public function testGetIdByNameMakesGetRequest()
     {
@@ -348,7 +340,6 @@ class IssueCategoryTest extends TestCase
      *
      * @covers ::put
      * @covers ::update
-     * @test
      */
     public function testUpdateCallsPut()
     {

--- a/tests/Unit/Api/IssueCategoryTest.php
+++ b/tests/Unit/Api/IssueCategoryTest.php
@@ -2,24 +2,21 @@
 
 namespace Redmine\Tests\Unit\Api;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\IssueCategory;
 use Redmine\Client\Client;
-use Redmine\Exception\MissingParameterException;
 use Redmine\Tests\Fixtures\MockClient;
 
 /**
- * @coversDefaultClass \Redmine\Api\IssueCategory
- *
  * @author     Malte Gerth <mail@malte-gerth.de>
  */
+#[CoversClass(IssueCategory::class)]
 class IssueCategoryTest extends TestCase
 {
     /**
      * Test all().
-     *
-     * @covers ::all
      */
     public function testAllTriggersDeprecationWarning()
     {
@@ -45,7 +42,6 @@ class IssueCategoryTest extends TestCase
     /**
      * Test all().
      *
-     * @covers ::all
      * @dataProvider getAllDAta
      */
     #[DataProvider('getAllData')]
@@ -85,8 +81,6 @@ class IssueCategoryTest extends TestCase
 
     /**
      * Test all().
-     *
-     * @covers ::all
      */
     public function testAllReturnsClientGetResponseWithParametersAndProject()
     {
@@ -123,8 +117,6 @@ class IssueCategoryTest extends TestCase
 
     /**
      * Test listing().
-     *
-     * @covers ::listing
      */
     public function testListingReturnsNameIdArray()
     {
@@ -159,8 +151,6 @@ class IssueCategoryTest extends TestCase
 
     /**
      * Test listing().
-     *
-     * @covers ::listing
      */
     public function testListingCallsGetOnlyTheFirstTime()
     {
@@ -196,8 +186,6 @@ class IssueCategoryTest extends TestCase
 
     /**
      * Test listing().
-     *
-     * @covers ::listing
      */
     public function testListingCallsGetEveryTimeWithForceUpdate()
     {
@@ -233,9 +221,6 @@ class IssueCategoryTest extends TestCase
 
     /**
      * Test remove().
-     *
-     * @covers ::delete
-     * @covers ::remove
      */
     public function testRemoveCallsDelete()
     {
@@ -266,9 +251,6 @@ class IssueCategoryTest extends TestCase
 
     /**
      * Test remove().
-     *
-     * @covers ::delete
-     * @covers ::remove
      */
     public function testRemoveCallsDeleteWithParameters()
     {
@@ -304,8 +286,6 @@ class IssueCategoryTest extends TestCase
 
     /**
      * Test getIdByName().
-     *
-     * @covers ::getIdByName
      */
     public function testGetIdByNameMakesGetRequest()
     {
@@ -337,9 +317,6 @@ class IssueCategoryTest extends TestCase
 
     /**
      * Test update().
-     *
-     * @covers ::put
-     * @covers ::update
      */
     public function testUpdateCallsPut()
     {

--- a/tests/Unit/Api/IssuePriority/ListTest.php
+++ b/tests/Unit/Api/IssuePriority/ListTest.php
@@ -2,14 +2,13 @@
 
 namespace Redmine\Tests\Unit\Api\IssuePriority;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\IssuePriority;
 use Redmine\Client\Client;
 use Redmine\Exception\UnexpectedResponseException;
 
-/**
- * @covers \Redmine\Api\IssuePriority::list
- */
+#[CoversClass(IssuePriority::class)]
 class ListTest extends TestCase
 {
     public function testListWithoutParametersReturnsResponse()

--- a/tests/Unit/Api/IssuePriorityTest.php
+++ b/tests/Unit/Api/IssuePriorityTest.php
@@ -46,7 +46,6 @@ class IssuePriorityTest extends TestCase
      *
      * @covers ::all
      * @dataProvider getAllData
-     * @test
      */
     #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
@@ -84,7 +83,6 @@ class IssuePriorityTest extends TestCase
      * Test all().
      *
      * @covers ::all
-     * @test
      */
     public function testAllReturnsClientGetResponseWithParameters()
     {

--- a/tests/Unit/Api/IssuePriorityTest.php
+++ b/tests/Unit/Api/IssuePriorityTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\IssuePriority;
@@ -9,16 +10,13 @@ use Redmine\Client\Client;
 use Redmine\Tests\Fixtures\MockClient;
 
 /**
- * @coversDefaultClass \Redmine\Api\IssuePriority
- *
  * @author     Malte Gerth <mail@malte-gerth.de>
  */
+#[CoversClass(IssuePriority::class)]
 class IssuePriorityTest extends TestCase
 {
     /**
      * Test all().
-     *
-     * @covers ::all
      */
     public function testAllTriggersDeprecationWarning()
     {
@@ -44,7 +42,6 @@ class IssuePriorityTest extends TestCase
     /**
      * Test all().
      *
-     * @covers ::all
      * @dataProvider getAllData
      */
     #[DataProvider('getAllData')]
@@ -81,8 +78,6 @@ class IssuePriorityTest extends TestCase
 
     /**
      * Test all().
-     *
-     * @covers ::all
      */
     public function testAllReturnsClientGetResponseWithParameters()
     {

--- a/tests/Unit/Api/IssuePriorityTest.php
+++ b/tests/Unit/Api/IssuePriorityTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\IssuePriority;
 use Redmine\Client\Client;
@@ -47,6 +48,7 @@ class IssuePriorityTest extends TestCase
      * @dataProvider getAllData
      * @test
      */
+    #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
     {
         // Create the used mock objects

--- a/tests/Unit/Api/IssueRelation/CreateTest.php
+++ b/tests/Unit/Api/IssueRelation/CreateTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api\IssueRelation;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\IssueRelation;
@@ -10,9 +11,7 @@ use Redmine\Exception\SerializerException;
 use Redmine\Http\HttpClient;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
-/**
- * @covers \Redmine\Api\IssueRelation::create
- */
+#[CoversClass(IssueRelation::class)]
 class CreateTest extends TestCase
 {
     /**

--- a/tests/Unit/Api/IssueRelation/CreateTest.php
+++ b/tests/Unit/Api/IssueRelation/CreateTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api\IssueRelation;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\IssueRelation;
 use Redmine\Exception\MissingParameterException;
@@ -17,6 +18,7 @@ class CreateTest extends TestCase
     /**
      * @dataProvider getCreateData
      */
+    #[DataProvider('getCreateData')]
     public function testCreateReturnsCorrectResponse($issueId, $parameters, $expectedPath, $expectedBody, $responseCode, $response, $expectedReturn)
     {
         $client = AssertingHttpClient::create(
@@ -100,6 +102,7 @@ class CreateTest extends TestCase
     /**
      * @dataProvider incompleteCreateParameterProvider
      */
+    #[DataProvider('incompleteCreateParameterProvider')]
     public function testCreateThrowsExceptionIfMandatoyParametersAreMissing($parameters)
     {
         // Create the used mock objects

--- a/tests/Unit/Api/IssueRelation/ListByIssueIdTest.php
+++ b/tests/Unit/Api/IssueRelation/ListByIssueIdTest.php
@@ -2,14 +2,13 @@
 
 namespace Redmine\Tests\Unit\Api\IssueRelation;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\IssueRelation;
 use Redmine\Client\Client;
 use Redmine\Exception\UnexpectedResponseException;
 
-/**
- * @covers \Redmine\Api\IssueRelation::listByIssueId
- */
+#[CoversClass(IssueRelation::class)]
 class ListByIssueIdTest extends TestCase
 {
     public function testListByIssueIdWithoutParametersReturnsResponse()

--- a/tests/Unit/Api/IssueRelation/ShowTest.php
+++ b/tests/Unit/Api/IssueRelation/ShowTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api\IssueRelation;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\IssueRelation;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
@@ -14,6 +15,7 @@ class ShowTest extends TestCase
     /**
      * @dataProvider getShowData
      */
+    #[DataProvider('getShowData')]
     public function testShowReturnsCorrectResponse($id, $expectedPath, $response, $expectedReturn)
     {
         $client = AssertingHttpClient::create(

--- a/tests/Unit/Api/IssueRelation/ShowTest.php
+++ b/tests/Unit/Api/IssueRelation/ShowTest.php
@@ -2,14 +2,13 @@
 
 namespace Redmine\Tests\Unit\Api\IssueRelation;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\IssueRelation;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
-/**
- * @covers \Redmine\Api\IssueRelation::show
- */
+#[CoversClass(IssueRelation::class)]
 class ShowTest extends TestCase
 {
     /**

--- a/tests/Unit/Api/IssueRelationTest.php
+++ b/tests/Unit/Api/IssueRelationTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\IssueRelation;
 use Redmine\Client\Client;
@@ -47,6 +48,7 @@ class IssueRelationTest extends TestCase
      * @dataProvider getAllData
      * @test
      */
+    #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponseWithProject($response, $responseType, $expectedResponse)
     {
         // Create the used mock objects

--- a/tests/Unit/Api/IssueRelationTest.php
+++ b/tests/Unit/Api/IssueRelationTest.php
@@ -46,7 +46,6 @@ class IssueRelationTest extends TestCase
      *
      * @covers ::all
      * @dataProvider getAllData
-     * @test
      */
     #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponseWithProject($response, $responseType, $expectedResponse)
@@ -84,7 +83,6 @@ class IssueRelationTest extends TestCase
      * Test all().
      *
      * @covers ::all
-     * @test
      */
     public function testAllReturnsClientGetResponseWithParametersAndProject()
     {
@@ -123,7 +121,6 @@ class IssueRelationTest extends TestCase
      *
      * @covers ::delete
      * @covers ::remove
-     * @test
      */
     public function testRemoveCallsDelete()
     {

--- a/tests/Unit/Api/IssueRelationTest.php
+++ b/tests/Unit/Api/IssueRelationTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\IssueRelation;
@@ -9,16 +10,13 @@ use Redmine\Client\Client;
 use Redmine\Tests\Fixtures\MockClient;
 
 /**
- * @coversDefaultClass \Redmine\Api\IssueRelation
- *
  * @author     Malte Gerth <mail@malte-gerth.de>
  */
+#[CoversClass(IssueRelation::class)]
 class IssueRelationTest extends TestCase
 {
     /**
      * Test all().
-     *
-     * @covers ::all
      */
     public function testAllTriggersDeprecationWarning()
     {
@@ -44,7 +42,6 @@ class IssueRelationTest extends TestCase
     /**
      * Test all().
      *
-     * @covers ::all
      * @dataProvider getAllData
      */
     #[DataProvider('getAllData')]
@@ -81,8 +78,6 @@ class IssueRelationTest extends TestCase
 
     /**
      * Test all().
-     *
-     * @covers ::all
      */
     public function testAllReturnsClientGetResponseWithParametersAndProject()
     {
@@ -118,9 +113,6 @@ class IssueRelationTest extends TestCase
 
     /**
      * Test remove().
-     *
-     * @covers ::delete
-     * @covers ::remove
      */
     public function testRemoveCallsDelete()
     {

--- a/tests/Unit/Api/IssueStatus/ListTest.php
+++ b/tests/Unit/Api/IssueStatus/ListTest.php
@@ -2,14 +2,13 @@
 
 namespace Redmine\Tests\Unit\Api\IssueStatus;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\IssueStatus;
 use Redmine\Client\Client;
 use Redmine\Exception\UnexpectedResponseException;
 
-/**
- * @covers \Redmine\Api\IssueStatus::list
- */
+#[CoversClass(IssueStatus::class)]
 class ListTest extends TestCase
 {
     public function testListWithoutParametersReturnsResponse()

--- a/tests/Unit/Api/IssueStatusTest.php
+++ b/tests/Unit/Api/IssueStatusTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\IssueStatus;
@@ -9,16 +10,13 @@ use Redmine\Client\Client;
 use Redmine\Tests\Fixtures\MockClient;
 
 /**
- * @coversDefaultClass \Redmine\Api\IssueStatus
- *
  * @author     Malte Gerth <mail@malte-gerth.de>
  */
+#[CoversClass(IssueStatus::class)]
 class IssueStatusTest extends TestCase
 {
     /**
      * Test all().
-     *
-     * @covers ::all
      */
     public function testAllTriggersDeprecationWarning()
     {
@@ -44,7 +42,6 @@ class IssueStatusTest extends TestCase
     /**
      * Test all().
      *
-     * @covers ::all
      * @dataProvider getAllData
      */
     #[DataProvider('getAllData')]
@@ -81,8 +78,6 @@ class IssueStatusTest extends TestCase
 
     /**
      * Test all().
-     *
-     * @covers ::all
      */
     public function testAllReturnsClientGetResponseWithParametersAndProject()
     {
@@ -118,8 +113,6 @@ class IssueStatusTest extends TestCase
 
     /**
      * Test listing().
-     *
-     * @covers ::listing
      */
     public function testListingReturnsNameIdArray()
     {
@@ -154,8 +147,6 @@ class IssueStatusTest extends TestCase
 
     /**
      * Test listing().
-     *
-     * @covers ::listing
      */
     public function testListingCallsGetOnlyTheFirstTime()
     {
@@ -191,8 +182,6 @@ class IssueStatusTest extends TestCase
 
     /**
      * Test listing().
-     *
-     * @covers ::listing
      */
     public function testListingCallsGetEveryTimeWithForceUpdate()
     {
@@ -228,8 +217,6 @@ class IssueStatusTest extends TestCase
 
     /**
      * Test getIdByName().
-     *
-     * @covers ::getIdByName
      */
     public function testGetIdByNameMakesGetRequest()
     {

--- a/tests/Unit/Api/IssueStatusTest.php
+++ b/tests/Unit/Api/IssueStatusTest.php
@@ -46,7 +46,6 @@ class IssueStatusTest extends TestCase
      *
      * @covers ::all
      * @dataProvider getAllData
-     * @test
      */
     #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
@@ -84,7 +83,6 @@ class IssueStatusTest extends TestCase
      * Test all().
      *
      * @covers ::all
-     * @test
      */
     public function testAllReturnsClientGetResponseWithParametersAndProject()
     {
@@ -122,7 +120,6 @@ class IssueStatusTest extends TestCase
      * Test listing().
      *
      * @covers ::listing
-     * @test
      */
     public function testListingReturnsNameIdArray()
     {
@@ -159,7 +156,6 @@ class IssueStatusTest extends TestCase
      * Test listing().
      *
      * @covers ::listing
-     * @test
      */
     public function testListingCallsGetOnlyTheFirstTime()
     {
@@ -197,7 +193,6 @@ class IssueStatusTest extends TestCase
      * Test listing().
      *
      * @covers ::listing
-     * @test
      */
     public function testListingCallsGetEveryTimeWithForceUpdate()
     {
@@ -235,7 +230,6 @@ class IssueStatusTest extends TestCase
      * Test getIdByName().
      *
      * @covers ::getIdByName
-     * @test
      */
     public function testGetIdByNameMakesGetRequest()
     {

--- a/tests/Unit/Api/IssueStatusTest.php
+++ b/tests/Unit/Api/IssueStatusTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\IssueStatus;
 use Redmine\Client\Client;
@@ -47,6 +48,7 @@ class IssueStatusTest extends TestCase
      * @dataProvider getAllData
      * @test
      */
+    #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
     {
         // Create the used mock objects

--- a/tests/Unit/Api/IssueTest.php
+++ b/tests/Unit/Api/IssueTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Issue;
@@ -11,10 +12,9 @@ use Redmine\Tests\Fixtures\MockClient;
 use SimpleXMLElement;
 
 /**
- * @coversDefaultClass \Redmine\Api\Issue
- *
  * @author     Malte Gerth <mail@malte-gerth.de>
  */
+#[CoversClass(Issue::class)]
 class IssueTest extends TestCase
 {
     public static function getPriorityConstantsData(): array
@@ -41,8 +41,6 @@ class IssueTest extends TestCase
 
     /**
      * Test all().
-     *
-     * @covers ::all
      */
     public function testAllTriggersDeprecationWarning()
     {
@@ -68,7 +66,6 @@ class IssueTest extends TestCase
     /**
      * Test all().
      *
-     * @covers ::all
      * @dataProvider getAllData
      */
     #[DataProvider('getAllData')]
@@ -105,8 +102,6 @@ class IssueTest extends TestCase
 
     /**
      * Test all().
-     *
-     * @covers ::all
      */
     public function testAllReturnsClientGetResponseWithParameters()
     {
@@ -142,9 +137,6 @@ class IssueTest extends TestCase
 
     /**
      * Test remove().
-     *
-     * @covers ::delete
-     * @covers ::remove
      */
     public function testRemoveCallsDelete()
     {
@@ -178,9 +170,6 @@ class IssueTest extends TestCase
 
     /**
      * Test attach().
-     *
-     * @covers ::attach
-     * @covers ::put
      */
     public function testAttachCallsPut()
     {
@@ -225,8 +214,6 @@ class IssueTest extends TestCase
 
     /**
      * Test removeWatcher().
-     *
-     * @covers ::removeWatcher
      */
     public function testRemoveWatcherCallsPost()
     {
@@ -254,14 +241,6 @@ class IssueTest extends TestCase
 
     /**
      * Test cleanParams() with Client for BC
-     *
-     * @covers ::create
-     * @covers ::cleanParams
-     * @covers ::getIssueCategoryApi
-     * @covers ::getIssueStatusApi
-     * @covers ::getProjectApi
-     * @covers ::getTrackerApi
-     * @covers ::getUserApi
      */
     public function testCreateWithClientCleansParameters()
     {
@@ -335,9 +314,6 @@ class IssueTest extends TestCase
 
     /**
      * Test update().
-     *
-     * @covers ::update
-     * @covers ::put
      */
     public function testUpdateCallsPut()
     {
@@ -367,9 +343,6 @@ class IssueTest extends TestCase
 
     /**
      * Test update().
-     *
-     * @covers ::update
-     * @covers ::cleanParams
      */
     public function testUpdateCleansParameters()
     {
@@ -441,8 +414,6 @@ class IssueTest extends TestCase
 
     /**
      * Test setIssueStatus().
-     *
-     * @covers ::setIssueStatus
      */
     public function testSetIssueStatusWithClient()
     {
@@ -486,8 +457,6 @@ class IssueTest extends TestCase
 
     /**
      * Test setIssueStatus().
-     *
-     * @covers ::setIssueStatus
      */
     public function testSetIssueStatusWithHttpClient()
     {
@@ -528,8 +497,6 @@ class IssueTest extends TestCase
 
     /**
      * Test addNoteToIssue().
-     *
-     * @covers ::addNoteToIssue
      */
     public function testAddNoteToIssue()
     {

--- a/tests/Unit/Api/IssueTest.php
+++ b/tests/Unit/Api/IssueTest.php
@@ -32,8 +32,6 @@ class IssueTest extends TestCase
      * Test the constants.
      *
      * @dataProvider getPriorityConstantsData
-     *
-     * @test
      */
     #[DataProvider('getPriorityConstantsData')]
     public function testPriorityConstants($expected, $value)
@@ -72,7 +70,6 @@ class IssueTest extends TestCase
      *
      * @covers ::all
      * @dataProvider getAllData
-     * @test
      */
     #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
@@ -110,7 +107,6 @@ class IssueTest extends TestCase
      * Test all().
      *
      * @covers ::all
-     * @test
      */
     public function testAllReturnsClientGetResponseWithParameters()
     {
@@ -149,7 +145,6 @@ class IssueTest extends TestCase
      *
      * @covers ::delete
      * @covers ::remove
-     * @test
      */
     public function testRemoveCallsDelete()
     {
@@ -186,7 +181,6 @@ class IssueTest extends TestCase
      *
      * @covers ::attach
      * @covers ::put
-     * @test
      */
     public function testAttachCallsPut()
     {
@@ -233,7 +227,6 @@ class IssueTest extends TestCase
      * Test removeWatcher().
      *
      * @covers ::removeWatcher
-     * @test
      */
     public function testRemoveWatcherCallsPost()
     {
@@ -269,7 +262,6 @@ class IssueTest extends TestCase
      * @covers ::getProjectApi
      * @covers ::getTrackerApi
      * @covers ::getUserApi
-     * @test
      */
     public function testCreateWithClientCleansParameters()
     {
@@ -346,7 +338,6 @@ class IssueTest extends TestCase
      *
      * @covers ::update
      * @covers ::put
-     * @test
      */
     public function testUpdateCallsPut()
     {
@@ -379,7 +370,6 @@ class IssueTest extends TestCase
      *
      * @covers ::update
      * @covers ::cleanParams
-     * @test
      */
     public function testUpdateCleansParameters()
     {
@@ -453,7 +443,6 @@ class IssueTest extends TestCase
      * Test setIssueStatus().
      *
      * @covers ::setIssueStatus
-     * @test
      */
     public function testSetIssueStatusWithClient()
     {
@@ -499,7 +488,6 @@ class IssueTest extends TestCase
      * Test setIssueStatus().
      *
      * @covers ::setIssueStatus
-     * @test
      */
     public function testSetIssueStatusWithHttpClient()
     {
@@ -542,7 +530,6 @@ class IssueTest extends TestCase
      * Test addNoteToIssue().
      *
      * @covers ::addNoteToIssue
-     * @test
      */
     public function testAddNoteToIssue()
     {
@@ -577,7 +564,6 @@ class IssueTest extends TestCase
     /**
      * Test assign an user to an issue.
      *
-     * @test
      */
     public function testAssignUserToAnIssue()
     {
@@ -609,7 +595,6 @@ class IssueTest extends TestCase
     /**
      * Test unassign an user from an issue.
      *
-     * @test
      */
     public function testUnassignUserFromAnIssue()
     {

--- a/tests/Unit/Api/IssueTest.php
+++ b/tests/Unit/Api/IssueTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Issue;
 use Redmine\Client\Client;
@@ -34,6 +35,7 @@ class IssueTest extends TestCase
      *
      * @test
      */
+    #[DataProvider('getPriorityConstantsData')]
     public function testPriorityConstants($expected, $value)
     {
         $this->assertSame($expected, $value);
@@ -72,6 +74,7 @@ class IssueTest extends TestCase
      * @dataProvider getAllData
      * @test
      */
+    #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
     {
         // Create the used mock objects

--- a/tests/Unit/Api/Membership/CreateTest.php
+++ b/tests/Unit/Api/Membership/CreateTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api\Membership;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Membership;
 use Redmine\Exception\MissingParameterException;
@@ -17,6 +18,7 @@ class CreateTest extends TestCase
     /**
      * @dataProvider getCreateData
      */
+    #[DataProvider('getCreateData')]
     public function testCreateReturnsCorrectResponse($identifier, $parameters, $expectedPath, $expectedBody, $responseCode, $response)
     {
         $client = AssertingHttpClient::create(
@@ -106,6 +108,7 @@ class CreateTest extends TestCase
     /**
      * @dataProvider incompleteCreateParameterProvider
      */
+    #[DataProvider('incompleteCreateParameterProvider')]
     public function testCreateThrowsExceptionIfMandatoyParametersAreMissing($parameters)
     {
         // Create the used mock objects

--- a/tests/Unit/Api/Membership/CreateTest.php
+++ b/tests/Unit/Api/Membership/CreateTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api\Membership;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Membership;
@@ -10,9 +11,7 @@ use Redmine\Http\HttpClient;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 use SimpleXMLElement;
 
-/**
- * @covers \Redmine\Api\Membership::create
- */
+#[CoversClass(Membership::class)]
 class CreateTest extends TestCase
 {
     /**

--- a/tests/Unit/Api/Membership/ListByProjectTest.php
+++ b/tests/Unit/Api/Membership/ListByProjectTest.php
@@ -72,7 +72,7 @@ class ListByProjectTest extends TestCase
     /**
      * @dataProvider getInvalidProjectIdentifiers
      */
-     #[DataProvider('getInvalidProjectIdentifiers')]
+    #[DataProvider('getInvalidProjectIdentifiers')]
     public function testListByProjectWithWrongProjectIdentifierThrowsException($projectIdentifier)
     {
         $api = new Membership(MockClient::create());

--- a/tests/Unit/Api/Membership/ListByProjectTest.php
+++ b/tests/Unit/Api/Membership/ListByProjectTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api\Membership;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Membership;
 use Redmine\Client\Client;
@@ -71,6 +72,7 @@ class ListByProjectTest extends TestCase
     /**
      * @dataProvider getInvalidProjectIdentifiers
      */
+     #[DataProvider('getInvalidProjectIdentifiers')]
     public function testListByProjectWithWrongProjectIdentifierThrowsException($projectIdentifier)
     {
         $api = new Membership(MockClient::create());

--- a/tests/Unit/Api/Membership/ListByProjectTest.php
+++ b/tests/Unit/Api/Membership/ListByProjectTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api\Membership;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Membership;
@@ -11,9 +12,7 @@ use Redmine\Exception\UnexpectedResponseException;
 use Redmine\Tests\Fixtures\MockClient;
 use stdClass;
 
-/**
- * @covers \Redmine\Api\Membership::listByProject
- */
+#[CoversClass(Membership::class)]
 class ListByProjectTest extends TestCase
 {
     public function testListByProjectWithoutParametersReturnsResponse()

--- a/tests/Unit/Api/MembershipTest.php
+++ b/tests/Unit/Api/MembershipTest.php
@@ -3,24 +3,21 @@
 namespace Redmine\Tests\Unit\Api;
 
 use Exception;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Membership;
 use Redmine\Client\Client;
-use Redmine\Exception\MissingParameterException;
 use Redmine\Tests\Fixtures\MockClient;
 
 /**
- * @coversDefaultClass \Redmine\Api\Membership
- *
  * @author     Malte Gerth <mail@malte-gerth.de>
  */
+#[CoversClass(Membership::class)]
 class MembershipTest extends TestCase
 {
     /**
      * Test all().
-     *
-     * @covers ::all
      */
     public function testAllTriggersDeprecationWarning()
     {
@@ -46,7 +43,6 @@ class MembershipTest extends TestCase
     /**
      * Test all().
      *
-     * @covers ::all
      * @dataProvider getAllData
      */
     #[DataProvider('getAllData')]
@@ -83,8 +79,6 @@ class MembershipTest extends TestCase
 
     /**
      * Test all().
-     *
-     * @covers ::all
      */
     public function testAllReturnsClientGetResponseWithParametersAndProject()
     {
@@ -120,9 +114,6 @@ class MembershipTest extends TestCase
 
     /**
      * Test remove().
-     *
-     * @covers ::delete
-     * @covers ::remove
      */
     public function testRemoveCallsDelete()
     {
@@ -156,8 +147,6 @@ class MembershipTest extends TestCase
 
     /**
      * Test removeMember().
-     *
-     * @covers ::removeMember
      */
     public function testRemoveMemberCallsDelete()
     {
@@ -202,8 +191,6 @@ class MembershipTest extends TestCase
 
     /**
      * Test removeMember().
-     *
-     * @covers ::removeMember
      */
     public function testRemoveMemberReturnsFalseIfUserIsNotMemberOfProject()
     {
@@ -229,8 +216,6 @@ class MembershipTest extends TestCase
 
     /**
      * Test removeMember().
-     *
-     * @covers ::removeMember
      */
     public function testRemoveMemberReturnsFalseIfMemberlistIsMissing()
     {
@@ -257,8 +242,6 @@ class MembershipTest extends TestCase
     /**
      * Test update().
      *
-     * @covers ::update
-     *
      */
     public function testUpdateThrowsExceptionIfRoleIdsAreMissingInParameters()
     {
@@ -280,9 +263,6 @@ class MembershipTest extends TestCase
 
     /**
      * Test update().
-     *
-     * @covers ::put
-     * @covers ::update
      */
     public function testUpdateCallsPut()
     {

--- a/tests/Unit/Api/MembershipTest.php
+++ b/tests/Unit/Api/MembershipTest.php
@@ -48,7 +48,6 @@ class MembershipTest extends TestCase
      *
      * @covers ::all
      * @dataProvider getAllData
-     * @test
      */
     #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponseWithProject($response, $responseType, $expectedResponse)
@@ -86,7 +85,6 @@ class MembershipTest extends TestCase
      * Test all().
      *
      * @covers ::all
-     * @test
      */
     public function testAllReturnsClientGetResponseWithParametersAndProject()
     {
@@ -125,7 +123,6 @@ class MembershipTest extends TestCase
      *
      * @covers ::delete
      * @covers ::remove
-     * @test
      */
     public function testRemoveCallsDelete()
     {
@@ -161,7 +158,6 @@ class MembershipTest extends TestCase
      * Test removeMember().
      *
      * @covers ::removeMember
-     * @test
      */
     public function testRemoveMemberCallsDelete()
     {
@@ -208,7 +204,6 @@ class MembershipTest extends TestCase
      * Test removeMember().
      *
      * @covers ::removeMember
-     * @test
      */
     public function testRemoveMemberReturnsFalseIfUserIsNotMemberOfProject()
     {
@@ -236,7 +231,6 @@ class MembershipTest extends TestCase
      * Test removeMember().
      *
      * @covers ::removeMember
-     * @test
      */
     public function testRemoveMemberReturnsFalseIfMemberlistIsMissing()
     {
@@ -265,7 +259,6 @@ class MembershipTest extends TestCase
      *
      * @covers ::update
      *
-     * @test
      */
     public function testUpdateThrowsExceptionIfRoleIdsAreMissingInParameters()
     {
@@ -290,7 +283,6 @@ class MembershipTest extends TestCase
      *
      * @covers ::put
      * @covers ::update
-     * @test
      */
     public function testUpdateCallsPut()
     {

--- a/tests/Unit/Api/MembershipTest.php
+++ b/tests/Unit/Api/MembershipTest.php
@@ -3,6 +3,7 @@
 namespace Redmine\Tests\Unit\Api;
 
 use Exception;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Membership;
 use Redmine\Client\Client;
@@ -49,6 +50,7 @@ class MembershipTest extends TestCase
      * @dataProvider getAllData
      * @test
      */
+    #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponseWithProject($response, $responseType, $expectedResponse)
     {
         // Create the used mock objects

--- a/tests/Unit/Api/News/ListByProjectTest.php
+++ b/tests/Unit/Api/News/ListByProjectTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api\News;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\News;
 use Redmine\Client\Client;
@@ -73,6 +74,7 @@ class ListByProjectTest extends TestCase
     /**
      * @dataProvider getInvalidProjectIdentifiers
      */
+    #[DataProvider('getInvalidProjectIdentifiers')]
     public function testListByProjectWithWrongProjectIdentifierThrowsException($projectIdentifier)
     {
         $api = new News(MockClient::create());

--- a/tests/Unit/Api/News/ListByProjectTest.php
+++ b/tests/Unit/Api/News/ListByProjectTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api\News;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\News;
@@ -11,9 +12,7 @@ use Redmine\Exception\UnexpectedResponseException;
 use Redmine\Tests\Fixtures\MockClient;
 use stdClass;
 
-/**
- * @covers \Redmine\Api\News::listByProject
- */
+#[CoversClass(News::class)]
 class ListByProjectTest extends TestCase
 {
     public function testListByProjectWithoutParametersReturnsResponse()

--- a/tests/Unit/Api/News/ListTest.php
+++ b/tests/Unit/Api/News/ListTest.php
@@ -2,14 +2,13 @@
 
 namespace Redmine\Tests\Unit\Api\News;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\News;
 use Redmine\Client\Client;
 use Redmine\Exception\UnexpectedResponseException;
 
-/**
- * @covers \Redmine\Api\News::list
- */
+#[CoversClass(News::class)]
 class ListTest extends TestCase
 {
     public function testListWithoutParametersReturnsResponse()

--- a/tests/Unit/Api/NewsTest.php
+++ b/tests/Unit/Api/NewsTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\News;
 use Redmine\Client\Client;
@@ -47,6 +48,7 @@ class NewsTest extends TestCase
      * @dataProvider getAllData
      * @test
      */
+    #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
     {
         // Create the used mock objects

--- a/tests/Unit/Api/NewsTest.php
+++ b/tests/Unit/Api/NewsTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\News;
@@ -9,16 +10,13 @@ use Redmine\Client\Client;
 use Redmine\Tests\Fixtures\MockClient;
 
 /**
- * @coversDefaultClass \Redmine\Api\News
- *
  * @author     Malte Gerth <mail@malte-gerth.de>
  */
+#[CoversClass(News::class)]
 class NewsTest extends TestCase
 {
     /**
      * Test all().
-     *
-     * @covers ::all
      */
     public function testAllTriggersDeprecationWarning()
     {
@@ -44,7 +42,6 @@ class NewsTest extends TestCase
     /**
      * Test all().
      *
-     * @covers ::all
      * @dataProvider getAllData
      */
     #[DataProvider('getAllData')]
@@ -81,8 +78,6 @@ class NewsTest extends TestCase
 
     /**
      * Test all().
-     *
-     * @covers ::all
      */
     public function testAllReturnsClientGetResponseWithProject()
     {
@@ -115,8 +110,6 @@ class NewsTest extends TestCase
 
     /**
      * Test all().
-     *
-     * @covers ::all
      */
     public function testAllReturnsClientGetResponseWithParametersAndProject()
     {

--- a/tests/Unit/Api/NewsTest.php
+++ b/tests/Unit/Api/NewsTest.php
@@ -46,7 +46,6 @@ class NewsTest extends TestCase
      *
      * @covers ::all
      * @dataProvider getAllData
-     * @test
      */
     #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
@@ -84,7 +83,6 @@ class NewsTest extends TestCase
      * Test all().
      *
      * @covers ::all
-     * @test
      */
     public function testAllReturnsClientGetResponseWithProject()
     {
@@ -119,7 +117,6 @@ class NewsTest extends TestCase
      * Test all().
      *
      * @covers ::all
-     * @test
      */
     public function testAllReturnsClientGetResponseWithParametersAndProject()
     {

--- a/tests/Unit/Api/Project/ArchiveTest.php
+++ b/tests/Unit/Api/Project/ArchiveTest.php
@@ -5,15 +5,14 @@ declare(strict_types=1);
 namespace Redmine\Tests\Unit\Api\Project;
 
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Project;
 use Redmine\Exception\UnexpectedResponseException;
 use Redmine\Http\HttpClient;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
-/**
- * @covers \Redmine\Api\Project::archive
- */
+#[CoversClass(Project::class)]
 class ArchiveTest extends TestCase
 {
     public function testArchiveReturnsTrue()

--- a/tests/Unit/Api/Project/CloseTest.php
+++ b/tests/Unit/Api/Project/CloseTest.php
@@ -3,16 +3,14 @@
 namespace Redmine\Tests\Unit\Api\Project;
 
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Project;
 use Redmine\Exception\UnexpectedResponseException;
 use Redmine\Http\HttpClient;
-use Redmine\Http\Response;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
-/**
- * @covers \Redmine\Api\Project::close
- */
+#[CoversClass(Project::class)]
 class CloseTest extends TestCase
 {
     public function testCloseReturnsTrue()

--- a/tests/Unit/Api/Project/CreateTest.php
+++ b/tests/Unit/Api/Project/CreateTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api\Project;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Project;
@@ -10,9 +11,7 @@ use Redmine\Http\HttpClient;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 use SimpleXMLElement;
 
-/**
- * @covers \Redmine\Api\Project::create
- */
+#[CoversClass(Project::class)]
 class CreateTest extends TestCase
 {
     /**

--- a/tests/Unit/Api/Project/CreateTest.php
+++ b/tests/Unit/Api/Project/CreateTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api\Project;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Project;
 use Redmine\Exception\MissingParameterException;
@@ -17,6 +18,7 @@ class CreateTest extends TestCase
     /**
      * @dataProvider getCreateData
      */
+    #[DataProvider('getCreateData')]
     public function testCreateReturnsCorrectResponse($parameters, $expectedPath, $expectedBody, $responseCode, $response)
     {
         $client = AssertingHttpClient::create(
@@ -172,6 +174,7 @@ class CreateTest extends TestCase
     /**
      * @dataProvider incompleteCreateParameterProvider
      */
+    #[DataProvider('incompleteCreateParameterProvider')]
     public function testCreateThrowsExceptionIfMandatoyParametersAreMissing($parameters)
     {
         // Create the used mock objects

--- a/tests/Unit/Api/Project/ListTest.php
+++ b/tests/Unit/Api/Project/ListTest.php
@@ -2,14 +2,13 @@
 
 namespace Redmine\Tests\Unit\Api\Project;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Project;
 use Redmine\Client\Client;
 use Redmine\Exception\UnexpectedResponseException;
 
-/**
- * @covers \Redmine\Api\Project::list
- */
+#[CoversClass(Project::class)]
 class ListTest extends TestCase
 {
     public function testListWithoutParametersReturnsResponse()

--- a/tests/Unit/Api/Project/ReopenTest.php
+++ b/tests/Unit/Api/Project/ReopenTest.php
@@ -3,15 +3,14 @@
 namespace Redmine\Tests\Unit\Api\Project;
 
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Project;
 use Redmine\Exception\UnexpectedResponseException;
 use Redmine\Http\HttpClient;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
-/**
- * @covers \Redmine\Api\Project::reopen
- */
+#[CoversClass(Project::class)]
 class ReopenTest extends TestCase
 {
     public function testReopenReturnsTrue()

--- a/tests/Unit/Api/Project/ShowTest.php
+++ b/tests/Unit/Api/Project/ShowTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api\Project;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Project;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
@@ -14,6 +15,7 @@ class ShowTest extends TestCase
     /**
      * @dataProvider getShowData
      */
+    #[DataProvider('getShowData')]
     public function testShowReturnsCorrectResponse($identifier, array $params, $expectedPath, $response, $expectedReturn)
     {
         $client = AssertingHttpClient::create(

--- a/tests/Unit/Api/Project/ShowTest.php
+++ b/tests/Unit/Api/Project/ShowTest.php
@@ -2,14 +2,13 @@
 
 namespace Redmine\Tests\Unit\Api\Project;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Project;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
-/**
- * @covers \Redmine\Api\Project::show
- */
+#[CoversClass(Project::class)]
 class ShowTest extends TestCase
 {
     /**

--- a/tests/Unit/Api/Project/UnarchiveTest.php
+++ b/tests/Unit/Api/Project/UnarchiveTest.php
@@ -3,16 +3,14 @@
 namespace Redmine\Tests\Unit\Api\Project;
 
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Project;
 use Redmine\Exception\UnexpectedResponseException;
 use Redmine\Http\HttpClient;
-use Redmine\Http\Response;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
-/**
- * @covers \Redmine\Api\Project::unarchive
- */
+#[CoversClass(Project::class)]
 class UnarchiveTest extends TestCase
 {
     public function testUnarchiveReturnsTrue()

--- a/tests/Unit/Api/ProjectTest.php
+++ b/tests/Unit/Api/ProjectTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Project;
 use Redmine\Client\Client;
@@ -50,6 +51,7 @@ class ProjectTest extends TestCase
      * @dataProvider getAllData
      * @test
      */
+    #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
     {
         // Create the used mock objects

--- a/tests/Unit/Api/ProjectTest.php
+++ b/tests/Unit/Api/ProjectTest.php
@@ -49,7 +49,6 @@ class ProjectTest extends TestCase
      *
      * @covers ::all
      * @dataProvider getAllData
-     * @test
      */
     #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
@@ -87,7 +86,6 @@ class ProjectTest extends TestCase
      * Test all().
      *
      * @covers ::all
-     * @test
      */
     public function testAllReturnsClientGetResponseWithParameters()
     {
@@ -126,7 +124,6 @@ class ProjectTest extends TestCase
      *
      * @covers ::delete
      * @covers ::remove
-     * @test
      */
     public function testRemoveCallsDelete()
     {
@@ -154,7 +151,6 @@ class ProjectTest extends TestCase
      * Test listing().
      *
      * @covers ::listing
-     * @test
      */
     public function testListingReturnsNameIdArray()
     {
@@ -191,7 +187,6 @@ class ProjectTest extends TestCase
      * Test listing().
      *
      * @covers ::listing
-     * @test
      */
     public function testListingCallsGetOnlyTheFirstTime()
     {
@@ -229,7 +224,6 @@ class ProjectTest extends TestCase
      * Test listing().
      *
      * @covers ::listing
-     * @test
      */
     public function testListingCallsGetEveryTimeWithForceUpdate()
     {
@@ -267,7 +261,6 @@ class ProjectTest extends TestCase
      * Test getIdByName().
      *
      * @covers ::getIdByName
-     * @test
      */
     public function testGetIdByNameMakesGetRequest()
     {
@@ -302,7 +295,6 @@ class ProjectTest extends TestCase
      *
      * @covers ::put
      * @covers ::update
-     * @test
      */
     public function testUpdateCallsPut()
     {

--- a/tests/Unit/Api/ProjectTest.php
+++ b/tests/Unit/Api/ProjectTest.php
@@ -2,26 +2,23 @@
 
 namespace Redmine\Tests\Unit\Api;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Project;
 use Redmine\Client\Client;
-use Redmine\Exception\MissingParameterException;
 use Redmine\Tests\Fixtures\MockClient;
 use ReflectionMethod;
 use SimpleXMLElement;
 
 /**
- * @coversDefaultClass \Redmine\Api\Project
- *
  * @author     Malte Gerth <mail@malte-gerth.de>
  */
+#[CoversClass(Project::class)]
 class ProjectTest extends TestCase
 {
     /**
      * Test all().
-     *
-     * @covers ::all
      */
     public function testAllTriggersDeprecationWarning()
     {
@@ -47,7 +44,6 @@ class ProjectTest extends TestCase
     /**
      * Test all().
      *
-     * @covers ::all
      * @dataProvider getAllData
      */
     #[DataProvider('getAllData')]
@@ -84,8 +80,6 @@ class ProjectTest extends TestCase
 
     /**
      * Test all().
-     *
-     * @covers ::all
      */
     public function testAllReturnsClientGetResponseWithParameters()
     {
@@ -121,9 +115,6 @@ class ProjectTest extends TestCase
 
     /**
      * Test remove().
-     *
-     * @covers ::delete
-     * @covers ::remove
      */
     public function testRemoveCallsDelete()
     {
@@ -149,8 +140,6 @@ class ProjectTest extends TestCase
 
     /**
      * Test listing().
-     *
-     * @covers ::listing
      */
     public function testListingReturnsNameIdArray()
     {
@@ -185,8 +174,6 @@ class ProjectTest extends TestCase
 
     /**
      * Test listing().
-     *
-     * @covers ::listing
      */
     public function testListingCallsGetOnlyTheFirstTime()
     {
@@ -222,8 +209,6 @@ class ProjectTest extends TestCase
 
     /**
      * Test listing().
-     *
-     * @covers ::listing
      */
     public function testListingCallsGetEveryTimeWithForceUpdate()
     {
@@ -259,8 +244,6 @@ class ProjectTest extends TestCase
 
     /**
      * Test getIdByName().
-     *
-     * @covers ::getIdByName
      */
     public function testGetIdByNameMakesGetRequest()
     {
@@ -292,9 +275,6 @@ class ProjectTest extends TestCase
 
     /**
      * Test update().
-     *
-     * @covers ::put
-     * @covers ::update
      */
     public function testUpdateCallsPut()
     {
@@ -321,9 +301,6 @@ class ProjectTest extends TestCase
         $this->assertSame($response, $api->update(5, $parameters));
     }
 
-    /**
-     * @covers \Redmine\Api\Project::prepareParamsXml
-     */
     public function testDeprecatedPrepareParamsXml()
     {
         $client = $this->createMock(Client::class);

--- a/tests/Unit/Api/Query/ListTest.php
+++ b/tests/Unit/Api/Query/ListTest.php
@@ -2,14 +2,13 @@
 
 namespace Redmine\Tests\Unit\Api\Query;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Query;
 use Redmine\Client\Client;
 use Redmine\Exception\UnexpectedResponseException;
 
-/**
- * @covers \Redmine\Api\Query::list
- */
+#[CoversClass(Query::class)]
 class ListTest extends TestCase
 {
     public function testListWithoutParametersReturnsResponse()

--- a/tests/Unit/Api/QueryTest.php
+++ b/tests/Unit/Api/QueryTest.php
@@ -46,7 +46,6 @@ class QueryTest extends TestCase
      *
      * @covers ::all
      * @dataProvider getAllData
-     * @test
      */
     #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
@@ -84,7 +83,6 @@ class QueryTest extends TestCase
      * Test all().
      *
      * @covers ::all
-     * @test
      */
     public function testAllReturnsClientGetResponseWithParameters()
     {

--- a/tests/Unit/Api/QueryTest.php
+++ b/tests/Unit/Api/QueryTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Query;
 use Redmine\Client\Client;
@@ -47,6 +48,7 @@ class QueryTest extends TestCase
      * @dataProvider getAllData
      * @test
      */
+    #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
     {
         // Create the used mock objects

--- a/tests/Unit/Api/QueryTest.php
+++ b/tests/Unit/Api/QueryTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Query;
@@ -9,16 +10,13 @@ use Redmine\Client\Client;
 use Redmine\Tests\Fixtures\MockClient;
 
 /**
- * @coversDefaultClass \Redmine\Api\Query
- *
  * @author     Malte Gerth <mail@malte-gerth.de>
  */
+#[CoversClass(Query::class)]
 class QueryTest extends TestCase
 {
     /**
      * Test all().
-     *
-     * @covers ::all
      */
     public function testAllTriggersDeprecationWarning()
     {
@@ -44,7 +42,6 @@ class QueryTest extends TestCase
     /**
      * Test all().
      *
-     * @covers ::all
      * @dataProvider getAllData
      */
     #[DataProvider('getAllData')]
@@ -81,8 +78,6 @@ class QueryTest extends TestCase
 
     /**
      * Test all().
-     *
-     * @covers ::all
      */
     public function testAllReturnsClientGetResponseWithParameters()
     {

--- a/tests/Unit/Api/Role/ListTest.php
+++ b/tests/Unit/Api/Role/ListTest.php
@@ -2,14 +2,13 @@
 
 namespace Redmine\Tests\Unit\Api\Role;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Role;
 use Redmine\Client\Client;
 use Redmine\Exception\UnexpectedResponseException;
 
-/**
- * @covers \Redmine\Api\Role::list
- */
+#[CoversClass(Role::class)]
 class ListTest extends TestCase
 {
     public function testListWithoutParametersReturnsResponse()

--- a/tests/Unit/Api/Role/ShowTest.php
+++ b/tests/Unit/Api/Role/ShowTest.php
@@ -2,14 +2,13 @@
 
 namespace Redmine\Tests\Unit\Api\Role;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Role;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
-/**
- * @covers \Redmine\Api\Role::show
- */
+#[CoversClass(Role::class)]
 class ShowTest extends TestCase
 {
     /**

--- a/tests/Unit/Api/Role/ShowTest.php
+++ b/tests/Unit/Api/Role/ShowTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api\Role;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Role;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
@@ -14,6 +15,7 @@ class ShowTest extends TestCase
     /**
      * @dataProvider getShowData
      */
+    #[DataProvider('getShowData')]
     public function testShowReturnsCorrectResponse($id, $expectedPath, $response, $expectedReturn)
     {
         $client = AssertingHttpClient::create(

--- a/tests/Unit/Api/RoleTest.php
+++ b/tests/Unit/Api/RoleTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Role;
 use Redmine\Client\Client;
@@ -47,6 +48,7 @@ class RoleTest extends TestCase
      * @dataProvider getAllData
      * @test
      */
+    #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
     {
         // Create the used mock objects

--- a/tests/Unit/Api/RoleTest.php
+++ b/tests/Unit/Api/RoleTest.php
@@ -46,7 +46,6 @@ class RoleTest extends TestCase
      *
      * @covers ::all
      * @dataProvider getAllData
-     * @test
      */
     #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
@@ -84,7 +83,6 @@ class RoleTest extends TestCase
      * Test all().
      *
      * @covers ::all
-     * @test
      */
     public function testAllReturnsClientGetResponseWithParametersAndProject()
     {
@@ -122,7 +120,6 @@ class RoleTest extends TestCase
      * Test listing().
      *
      * @covers ::listing
-     * @test
      */
     public function testListingReturnsNameIdArray()
     {
@@ -159,7 +156,6 @@ class RoleTest extends TestCase
      * Test listing().
      *
      * @covers ::listing
-     * @test
      */
     public function testListingCallsGetOnlyTheFirstTime()
     {
@@ -197,7 +193,6 @@ class RoleTest extends TestCase
      * Test listing().
      *
      * @covers ::listing
-     * @test
      */
     public function testListingCallsGetEveryTimeWithForceUpdate()
     {

--- a/tests/Unit/Api/RoleTest.php
+++ b/tests/Unit/Api/RoleTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Role;
@@ -9,16 +10,13 @@ use Redmine\Client\Client;
 use Redmine\Tests\Fixtures\MockClient;
 
 /**
- * @coversDefaultClass \Redmine\Api\Role
- *
  * @author     Malte Gerth <mail@malte-gerth.de>
  */
+#[CoversClass(Role::class)]
 class RoleTest extends TestCase
 {
     /**
      * Test all().
-     *
-     * @covers ::all
      */
     public function testAllTriggersDeprecationWarning()
     {
@@ -44,7 +42,6 @@ class RoleTest extends TestCase
     /**
      * Test all().
      *
-     * @covers ::all
      * @dataProvider getAllData
      */
     #[DataProvider('getAllData')]
@@ -81,8 +78,6 @@ class RoleTest extends TestCase
 
     /**
      * Test all().
-     *
-     * @covers ::all
      */
     public function testAllReturnsClientGetResponseWithParametersAndProject()
     {
@@ -118,8 +113,6 @@ class RoleTest extends TestCase
 
     /**
      * Test listing().
-     *
-     * @covers ::listing
      */
     public function testListingReturnsNameIdArray()
     {
@@ -154,8 +147,6 @@ class RoleTest extends TestCase
 
     /**
      * Test listing().
-     *
-     * @covers ::listing
      */
     public function testListingCallsGetOnlyTheFirstTime()
     {
@@ -191,8 +182,6 @@ class RoleTest extends TestCase
 
     /**
      * Test listing().
-     *
-     * @covers ::listing
      */
     public function testListingCallsGetEveryTimeWithForceUpdate()
     {

--- a/tests/Unit/Api/Search/ListByQueryTest.php
+++ b/tests/Unit/Api/Search/ListByQueryTest.php
@@ -2,15 +2,13 @@
 
 namespace Redmine\Tests\Unit\Api\Search;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Search;
 use Redmine\Client\Client;
 use Redmine\Exception\UnexpectedResponseException;
-use Redmine\Tests\Fixtures\MockClient;
 
-/**
- * @covers \Redmine\Api\Search::listByQuery
- */
+#[CoversClass(Search::class)]
 class ListByQueryTest extends TestCase
 {
     public function testListByQueryWithoutParametersReturnsResponse()

--- a/tests/Unit/Api/Search/SearchTest.php
+++ b/tests/Unit/Api/Search/SearchTest.php
@@ -2,15 +2,14 @@
 
 namespace Redmine\Tests\Unit\Api\Search;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Search;
 use Redmine\Client\Client;
 use Redmine\Tests\Fixtures\MockClient;
 
-/**
- * @covers \Redmine\Api\Search::search
- */
+#[CoversClass(Search::class)]
 class SearchTest extends TestCase
 {
     public function testSearchTriggersDeprecationWarning()

--- a/tests/Unit/Api/Search/SearchTest.php
+++ b/tests/Unit/Api/Search/SearchTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api\Search;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Search;
 use Redmine\Client\Client;
@@ -36,6 +37,7 @@ class SearchTest extends TestCase
     /**
      * @dataProvider getAllData
      */
+    #[DataProvider('getAllData')]
     public function testSearchReturnsClientGetResponse($response, $responseType, $expectedResponse)
     {
         // Create the used mock objects

--- a/tests/Unit/Api/TimeEntry/CreateTest.php
+++ b/tests/Unit/Api/TimeEntry/CreateTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api\TimeEntry;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\TimeEntry;
 use Redmine\Exception\MissingParameterException;
@@ -17,6 +18,7 @@ class CreateTest extends TestCase
     /**
      * @dataProvider getCreateData
      */
+    #[DataProvider('getCreateData')]
     public function testCreateReturnsCorrectResponse($parameters, $expectedPath, $expectedBody, $responseCode, $response)
     {
         $client = AssertingHttpClient::create(
@@ -147,6 +149,7 @@ class CreateTest extends TestCase
     /**
      * @dataProvider incompleteCreateParameterProvider
      */
+    #[DataProvider('incompleteCreateParameterProvider')]
     public function testCreateThrowsExceptionIfValueIsMissingInParameters($parameters)
     {
         // Create the used mock objects

--- a/tests/Unit/Api/TimeEntry/CreateTest.php
+++ b/tests/Unit/Api/TimeEntry/CreateTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api\TimeEntry;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\TimeEntry;
@@ -10,9 +11,7 @@ use Redmine\Http\HttpClient;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 use SimpleXMLElement;
 
-/**
- * @covers \Redmine\Api\TimeEntry::create
- */
+#[CoversClass(TimeEntry::class)]
 class CreateTest extends TestCase
 {
     /**

--- a/tests/Unit/Api/TimeEntry/ListTest.php
+++ b/tests/Unit/Api/TimeEntry/ListTest.php
@@ -2,14 +2,13 @@
 
 namespace Redmine\Tests\Unit\Api\TimeEntry;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\TimeEntry;
 use Redmine\Client\Client;
 use Redmine\Exception\UnexpectedResponseException;
 
-/**
- * @covers \Redmine\Api\TimeEntry::list
- */
+#[CoversClass(TimeEntry::class)]
 class ListTest extends TestCase
 {
     public function testListWithoutParametersReturnsResponse()

--- a/tests/Unit/Api/TimeEntry/ShowTest.php
+++ b/tests/Unit/Api/TimeEntry/ShowTest.php
@@ -2,14 +2,13 @@
 
 namespace Redmine\Tests\Unit\Api\TimeEntry;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\TimeEntry;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
-/**
- * @covers \Redmine\Api\TimeEntry::show
- */
+#[CoversClass(TimeEntry::class)]
 class ShowTest extends TestCase
 {
     /**

--- a/tests/Unit/Api/TimeEntry/ShowTest.php
+++ b/tests/Unit/Api/TimeEntry/ShowTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api\TimeEntry;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\TimeEntry;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
@@ -14,6 +15,7 @@ class ShowTest extends TestCase
     /**
      * @dataProvider getShowData
      */
+    #[DataProvider('getShowData')]
     public function testShowReturnsCorrectResponse($id, $expectedPath, $response, $expectedReturn)
     {
         $client = AssertingHttpClient::create(

--- a/tests/Unit/Api/TimeEntryActivity/ListTest.php
+++ b/tests/Unit/Api/TimeEntryActivity/ListTest.php
@@ -2,14 +2,13 @@
 
 namespace Redmine\Tests\Unit\Api\TimeEntryActivity;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\TimeEntryActivity;
 use Redmine\Client\Client;
 use Redmine\Exception\UnexpectedResponseException;
 
-/**
- * @coversDefaultClass \Redmine\Api\TimeEntryActivity::list
- */
+#[CoversClass(TimeEntryActivity::class)]
 class ListTest extends TestCase
 {
     public function testListWithoutParametersReturnsResponse()

--- a/tests/Unit/Api/TimeEntryActivityTest.php
+++ b/tests/Unit/Api/TimeEntryActivityTest.php
@@ -46,7 +46,6 @@ class TimeEntryActivityTest extends TestCase
      *
      * @covers ::all
      * @dataProvider getAllData
-     * @test
      */
     #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
@@ -84,7 +83,6 @@ class TimeEntryActivityTest extends TestCase
      * Test all().
      *
      * @covers ::all
-     * @test
      */
     public function testAllReturnsClientGetResponseWithParameters()
     {

--- a/tests/Unit/Api/TimeEntryActivityTest.php
+++ b/tests/Unit/Api/TimeEntryActivityTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\TimeEntryActivity;
 use Redmine\Client\Client;
@@ -47,6 +48,7 @@ class TimeEntryActivityTest extends TestCase
      * @dataProvider getAllData
      * @test
      */
+    #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
     {
         // Create the used mock objects

--- a/tests/Unit/Api/TimeEntryActivityTest.php
+++ b/tests/Unit/Api/TimeEntryActivityTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\TimeEntryActivity;
@@ -9,16 +10,13 @@ use Redmine\Client\Client;
 use Redmine\Tests\Fixtures\MockClient;
 
 /**
- * @coversDefaultClass \Redmine\Api\TimeEntryActivity
- *
  * @author     Malte Gerth <mail@malte-gerth.de>
  */
+#[CoversClass(TimeEntryActivity::class)]
 class TimeEntryActivityTest extends TestCase
 {
     /**
      * Test all().
-     *
-     * @covers ::all
      */
     public function testAllTriggersDeprecationWarning()
     {
@@ -44,7 +42,6 @@ class TimeEntryActivityTest extends TestCase
     /**
      * Test all().
      *
-     * @covers ::all
      * @dataProvider getAllData
      */
     #[DataProvider('getAllData')]
@@ -81,8 +78,6 @@ class TimeEntryActivityTest extends TestCase
 
     /**
      * Test all().
-     *
-     * @covers ::all
      */
     public function testAllReturnsClientGetResponseWithParameters()
     {

--- a/tests/Unit/Api/TimeEntryTest.php
+++ b/tests/Unit/Api/TimeEntryTest.php
@@ -2,24 +2,21 @@
 
 namespace Redmine\Tests\Unit\Api;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\TimeEntry;
 use Redmine\Client\Client;
-use Redmine\Exception\MissingParameterException;
 use Redmine\Tests\Fixtures\MockClient;
 
 /**
- * @coversDefaultClass \Redmine\Api\TimeEntry
- *
  * @author     Malte Gerth <mail@malte-gerth.de>
  */
+#[CoversClass(TimeEntry::class)]
 class TimeEntryTest extends TestCase
 {
     /**
      * Test all().
-     *
-     * @covers ::all
      */
     public function testAllTriggersDeprecationWarning()
     {
@@ -45,7 +42,6 @@ class TimeEntryTest extends TestCase
     /**
      * Test all().
      *
-     * @covers ::all
      * @dataProvider getAllData
      */
     #[DataProvider('getAllData')]
@@ -82,8 +78,6 @@ class TimeEntryTest extends TestCase
 
     /**
      * Test all().
-     *
-     * @covers ::all
      */
     public function testAllReturnsClientGetResponseWithParameters()
     {
@@ -125,9 +119,6 @@ class TimeEntryTest extends TestCase
 
     /**
      * Test remove().
-     *
-     * @covers ::delete
-     * @covers ::remove
      */
     public function testRemoveCallsDelete()
     {
@@ -153,9 +144,6 @@ class TimeEntryTest extends TestCase
 
     /**
      * Test update().
-     *
-     * @covers ::put
-     * @covers ::update
      */
     public function testUpdateCallsPut()
     {

--- a/tests/Unit/Api/TimeEntryTest.php
+++ b/tests/Unit/Api/TimeEntryTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\TimeEntry;
 use Redmine\Client\Client;
@@ -48,6 +49,7 @@ class TimeEntryTest extends TestCase
      * @dataProvider getAllData
      * @test
      */
+    #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
     {
         // Create the used mock objects

--- a/tests/Unit/Api/TimeEntryTest.php
+++ b/tests/Unit/Api/TimeEntryTest.php
@@ -47,7 +47,6 @@ class TimeEntryTest extends TestCase
      *
      * @covers ::all
      * @dataProvider getAllData
-     * @test
      */
     #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
@@ -85,7 +84,6 @@ class TimeEntryTest extends TestCase
      * Test all().
      *
      * @covers ::all
-     * @test
      */
     public function testAllReturnsClientGetResponseWithParameters()
     {
@@ -130,7 +128,6 @@ class TimeEntryTest extends TestCase
      *
      * @covers ::delete
      * @covers ::remove
-     * @test
      */
     public function testRemoveCallsDelete()
     {
@@ -159,7 +156,6 @@ class TimeEntryTest extends TestCase
      *
      * @covers ::put
      * @covers ::update
-     * @test
      */
     public function testUpdateCallsPut()
     {

--- a/tests/Unit/Api/Tracker/ListTest.php
+++ b/tests/Unit/Api/Tracker/ListTest.php
@@ -2,14 +2,13 @@
 
 namespace Redmine\Tests\Unit\Api\Tracker;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Tracker;
 use Redmine\Client\Client;
 use Redmine\Exception\UnexpectedResponseException;
 
-/**
- * @covers \Redmine\Api\Tracker::list
- */
+#[CoversClass(Tracker::class)]
 class ListTest extends TestCase
 {
     public function testListWithoutParametersReturnsResponse()

--- a/tests/Unit/Api/TrackerTest.php
+++ b/tests/Unit/Api/TrackerTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Tracker;
 use Redmine\Client\Client;
@@ -47,6 +48,7 @@ class TrackerTest extends TestCase
      * @dataProvider getAllData
      * @test
      */
+    #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
     {
         // Create the used mock objects

--- a/tests/Unit/Api/TrackerTest.php
+++ b/tests/Unit/Api/TrackerTest.php
@@ -46,7 +46,6 @@ class TrackerTest extends TestCase
      *
      * @covers ::all
      * @dataProvider getAllData
-     * @test
      */
     #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
@@ -84,7 +83,6 @@ class TrackerTest extends TestCase
      * Test all().
      *
      * @covers ::all
-     * @test
      */
     public function testAllReturnsClientGetResponseWithParametersAndProject()
     {
@@ -122,7 +120,6 @@ class TrackerTest extends TestCase
      * Test listing().
      *
      * @covers ::listing
-     * @test
      */
     public function testListingReturnsNameIdArray()
     {
@@ -159,7 +156,6 @@ class TrackerTest extends TestCase
      * Test listing().
      *
      * @covers ::listing
-     * @test
      */
     public function testListingCallsGetOnlyTheFirstTime()
     {
@@ -197,7 +193,6 @@ class TrackerTest extends TestCase
      * Test listing().
      *
      * @covers ::listing
-     * @test
      */
     public function testListingCallsGetEveryTimeWithForceUpdate()
     {
@@ -235,7 +230,6 @@ class TrackerTest extends TestCase
      * Test getIdByName().
      *
      * @covers ::getIdByName
-     * @test
      */
     public function testGetIdByNameMakesGetRequest()
     {

--- a/tests/Unit/Api/TrackerTest.php
+++ b/tests/Unit/Api/TrackerTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Tracker;
@@ -9,16 +10,13 @@ use Redmine\Client\Client;
 use Redmine\Tests\Fixtures\MockClient;
 
 /**
- * @coversDefaultClass \Redmine\Api\Tracker
- *
  * @author     Malte Gerth <mail@malte-gerth.de>
  */
+#[CoversClass(Tracker::class)]
 class TrackerTest extends TestCase
 {
     /**
      * Test all().
-     *
-     * @covers ::all
      */
     public function testAllTriggersDeprecationWarning()
     {
@@ -44,7 +42,6 @@ class TrackerTest extends TestCase
     /**
      * Test all().
      *
-     * @covers ::all
      * @dataProvider getAllData
      */
     #[DataProvider('getAllData')]
@@ -81,8 +78,6 @@ class TrackerTest extends TestCase
 
     /**
      * Test all().
-     *
-     * @covers ::all
      */
     public function testAllReturnsClientGetResponseWithParametersAndProject()
     {
@@ -118,8 +113,6 @@ class TrackerTest extends TestCase
 
     /**
      * Test listing().
-     *
-     * @covers ::listing
      */
     public function testListingReturnsNameIdArray()
     {
@@ -154,8 +147,6 @@ class TrackerTest extends TestCase
 
     /**
      * Test listing().
-     *
-     * @covers ::listing
      */
     public function testListingCallsGetOnlyTheFirstTime()
     {
@@ -191,8 +182,6 @@ class TrackerTest extends TestCase
 
     /**
      * Test listing().
-     *
-     * @covers ::listing
      */
     public function testListingCallsGetEveryTimeWithForceUpdate()
     {
@@ -228,8 +217,6 @@ class TrackerTest extends TestCase
 
     /**
      * Test getIdByName().
-     *
-     * @covers ::getIdByName
      */
     public function testGetIdByNameMakesGetRequest()
     {

--- a/tests/Unit/Api/User/CreateTest.php
+++ b/tests/Unit/Api/User/CreateTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api\User;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\User;
 use Redmine\Exception\MissingParameterException;
@@ -17,6 +18,7 @@ class CreateTest extends TestCase
     /**
      * @dataProvider getCreateData
      */
+    #[DataProvider('getCreateData')]
     public function testCreateReturnsCorrectResponse($parameters, $expectedPath, $expectedBody, $responseCode, $response)
     {
         $client = AssertingHttpClient::create(
@@ -134,6 +136,7 @@ class CreateTest extends TestCase
     /**
      * @dataProvider incompleteCreateParameterProvider
      */
+    #[DataProvider('incompleteCreateParameterProvider')]
     public function testCreateThrowsExceptionIfValueIsMissingInParameters($parameters)
     {
         // Create the used mock objects

--- a/tests/Unit/Api/User/CreateTest.php
+++ b/tests/Unit/Api/User/CreateTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api\User;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\User;
@@ -10,9 +11,7 @@ use Redmine\Http\HttpClient;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 use SimpleXMLElement;
 
-/**
- * @covers \Redmine\Api\User::create
- */
+#[CoversClass(User::class)]
 class CreateTest extends TestCase
 {
     /**

--- a/tests/Unit/Api/User/ListTest.php
+++ b/tests/Unit/Api/User/ListTest.php
@@ -2,14 +2,13 @@
 
 namespace Redmine\Tests\Unit\Api\User;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\User;
 use Redmine\Client\Client;
 use Redmine\Exception\UnexpectedResponseException;
 
-/**
- * @covers \Redmine\Api\User::list
- */
+#[CoversClass(User::class)]
 class ListTest extends TestCase
 {
     public function testListWithoutParametersReturnsResponse()

--- a/tests/Unit/Api/User/ShowTest.php
+++ b/tests/Unit/Api/User/ShowTest.php
@@ -2,14 +2,13 @@
 
 namespace Redmine\Tests\Unit\Api\User;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\User;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
-/**
- * @covers \Redmine\Api\User::show
- */
+#[CoversClass(User::class)]
 class ShowTest extends TestCase
 {
     /**

--- a/tests/Unit/Api/User/ShowTest.php
+++ b/tests/Unit/Api/User/ShowTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api\User;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\User;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
@@ -14,6 +15,7 @@ class ShowTest extends TestCase
     /**
      * @dataProvider getShowData
      */
+    #[DataProvider('getShowData')]
     public function testShowReturnsCorrectResponse($userId, array $params, $expectedPath, $response, $expectedReturn)
     {
         $client = AssertingHttpClient::create(

--- a/tests/Unit/Api/UserTest.php
+++ b/tests/Unit/Api/UserTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\User;
 use Redmine\Client\Client;
@@ -121,6 +122,7 @@ class UserTest extends TestCase
      * @dataProvider getAllData
      * @test
      */
+    #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
     {
         // Create the used mock objects

--- a/tests/Unit/Api/UserTest.php
+++ b/tests/Unit/Api/UserTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\User;
@@ -9,16 +10,13 @@ use Redmine\Client\Client;
 use Redmine\Tests\Fixtures\MockClient;
 
 /**
- * @coversDefaultClass \Redmine\Api\User
- *
  * @author     Malte Gerth <mail@malte-gerth.de>
  */
+#[CoversClass(User::class)]
 class UserTest extends TestCase
 {
     /**
      * Test getCurrentUser().
-     *
-     * @covers ::getCurrentUser
      */
     public function testGetCurrentUserReturnsClientGetResponse()
     {
@@ -53,8 +51,6 @@ class UserTest extends TestCase
 
     /**
      * Test getIdByUsername().
-     *
-     * @covers ::getIdByUsername
      */
     public function testGetIdByUsernameMakesGetRequest()
     {
@@ -89,8 +85,6 @@ class UserTest extends TestCase
 
     /**
      * Test all().
-     *
-     * @covers ::all
      */
     public function testAllTriggersDeprecationWarning()
     {
@@ -116,7 +110,6 @@ class UserTest extends TestCase
     /**
      * Test all().
      *
-     * @covers ::all
      * @dataProvider getAllData
      */
     #[DataProvider('getAllData')]
@@ -153,8 +146,6 @@ class UserTest extends TestCase
 
     /**
      * Test all().
-     *
-     * @covers ::all
      */
     public function testAllReturnsClientGetResponseWithParameters()
     {
@@ -194,9 +185,6 @@ class UserTest extends TestCase
 
     /**
      * Test remove().
-     *
-     * @covers ::delete
-     * @covers ::remove
      */
     public function testRemoveCallsDelete()
     {
@@ -222,9 +210,6 @@ class UserTest extends TestCase
 
     /**
      * Test update().
-     *
-     * @covers ::put
-     * @covers ::update
      */
     public function testUpdateCallsPut()
     {
@@ -260,10 +245,6 @@ class UserTest extends TestCase
 
     /**
      * Test update().
-     *
-     * @covers ::put
-     * @covers ::update
-     * @covers ::attachCustomFieldXML
      */
     public function testUpdateWithCustomField()
     {
@@ -308,8 +289,6 @@ class UserTest extends TestCase
 
     /**
      * Test listing().
-     *
-     * @covers ::listing
      */
     public function testListingReturnsNameIdArray()
     {
@@ -344,8 +323,6 @@ class UserTest extends TestCase
 
     /**
      * Test listing().
-     *
-     * @covers ::listing
      */
     public function testListingCallsGetOnlyTheFirstTime()
     {
@@ -381,8 +358,6 @@ class UserTest extends TestCase
 
     /**
      * Test listing().
-     *
-     * @covers ::listing
      */
     public function testListingCallsGetEveryTimeWithForceUpdate()
     {

--- a/tests/Unit/Api/UserTest.php
+++ b/tests/Unit/Api/UserTest.php
@@ -19,7 +19,6 @@ class UserTest extends TestCase
      * Test getCurrentUser().
      *
      * @covers ::getCurrentUser
-     * @test
      */
     public function testGetCurrentUserReturnsClientGetResponse()
     {
@@ -56,7 +55,6 @@ class UserTest extends TestCase
      * Test getIdByUsername().
      *
      * @covers ::getIdByUsername
-     * @test
      */
     public function testGetIdByUsernameMakesGetRequest()
     {
@@ -120,7 +118,6 @@ class UserTest extends TestCase
      *
      * @covers ::all
      * @dataProvider getAllData
-     * @test
      */
     #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
@@ -158,7 +155,6 @@ class UserTest extends TestCase
      * Test all().
      *
      * @covers ::all
-     * @test
      */
     public function testAllReturnsClientGetResponseWithParameters()
     {
@@ -201,7 +197,6 @@ class UserTest extends TestCase
      *
      * @covers ::delete
      * @covers ::remove
-     * @test
      */
     public function testRemoveCallsDelete()
     {
@@ -230,7 +225,6 @@ class UserTest extends TestCase
      *
      * @covers ::put
      * @covers ::update
-     * @test
      */
     public function testUpdateCallsPut()
     {
@@ -270,7 +264,6 @@ class UserTest extends TestCase
      * @covers ::put
      * @covers ::update
      * @covers ::attachCustomFieldXML
-     * @test
      */
     public function testUpdateWithCustomField()
     {
@@ -317,7 +310,6 @@ class UserTest extends TestCase
      * Test listing().
      *
      * @covers ::listing
-     * @test
      */
     public function testListingReturnsNameIdArray()
     {
@@ -354,7 +346,6 @@ class UserTest extends TestCase
      * Test listing().
      *
      * @covers ::listing
-     * @test
      */
     public function testListingCallsGetOnlyTheFirstTime()
     {
@@ -392,7 +383,6 @@ class UserTest extends TestCase
      * Test listing().
      *
      * @covers ::listing
-     * @test
      */
     public function testListingCallsGetEveryTimeWithForceUpdate()
     {

--- a/tests/Unit/Api/Version/CreateTest.php
+++ b/tests/Unit/Api/Version/CreateTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api\Version;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Version;
 use Redmine\Exception\InvalidParameterException;
@@ -18,6 +19,7 @@ class CreateTest extends TestCase
     /**
      * @dataProvider getCreateData
      */
+    #[DataProvider('getCreateData')]
     public function testCreateReturnsCorrectResponse($identifier, $parameters, $expectedPath, $expectedBody, $responseCode, $response)
     {
         $client = AssertingHttpClient::create(

--- a/tests/Unit/Api/Version/CreateTest.php
+++ b/tests/Unit/Api/Version/CreateTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api\Version;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Version;
@@ -11,9 +12,7 @@ use Redmine\Http\HttpClient;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 use SimpleXMLElement;
 
-/**
- * @covers \Redmine\Api\Version::create
- */
+#[CoversClass(Version::class)]
 class CreateTest extends TestCase
 {
     /**

--- a/tests/Unit/Api/Version/ListByProjectTest.php
+++ b/tests/Unit/Api/Version/ListByProjectTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api\Version;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Version;
@@ -11,9 +12,7 @@ use Redmine\Exception\UnexpectedResponseException;
 use Redmine\Tests\Fixtures\MockClient;
 use stdClass;
 
-/**
- * @covers \Redmine\Api\Version::listByProject
- */
+#[CoversClass(Version::class)]
 class ListByProjectTest extends TestCase
 {
     public function testListByProjectWithoutParametersReturnsResponse()

--- a/tests/Unit/Api/Version/ListByProjectTest.php
+++ b/tests/Unit/Api/Version/ListByProjectTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api\Version;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Version;
 use Redmine\Client\Client;
@@ -74,6 +75,7 @@ class ListByProjectTest extends TestCase
     /**
      * @dataProvider getInvalidProjectIdentifiers
      */
+    #[DataProvider('getInvalidProjectIdentifiers')]
     public function testListByProjectWithWrongProjectIdentifierThrowsException($projectIdentifier)
     {
         $api = new Version(MockClient::create());

--- a/tests/Unit/Api/Version/ShowTest.php
+++ b/tests/Unit/Api/Version/ShowTest.php
@@ -2,14 +2,13 @@
 
 namespace Redmine\Tests\Unit\Api\Version;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Version;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
-/**
- * @covers \Redmine\Api\Version::show
- */
+#[CoversClass(Version::class)]
 class ShowTest extends TestCase
 {
     /**

--- a/tests/Unit/Api/Version/ShowTest.php
+++ b/tests/Unit/Api/Version/ShowTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api\Version;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Version;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
@@ -14,6 +15,7 @@ class ShowTest extends TestCase
     /**
      * @dataProvider getShowData
      */
+    #[DataProvider('getShowData')]
     public function testShowReturnsCorrectResponse($version, $expectedPath, $response, $expectedReturn)
     {
         $client = AssertingHttpClient::create(

--- a/tests/Unit/Api/VersionTest.php
+++ b/tests/Unit/Api/VersionTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Version;
 use Redmine\Client\Client;
@@ -48,6 +49,7 @@ class VersionTest extends TestCase
      * @dataProvider getAllData
      * @test
      */
+    #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
     {
         // Create the used mock objects
@@ -476,6 +478,7 @@ class VersionTest extends TestCase
      *
      * @param string $sharingValue
      */
+    #[DataProvider('invalidSharingProvider')]
     public function testCreateThrowsExceptionWithInvalidSharing($sharingValue)
     {
         // Test values
@@ -508,6 +511,7 @@ class VersionTest extends TestCase
      * @param string $sharingValue
      * @param string $sharingXmlElement
      */
+    #[DataProvider('validSharingProvider')]
     public function testUpdateWithValidSharing($sharingValue, $sharingXmlElement)
     {
         // Test values
@@ -552,6 +556,7 @@ class VersionTest extends TestCase
      *
      * @param string $sharingValue
      */
+    #[DataProvider('validEmptySharingProvider')]
     public function testUpdateWithValidEmptySharing($sharingValue)
     {
         // Test values
@@ -599,6 +604,7 @@ class VersionTest extends TestCase
      *
      * @param string $sharingValue
      */
+    #[DataProvider('invalidSharingProvider')]
     public function testUpdateThrowsExceptionWithInvalidSharing($sharingValue)
     {
         // Test values

--- a/tests/Unit/Api/VersionTest.php
+++ b/tests/Unit/Api/VersionTest.php
@@ -47,7 +47,6 @@ class VersionTest extends TestCase
      *
      * @covers ::all
      * @dataProvider getAllData
-     * @test
      */
     #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
@@ -85,7 +84,6 @@ class VersionTest extends TestCase
      * Test all().
      *
      * @covers ::all
-     * @test
      */
     public function testAllReturnsClientGetResponseWithParameters()
     {
@@ -128,7 +126,6 @@ class VersionTest extends TestCase
      *
      * @covers ::delete
      * @covers ::remove
-     * @test
      */
     public function testRemoveWithNumericIdCallsDelete()
     {
@@ -157,7 +154,6 @@ class VersionTest extends TestCase
      *
      * @covers ::delete
      * @covers ::remove
-     * @test
      */
     public function testRemoveWithStringCallsDelete()
     {
@@ -187,7 +183,6 @@ class VersionTest extends TestCase
      * @covers ::update
      * @covers ::validateStatus
      *
-     * @test
      */
     public function testUpdateThrowsExceptionWithInvalidStatus()
     {
@@ -215,7 +210,6 @@ class VersionTest extends TestCase
      *
      * @covers ::put
      * @covers ::update
-     * @test
      */
     public function testUpdateCallsPut()
     {
@@ -255,7 +249,6 @@ class VersionTest extends TestCase
      * @covers ::update
      * @covers ::put
      * @covers ::validateStatus
-     * @test
      */
     public function testUpdateWithValidStatusCallsPut()
     {
@@ -295,7 +288,6 @@ class VersionTest extends TestCase
      * Test listing().
      *
      * @covers ::listing
-     * @test
      */
     public function testListingReturnsNameIdArray()
     {
@@ -330,7 +322,6 @@ class VersionTest extends TestCase
      * Test listing().
      *
      * @covers ::listing
-     * @test
      */
     public function testListingReturnsIdNameIfReverseIsFalseArray()
     {
@@ -365,7 +356,6 @@ class VersionTest extends TestCase
      * Test listing().
      *
      * @covers ::listing
-     * @test
      */
     public function testListingCallsGetOnlyTheFirstTime()
     {
@@ -401,7 +391,6 @@ class VersionTest extends TestCase
      * Test listing().
      *
      * @covers ::listing
-     * @test
      */
     public function testListingCallsGetEveryTimeWithForceUpdate()
     {
@@ -437,7 +426,6 @@ class VersionTest extends TestCase
      * Test getIdByName().
      *
      * @covers ::getIdByName
-     * @test
      */
     public function testGetIdByNameMakesGetRequest()
     {
@@ -474,7 +462,6 @@ class VersionTest extends TestCase
      * @covers            ::validateSharing
      * @dataProvider      invalidSharingProvider
      *
-     * @test
      *
      * @param string $sharingValue
      */
@@ -506,7 +493,6 @@ class VersionTest extends TestCase
      * @covers       ::update
      * @covers       ::validateSharing
      * @dataProvider validSharingProvider
-     * @test
      *
      * @param string $sharingValue
      * @param string $sharingXmlElement
@@ -552,7 +538,6 @@ class VersionTest extends TestCase
      * @covers       ::update
      * @covers       ::validateSharing
      * @dataProvider validEmptySharingProvider
-     * @test
      *
      * @param string $sharingValue
      */
@@ -600,7 +585,6 @@ class VersionTest extends TestCase
      * @covers            ::validateSharing
      * @dataProvider      invalidSharingProvider
      *
-     * @test
      *
      * @param string $sharingValue
      */

--- a/tests/Unit/Api/VersionTest.php
+++ b/tests/Unit/Api/VersionTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Version;
@@ -10,16 +11,13 @@ use Redmine\Exception\InvalidParameterException;
 use Redmine\Tests\Fixtures\MockClient;
 
 /**
- * @coversDefaultClass \Redmine\Api\Version
- *
  * @author     Malte Gerth <mail@malte-gerth.de>
  */
+#[CoversClass(Version::class)]
 class VersionTest extends TestCase
 {
     /**
      * Test all().
-     *
-     * @covers ::all
      */
     public function testAllTriggersDeprecationWarning()
     {
@@ -45,7 +43,6 @@ class VersionTest extends TestCase
     /**
      * Test all().
      *
-     * @covers ::all
      * @dataProvider getAllData
      */
     #[DataProvider('getAllData')]
@@ -82,8 +79,6 @@ class VersionTest extends TestCase
 
     /**
      * Test all().
-     *
-     * @covers ::all
      */
     public function testAllReturnsClientGetResponseWithParameters()
     {
@@ -123,9 +118,6 @@ class VersionTest extends TestCase
 
     /**
      * Test remove().
-     *
-     * @covers ::delete
-     * @covers ::remove
      */
     public function testRemoveWithNumericIdCallsDelete()
     {
@@ -151,9 +143,6 @@ class VersionTest extends TestCase
 
     /**
      * Test remove().
-     *
-     * @covers ::delete
-     * @covers ::remove
      */
     public function testRemoveWithStringCallsDelete()
     {
@@ -180,9 +169,6 @@ class VersionTest extends TestCase
     /**
      * Test update().
      *
-     * @covers ::update
-     * @covers ::validateStatus
-     *
      */
     public function testUpdateThrowsExceptionWithInvalidStatus()
     {
@@ -207,9 +193,6 @@ class VersionTest extends TestCase
 
     /**
      * Test update().
-     *
-     * @covers ::put
-     * @covers ::update
      */
     public function testUpdateCallsPut()
     {
@@ -245,10 +228,6 @@ class VersionTest extends TestCase
 
     /**
      * Test update().
-     *
-     * @covers ::update
-     * @covers ::put
-     * @covers ::validateStatus
      */
     public function testUpdateWithValidStatusCallsPut()
     {
@@ -286,8 +265,6 @@ class VersionTest extends TestCase
 
     /**
      * Test listing().
-     *
-     * @covers ::listing
      */
     public function testListingReturnsNameIdArray()
     {
@@ -320,8 +297,6 @@ class VersionTest extends TestCase
 
     /**
      * Test listing().
-     *
-     * @covers ::listing
      */
     public function testListingReturnsIdNameIfReverseIsFalseArray()
     {
@@ -354,8 +329,6 @@ class VersionTest extends TestCase
 
     /**
      * Test listing().
-     *
-     * @covers ::listing
      */
     public function testListingCallsGetOnlyTheFirstTime()
     {
@@ -389,8 +362,6 @@ class VersionTest extends TestCase
 
     /**
      * Test listing().
-     *
-     * @covers ::listing
      */
     public function testListingCallsGetEveryTimeWithForceUpdate()
     {
@@ -424,8 +395,6 @@ class VersionTest extends TestCase
 
     /**
      * Test getIdByName().
-     *
-     * @covers ::getIdByName
      */
     public function testGetIdByNameMakesGetRequest()
     {
@@ -458,8 +427,6 @@ class VersionTest extends TestCase
     /**
      * Test validateSharing().
      *
-     * @covers            ::create
-     * @covers            ::validateSharing
      * @dataProvider      invalidSharingProvider
      *
      *
@@ -490,8 +457,6 @@ class VersionTest extends TestCase
     /**
      * Test validateSharing().
      *
-     * @covers       ::update
-     * @covers       ::validateSharing
      * @dataProvider validSharingProvider
      *
      * @param string $sharingValue
@@ -535,8 +500,6 @@ class VersionTest extends TestCase
     /**
      * Test validateSharing().
      *
-     * @covers       ::update
-     * @covers       ::validateSharing
      * @dataProvider validEmptySharingProvider
      *
      * @param string $sharingValue
@@ -581,8 +544,6 @@ class VersionTest extends TestCase
     /**
      * Test validateSharing().
      *
-     * @covers            ::update
-     * @covers            ::validateSharing
      * @dataProvider      invalidSharingProvider
      *
      *

--- a/tests/Unit/Api/Wiki/ListByProjectTest.php
+++ b/tests/Unit/Api/Wiki/ListByProjectTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api\Wiki;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Wiki;
@@ -11,9 +12,7 @@ use Redmine\Exception\UnexpectedResponseException;
 use Redmine\Tests\Fixtures\MockClient;
 use stdClass;
 
-/**
- * @covers \Redmine\Api\Wiki::listByProject
- */
+#[CoversClass(Wiki::class)]
 class ListByProjectTest extends TestCase
 {
     public function testListByProjectWithoutParametersReturnsResponse()

--- a/tests/Unit/Api/Wiki/ListByProjectTest.php
+++ b/tests/Unit/Api/Wiki/ListByProjectTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api\Wiki;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Wiki;
 use Redmine\Client\Client;
@@ -74,6 +75,7 @@ class ListByProjectTest extends TestCase
     /**
      * @dataProvider getInvalidProjectIdentifiers
      */
+    #[DataProvider('getInvalidProjectIdentifiers')]
     public function testListByProjectWithWrongProjectIdentifierThrowsException($projectIdentifier)
     {
         $api = new Wiki(MockClient::create());

--- a/tests/Unit/Api/Wiki/ShowTest.php
+++ b/tests/Unit/Api/Wiki/ShowTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api\Wiki;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Wiki;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
@@ -14,6 +15,7 @@ class ShowTest extends TestCase
     /**
      * @dataProvider getShowData
      */
+    #[DataProvider('getShowData')]
     public function testShowReturnsCorrectResponse($identifier, $page, $version, $expectedPath, $response, $expectedReturn)
     {
         $client = AssertingHttpClient::create(

--- a/tests/Unit/Api/Wiki/ShowTest.php
+++ b/tests/Unit/Api/Wiki/ShowTest.php
@@ -2,14 +2,13 @@
 
 namespace Redmine\Tests\Unit\Api\Wiki;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Wiki;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
-/**
- * @covers \Redmine\Api\Wiki::show
- */
+#[CoversClass(Wiki::class)]
 class ShowTest extends TestCase
 {
     /**

--- a/tests/Unit/Api/WikiTest.php
+++ b/tests/Unit/Api/WikiTest.php
@@ -46,7 +46,6 @@ class WikiTest extends TestCase
      *
      * @covers ::all
      * @dataProvider getAllData
-     * @test
      */
     #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
@@ -84,7 +83,6 @@ class WikiTest extends TestCase
      * Test all().
      *
      * @covers ::all
-     * @test
      */
     public function testAllReturnsClientGetResponseWithParameters()
     {
@@ -127,7 +125,6 @@ class WikiTest extends TestCase
      *
      * @covers ::delete
      * @covers ::remove
-     * @test
      */
     public function testRemoveCallsDelete()
     {
@@ -156,7 +153,6 @@ class WikiTest extends TestCase
      *
      * @covers ::create
      * @covers ::post
-     * @test
      */
     public function testCreateCallsPost()
     {
@@ -188,7 +184,6 @@ class WikiTest extends TestCase
      *
      * @covers ::create
      * @covers ::post
-     * @test
      */
     public function testCreateWithParametersCallsPost()
     {
@@ -231,7 +226,6 @@ class WikiTest extends TestCase
      *
      * @covers ::put
      * @covers ::update
-     * @test
      */
     public function testUpdateCallsPut()
     {
@@ -263,7 +257,6 @@ class WikiTest extends TestCase
      *
      * @covers ::put
      * @covers ::update
-     * @test
      */
     public function testUpdateWithParametersCallsPut()
     {

--- a/tests/Unit/Api/WikiTest.php
+++ b/tests/Unit/Api/WikiTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Wiki;
@@ -9,16 +10,13 @@ use Redmine\Client\Client;
 use Redmine\Tests\Fixtures\MockClient;
 
 /**
- * @coversDefaultClass \Redmine\Api\Wiki
- *
  * @author     Malte Gerth <mail@malte-gerth.de>
  */
+#[CoversClass(Wiki::class)]
 class WikiTest extends TestCase
 {
     /**
      * Test all().
-     *
-     * @covers ::all
      */
     public function testAllTriggersDeprecationWarning()
     {
@@ -44,7 +42,6 @@ class WikiTest extends TestCase
     /**
      * Test all().
      *
-     * @covers ::all
      * @dataProvider getAllData
      */
     #[DataProvider('getAllData')]
@@ -81,8 +78,6 @@ class WikiTest extends TestCase
 
     /**
      * Test all().
-     *
-     * @covers ::all
      */
     public function testAllReturnsClientGetResponseWithParameters()
     {
@@ -122,9 +117,6 @@ class WikiTest extends TestCase
 
     /**
      * Test remove().
-     *
-     * @covers ::delete
-     * @covers ::remove
      */
     public function testRemoveCallsDelete()
     {
@@ -150,9 +142,6 @@ class WikiTest extends TestCase
 
     /**
      * Test create().
-     *
-     * @covers ::create
-     * @covers ::post
      */
     public function testCreateCallsPost()
     {
@@ -181,9 +170,6 @@ class WikiTest extends TestCase
 
     /**
      * Test create().
-     *
-     * @covers ::create
-     * @covers ::post
      */
     public function testCreateWithParametersCallsPost()
     {
@@ -223,9 +209,6 @@ class WikiTest extends TestCase
 
     /**
      * Test update().
-     *
-     * @covers ::put
-     * @covers ::update
      */
     public function testUpdateCallsPut()
     {
@@ -254,9 +237,6 @@ class WikiTest extends TestCase
 
     /**
      * Test update().
-     *
-     * @covers ::put
-     * @covers ::update
      */
     public function testUpdateWithParametersCallsPut()
     {

--- a/tests/Unit/Api/WikiTest.php
+++ b/tests/Unit/Api/WikiTest.php
@@ -2,6 +2,7 @@
 
 namespace Redmine\Tests\Unit\Api;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Wiki;
 use Redmine\Client\Client;
@@ -47,6 +48,7 @@ class WikiTest extends TestCase
      * @dataProvider getAllData
      * @test
      */
+    #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse($response, $responseType, $expectedResponse)
     {
         // Create the used mock objects

--- a/tests/Unit/Client/NativeCurlClient/RequestTest.php
+++ b/tests/Unit/Client/NativeCurlClient/RequestTest.php
@@ -3,6 +3,7 @@
 namespace Redmine\Tests\Unit\Client\NativeCurlClientTest;
 
 use phpmock\phpunit\PHPMock;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Client\NativeCurlClient;
@@ -10,12 +11,7 @@ use Redmine\Http\Request;
 use Redmine\Http\Response;
 use stdClass;
 
-/**
- * @covers \Redmine\Client\NativeCurlClient::request
- * @covers \Redmine\Client\NativeCurlClient::runRequest
- * @covers \Redmine\Client\NativeCurlClient::createCurl
- * @covers \Redmine\Client\NativeCurlClient::createHttpHeader
- */
+#[CoversClass(NativeCurlClient::class)]
 class RequestTest extends TestCase
 {
     use PHPMock;

--- a/tests/Unit/Client/NativeCurlClient/RequestTest.php
+++ b/tests/Unit/Client/NativeCurlClient/RequestTest.php
@@ -37,10 +37,10 @@ class RequestTest extends TestCase
         $curlSetoptArray = $this->getFunctionMock($namespace, 'curl_setopt_array');
 
         $curlGetinfo = $this->getFunctionMock($namespace, 'curl_getinfo');
-        $curlGetinfo->expects($this->exactly(2))->will($this->returnValueMap(([
+        $curlGetinfo->expects($this->exactly(2))->willReturnMap(([
             [$curl, CURLINFO_HTTP_CODE, $statusCode],
             [$curl, CURLINFO_CONTENT_TYPE, $contentType],
-        ])));
+        ]));
 
         $curlErrno = $this->getFunctionMock($namespace, 'curl_errno');
         $curlErrno->expects($this->exactly(1))->willReturn(CURLE_OK);
@@ -52,6 +52,7 @@ class RequestTest extends TestCase
             'access_token'
         );
 
+        /** @var Request|\PHPUnit\Framework\MockObject\MockObject */
         $request = $this->createConfiguredMock(Request::class, [
             'getMethod' => $method,
             'getPath' => '/path',
@@ -109,10 +110,10 @@ class RequestTest extends TestCase
         $curlSetoptArray = $this->getFunctionMock($namespace, 'curl_setopt_array');
 
         $curlGetinfo = $this->getFunctionMock($namespace, 'curl_getinfo');
-        $curlGetinfo->expects($this->exactly(2))->will($this->returnValueMap(([
+        $curlGetinfo->expects($this->exactly(2))->willReturnMap(([
             [$curl, CURLINFO_HTTP_CODE, 201],
             [$curl, CURLINFO_CONTENT_TYPE, 'application/json'],
-        ])));
+        ]));
 
         $curlErrno = $this->getFunctionMock($namespace, 'curl_errno');
         $curlErrno->expects($this->exactly(1))->willReturn(CURLE_OK);
@@ -138,6 +139,7 @@ class RequestTest extends TestCase
             E_USER_DEPRECATED
         );
 
+        /** @var Request|\PHPUnit\Framework\MockObject\MockObject */
         $request = $this->createConfiguredMock(Request::class, [
             'getMethod' => 'POST',
             'getPath' => '/uploads.json',

--- a/tests/Unit/Client/NativeCurlClient/RequestTest.php
+++ b/tests/Unit/Client/NativeCurlClient/RequestTest.php
@@ -3,6 +3,7 @@
 namespace Redmine\Tests\Unit\Client\NativeCurlClientTest;
 
 use phpmock\phpunit\PHPMock;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Client\NativeCurlClient;
 use Redmine\Http\Request;
@@ -22,6 +23,7 @@ class RequestTest extends TestCase
     /**
      * @dataProvider getRequestReponseData
      */
+    #[DataProvider('getRequestReponseData')]
     public function testRequestReturnsCorrectResponse($method, $data, $statusCode, $contentType, $content)
     {
         $namespace = 'Redmine\Client';

--- a/tests/Unit/Client/NativeCurlClientTest.php
+++ b/tests/Unit/Client/NativeCurlClientTest.php
@@ -15,7 +15,6 @@ use Redmine\Client\NativeCurlClient;
 use Redmine\Http\HttpClient;
 use stdClass;
 
-
 #[CoversClass(NativeCurlClient::class)]
 class NativeCurlClientTest extends TestCase
 {

--- a/tests/Unit/Client/NativeCurlClientTest.php
+++ b/tests/Unit/Client/NativeCurlClientTest.php
@@ -7,6 +7,7 @@ namespace Redmine\Tests\Unit\Client;
 use Exception;
 use InvalidArgumentException;
 use phpmock\phpunit\PHPMock;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Client\Client;
@@ -14,6 +15,8 @@ use Redmine\Client\NativeCurlClient;
 use Redmine\Http\HttpClient;
 use stdClass;
 
+
+#[CoversClass(NativeCurlClient::class)]
 class NativeCurlClientTest extends TestCase
 {
     use PHPMock;
@@ -33,9 +36,6 @@ class NativeCurlClientTest extends TestCase
         CURLOPT_RETURNTRANSFER => 1,
     ];
 
-    /**
-     * @covers \Redmine\Client\NativeCurlClient
-     */
     public function testApiKeyShouldBePassToConstructor()
     {
         $client = new NativeCurlClient(
@@ -48,9 +48,6 @@ class NativeCurlClientTest extends TestCase
         $this->assertInstanceOf(HttpClient::class, $client);
     }
 
-    /**
-     * @covers \Redmine\Client\NativeCurlClient
-     */
     public function testShouldPassUsernameAndPasswordToConstructor()
     {
         $client = new NativeCurlClient(
@@ -63,9 +60,6 @@ class NativeCurlClientTest extends TestCase
         $this->assertInstanceOf(Client::class, $client);
     }
 
-    /**
-     * @covers \Redmine\Client\NativeCurlClient
-     */
     public function testGetLastResponseStatusCodeIsInitialNull()
     {
         $client = new NativeCurlClient(
@@ -76,9 +70,6 @@ class NativeCurlClientTest extends TestCase
         $this->assertSame(0, $client->getLastResponseStatusCode());
     }
 
-    /**
-     * @covers \Redmine\Client\NativeCurlClient
-     */
     public function testGetLastResponseContentTypeIsInitialEmpty()
     {
         $client = new NativeCurlClient(
@@ -89,9 +80,6 @@ class NativeCurlClientTest extends TestCase
         $this->assertSame('', $client->getLastResponseContentType());
     }
 
-    /**
-     * @covers \Redmine\Client\NativeCurlClient
-     */
     public function testGetLastResponseBodyIsInitialEmpty()
     {
         $client = new NativeCurlClient(
@@ -102,9 +90,6 @@ class NativeCurlClientTest extends TestCase
         $this->assertSame('', $client->getLastResponseBody());
     }
 
-    /**
-     * @covers \Redmine\Client\NativeCurlClient
-     */
     public function testStartAndStopImpersonateUser()
     {
         $expectedOptions = [
@@ -161,9 +146,6 @@ class NativeCurlClientTest extends TestCase
         $client->requestGet('/path');
     }
 
-    /**
-     * @covers \Redmine\Client\NativeCurlClient
-     */
     public function testSetSslVersion()
     {
         $expectedOptions = [
@@ -219,9 +201,6 @@ class NativeCurlClientTest extends TestCase
         $client->requestGet('/path');
     }
 
-    /**
-     * @covers \Redmine\Client\NativeCurlClient
-     */
     public function testSetSslVerifypeer()
     {
         $expectedOptions = [
@@ -278,9 +257,6 @@ class NativeCurlClientTest extends TestCase
         $client->requestGet('/path');
     }
 
-    /**
-     * @covers \Redmine\Client\NativeCurlClient
-     */
     public function testSetSslVerifyhost()
     {
         $expectedOptions = [
@@ -337,9 +313,6 @@ class NativeCurlClientTest extends TestCase
         $client->requestGet('/path');
     }
 
-    /**
-     * @covers \Redmine\Client\NativeCurlClient
-     */
     public function testSetCustomHttpHeaders()
     {
         $expectedOptions = [
@@ -402,9 +375,6 @@ class NativeCurlClientTest extends TestCase
         $client->requestGet('/path');
     }
 
-    /**
-     * @covers \Redmine\Client\NativeCurlClient
-     */
     public function testSetCustomHost()
     {
         $expectedOptions = [
@@ -463,9 +433,6 @@ class NativeCurlClientTest extends TestCase
         $client->requestGet('/path');
     }
 
-    /**
-     * @covers \Redmine\Client\NativeCurlClient
-     */
     public function testSetPort()
     {
         $expectedOptions = [
@@ -521,9 +488,6 @@ class NativeCurlClientTest extends TestCase
         $client->requestGet('/path');
     }
 
-    /**
-     * @covers \Redmine\Client\NativeCurlClient
-     */
     public function testCustomPortWillSetFromSchema()
     {
         $expectedOptions = [
@@ -574,9 +538,6 @@ class NativeCurlClientTest extends TestCase
         $client->requestGet('/path');
     }
 
-    /**
-     * @covers \Redmine\Client\NativeCurlClient
-     */
     public function testCustomPortWillSetFromUrl()
     {
         $expectedOptions = [
@@ -628,7 +589,6 @@ class NativeCurlClientTest extends TestCase
     }
 
     /**
-     * @covers \Redmine\Client\NativeCurlClient
      * @dataProvider getRequestReponseData
      */
     #[DataProvider('getRequestReponseData')]
@@ -692,9 +652,6 @@ class NativeCurlClientTest extends TestCase
         ];
     }
 
-    /**
-     * @covers \Redmine\Client\NativeCurlClient
-     */
     public function testHandlingOfResponseWithoutContent()
     {
         $content = '';
@@ -733,9 +690,6 @@ class NativeCurlClientTest extends TestCase
         $this->assertSame($content, $client->getLastResponseBody());
     }
 
-    /**
-     * @covers \Redmine\Client\NativeCurlClient
-     */
     public function testCurlErrorThrowsException()
     {
         $curl = $this->createMock(stdClass::class);
@@ -768,14 +722,10 @@ class NativeCurlClientTest extends TestCase
     }
 
     /**
-     * @covers \Redmine\Client\NativeCurlClient
-     *
-     * @param string $apiName
-     * @param string $class
      * @dataProvider getApiClassesProvider
      */
     #[DataProvider('getApiClassesProvider')]
-    public function testGetApiShouldReturnApiInstance($apiName, $class)
+    public function testGetApiShouldReturnApiInstance(string $apiName, string $class)
     {
         $client = new NativeCurlClient(
             'http://test.local',
@@ -810,9 +760,6 @@ class NativeCurlClientTest extends TestCase
         ];
     }
 
-    /**
-     * @covers \Redmine\Client\NativeCurlClient
-     */
     public function testGetApiShouldThrowException()
     {
         $client = new NativeCurlClient(

--- a/tests/Unit/Client/NativeCurlClientTest.php
+++ b/tests/Unit/Client/NativeCurlClientTest.php
@@ -135,10 +135,10 @@ class NativeCurlClientTest extends TestCase
         $curlExec->expects($this->exactly(3))->willReturn('');
 
         $curlGetinfo = $this->getFunctionMock(self::__NAMESPACE__, 'curl_getinfo');
-        $curlGetinfo->expects($this->exactly(6))->will($this->returnValueMap(([
+        $curlGetinfo->expects($this->exactly(6))->willReturnMap(([
             [$curl, CURLINFO_HTTP_CODE, 200],
             [$curl, CURLINFO_CONTENT_TYPE, 'application/json'],
-        ])));
+        ]));
 
         $curlSetoptArray = $this->getFunctionMock(self::__NAMESPACE__, 'curl_setopt_array');
         $curlSetoptArray->expects($this->exactly(3))
@@ -194,10 +194,10 @@ class NativeCurlClientTest extends TestCase
         $curlExec->expects($this->exactly(3))->willReturn('');
 
         $curlGetinfo = $this->getFunctionMock(self::__NAMESPACE__, 'curl_getinfo');
-        $curlGetinfo->expects($this->exactly(6))->will($this->returnValueMap(([
+        $curlGetinfo->expects($this->exactly(6))->willReturnMap(([
             [$curl, CURLINFO_HTTP_CODE, 200],
             [$curl, CURLINFO_CONTENT_TYPE, 'application/json'],
-        ])));
+        ]));
 
         $curlSetoptArray = $this->getFunctionMock(self::__NAMESPACE__, 'curl_setopt_array');
         $curlSetoptArray->expects($this->exactly(3))
@@ -254,10 +254,10 @@ class NativeCurlClientTest extends TestCase
         $curlExec->expects($this->exactly(3))->willReturn('');
 
         $curlGetinfo = $this->getFunctionMock(self::__NAMESPACE__, 'curl_getinfo');
-        $curlGetinfo->expects($this->exactly(6))->will($this->returnValueMap(([
+        $curlGetinfo->expects($this->exactly(6))->willReturnMap(([
             [$curl, CURLINFO_HTTP_CODE, 200],
             [$curl, CURLINFO_CONTENT_TYPE, 'application/json'],
-        ])));
+        ]));
 
         $curlSetoptArray = $this->getFunctionMock(self::__NAMESPACE__, 'curl_setopt_array');
         $curlSetoptArray->expects($this->exactly(3))
@@ -314,10 +314,10 @@ class NativeCurlClientTest extends TestCase
         $curlExec->expects($this->exactly(3))->willReturn('');
 
         $curlGetinfo = $this->getFunctionMock(self::__NAMESPACE__, 'curl_getinfo');
-        $curlGetinfo->expects($this->exactly(6))->will($this->returnValueMap(([
+        $curlGetinfo->expects($this->exactly(6))->willReturnMap(([
             [$curl, CURLINFO_HTTP_CODE, 200],
             [$curl, CURLINFO_CONTENT_TYPE, 'application/json'],
-        ])));
+        ]));
 
         $curlSetoptArray = $this->getFunctionMock(self::__NAMESPACE__, 'curl_setopt_array');
         $curlSetoptArray->expects($this->exactly(3))
@@ -375,10 +375,10 @@ class NativeCurlClientTest extends TestCase
         $curlExec->expects($this->exactly(3))->willReturn('');
 
         $curlGetinfo = $this->getFunctionMock(self::__NAMESPACE__, 'curl_getinfo');
-        $curlGetinfo->expects($this->exactly(6))->will($this->returnValueMap(([
+        $curlGetinfo->expects($this->exactly(6))->willReturnMap(([
             [$curl, CURLINFO_HTTP_CODE, 200],
             [$curl, CURLINFO_CONTENT_TYPE, 'application/json'],
-        ])));
+        ]));
 
         $curlSetoptArray = $this->getFunctionMock(self::__NAMESPACE__, 'curl_setopt_array');
         $curlSetoptArray->expects($this->exactly(3))
@@ -440,10 +440,10 @@ class NativeCurlClientTest extends TestCase
         $curlExec->expects($this->exactly(3))->willReturn('');
 
         $curlGetinfo = $this->getFunctionMock(self::__NAMESPACE__, 'curl_getinfo');
-        $curlGetinfo->expects($this->exactly(6))->will($this->returnValueMap(([
+        $curlGetinfo->expects($this->exactly(6))->willReturnMap(([
             [$curl, CURLINFO_HTTP_CODE, 200],
             [$curl, CURLINFO_CONTENT_TYPE, 'application/json'],
-        ])));
+        ]));
 
         $curlSetoptArray = $this->getFunctionMock(self::__NAMESPACE__, 'curl_setopt_array');
         $curlSetoptArray->expects($this->exactly(3))
@@ -501,10 +501,10 @@ class NativeCurlClientTest extends TestCase
         $curlExec->expects($this->exactly(3))->willReturn('');
 
         $curlGetinfo = $this->getFunctionMock(self::__NAMESPACE__, 'curl_getinfo');
-        $curlGetinfo->expects($this->exactly(6))->will($this->returnValueMap(([
+        $curlGetinfo->expects($this->exactly(6))->willReturnMap(([
             [$curl, CURLINFO_HTTP_CODE, 200],
             [$curl, CURLINFO_CONTENT_TYPE, 'application/json'],
-        ])));
+        ]));
 
         $curlSetoptArray = $this->getFunctionMock(self::__NAMESPACE__, 'curl_setopt_array');
         $curlSetoptArray->expects($this->exactly(3))
@@ -560,10 +560,10 @@ class NativeCurlClientTest extends TestCase
         $curlExec->expects($this->exactly(1))->willReturn('');
 
         $curlGetinfo = $this->getFunctionMock(self::__NAMESPACE__, 'curl_getinfo');
-        $curlGetinfo->expects($this->exactly(2))->will($this->returnValueMap(([
+        $curlGetinfo->expects($this->exactly(2))->willReturnMap(([
             [$curl, CURLINFO_HTTP_CODE, 200],
             [$curl, CURLINFO_CONTENT_TYPE, 'application/json'],
-        ])));
+        ]));
 
         $curlSetoptArray = $this->getFunctionMock(self::__NAMESPACE__, 'curl_setopt_array');
         $curlSetoptArray->expects($this->exactly(1))
@@ -614,10 +614,10 @@ class NativeCurlClientTest extends TestCase
         $curlExec->expects($this->exactly(1))->willReturn('');
 
         $curlGetinfo = $this->getFunctionMock(self::__NAMESPACE__, 'curl_getinfo');
-        $curlGetinfo->expects($this->exactly(2))->will($this->returnValueMap(([
+        $curlGetinfo->expects($this->exactly(2))->willReturnMap(([
             [$curl, CURLINFO_HTTP_CODE, 200],
             [$curl, CURLINFO_CONTENT_TYPE, 'application/json'],
-        ])));
+        ]));
 
         $curlSetoptArray = $this->getFunctionMock(self::__NAMESPACE__, 'curl_setopt_array');
         $curlSetoptArray->expects($this->exactly(1))
@@ -658,10 +658,10 @@ class NativeCurlClientTest extends TestCase
         $curlSetoptArray = $this->getFunctionMock(self::__NAMESPACE__, 'curl_setopt_array');
 
         $curlGetinfo = $this->getFunctionMock(self::__NAMESPACE__, 'curl_getinfo');
-        $curlGetinfo->expects($this->exactly(2))->will($this->returnValueMap(([
+        $curlGetinfo->expects($this->exactly(2))->willReturnMap(([
             [$curl, CURLINFO_HTTP_CODE, $statusCode],
             [$curl, CURLINFO_CONTENT_TYPE, $contentType],
-        ])));
+        ]));
 
         $curlErrno = $this->getFunctionMock(self::__NAMESPACE__, 'curl_errno');
         $curlErrno->expects($this->exactly(1))->willReturn(CURLE_OK);
@@ -726,10 +726,10 @@ class NativeCurlClientTest extends TestCase
         $curlSetoptArray = $this->getFunctionMock(self::__NAMESPACE__, 'curl_setopt_array');
 
         $curlGetinfo = $this->getFunctionMock(self::__NAMESPACE__, 'curl_getinfo');
-        $curlGetinfo->expects($this->exactly(2))->will($this->returnValueMap(([
+        $curlGetinfo->expects($this->exactly(2))->willReturnMap(([
             [$curl, CURLINFO_HTTP_CODE, $statusCode],
             [$curl, CURLINFO_CONTENT_TYPE, $contentType],
-        ])));
+        ]));
 
         $curlErrno = $this->getFunctionMock(self::__NAMESPACE__, 'curl_errno');
         $curlErrno->expects($this->exactly(1))->willReturn(CURLE_OK);

--- a/tests/Unit/Client/NativeCurlClientTest.php
+++ b/tests/Unit/Client/NativeCurlClientTest.php
@@ -7,6 +7,7 @@ namespace Redmine\Tests\Unit\Client;
 use Exception;
 use InvalidArgumentException;
 use phpmock\phpunit\PHPMock;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Client\Client;
 use Redmine\Client\NativeCurlClient;
@@ -645,6 +646,7 @@ class NativeCurlClientTest extends TestCase
      * @test
      * @dataProvider getRequestReponseData
      */
+    #[DataProvider('getRequestReponseData')]
     public function testRequestsReturnsCorrectContent($method, $data, $boolReturn, $statusCode, $contentType, $content)
     {
         $curl = $this->createMock(stdClass::class);
@@ -790,6 +792,7 @@ class NativeCurlClientTest extends TestCase
      * @param string $class
      * @dataProvider getApiClassesProvider
      */
+    #[DataProvider('getApiClassesProvider')]
     public function getApiShouldReturnApiInstance($apiName, $class)
     {
         $client = new NativeCurlClient(

--- a/tests/Unit/Client/NativeCurlClientTest.php
+++ b/tests/Unit/Client/NativeCurlClientTest.php
@@ -35,9 +35,8 @@ class NativeCurlClientTest extends TestCase
 
     /**
      * @covers \Redmine\Client\NativeCurlClient
-     * @test
      */
-    public function shouldPassApiKeyToConstructor()
+    public function testApiKeyShouldBePassToConstructor()
     {
         $client = new NativeCurlClient(
             'http://test.local',
@@ -51,9 +50,8 @@ class NativeCurlClientTest extends TestCase
 
     /**
      * @covers \Redmine\Client\NativeCurlClient
-     * @test
      */
-    public function shouldPassUsernameAndPasswordToConstructor()
+    public function testShouldPassUsernameAndPasswordToConstructor()
     {
         $client = new NativeCurlClient(
             'http://test.local',
@@ -67,7 +65,6 @@ class NativeCurlClientTest extends TestCase
 
     /**
      * @covers \Redmine\Client\NativeCurlClient
-     * @test
      */
     public function testGetLastResponseStatusCodeIsInitialNull()
     {
@@ -81,7 +78,6 @@ class NativeCurlClientTest extends TestCase
 
     /**
      * @covers \Redmine\Client\NativeCurlClient
-     * @test
      */
     public function testGetLastResponseContentTypeIsInitialEmpty()
     {
@@ -95,7 +91,6 @@ class NativeCurlClientTest extends TestCase
 
     /**
      * @covers \Redmine\Client\NativeCurlClient
-     * @test
      */
     public function testGetLastResponseBodyIsInitialEmpty()
     {
@@ -109,7 +104,6 @@ class NativeCurlClientTest extends TestCase
 
     /**
      * @covers \Redmine\Client\NativeCurlClient
-     * @test
      */
     public function testStartAndStopImpersonateUser()
     {
@@ -169,7 +163,6 @@ class NativeCurlClientTest extends TestCase
 
     /**
      * @covers \Redmine\Client\NativeCurlClient
-     * @test
      */
     public function testSetSslVersion()
     {
@@ -228,7 +221,6 @@ class NativeCurlClientTest extends TestCase
 
     /**
      * @covers \Redmine\Client\NativeCurlClient
-     * @test
      */
     public function testSetSslVerifypeer()
     {
@@ -288,7 +280,6 @@ class NativeCurlClientTest extends TestCase
 
     /**
      * @covers \Redmine\Client\NativeCurlClient
-     * @test
      */
     public function testSetSslVerifyhost()
     {
@@ -348,7 +339,6 @@ class NativeCurlClientTest extends TestCase
 
     /**
      * @covers \Redmine\Client\NativeCurlClient
-     * @test
      */
     public function testSetCustomHttpHeaders()
     {
@@ -414,7 +404,6 @@ class NativeCurlClientTest extends TestCase
 
     /**
      * @covers \Redmine\Client\NativeCurlClient
-     * @test
      */
     public function testSetCustomHost()
     {
@@ -476,7 +465,6 @@ class NativeCurlClientTest extends TestCase
 
     /**
      * @covers \Redmine\Client\NativeCurlClient
-     * @test
      */
     public function testSetPort()
     {
@@ -535,7 +523,6 @@ class NativeCurlClientTest extends TestCase
 
     /**
      * @covers \Redmine\Client\NativeCurlClient
-     * @test
      */
     public function testCustomPortWillSetFromSchema()
     {
@@ -589,7 +576,6 @@ class NativeCurlClientTest extends TestCase
 
     /**
      * @covers \Redmine\Client\NativeCurlClient
-     * @test
      */
     public function testCustomPortWillSetFromUrl()
     {
@@ -643,7 +629,6 @@ class NativeCurlClientTest extends TestCase
 
     /**
      * @covers \Redmine\Client\NativeCurlClient
-     * @test
      * @dataProvider getRequestReponseData
      */
     #[DataProvider('getRequestReponseData')]
@@ -709,7 +694,6 @@ class NativeCurlClientTest extends TestCase
 
     /**
      * @covers \Redmine\Client\NativeCurlClient
-     * @test
      */
     public function testHandlingOfResponseWithoutContent()
     {
@@ -751,7 +735,6 @@ class NativeCurlClientTest extends TestCase
 
     /**
      * @covers \Redmine\Client\NativeCurlClient
-     * @test
      */
     public function testCurlErrorThrowsException()
     {
@@ -786,14 +769,13 @@ class NativeCurlClientTest extends TestCase
 
     /**
      * @covers \Redmine\Client\NativeCurlClient
-     * @test
      *
      * @param string $apiName
      * @param string $class
      * @dataProvider getApiClassesProvider
      */
     #[DataProvider('getApiClassesProvider')]
-    public function getApiShouldReturnApiInstance($apiName, $class)
+    public function testGetApiShouldReturnApiInstance($apiName, $class)
     {
         $client = new NativeCurlClient(
             'http://test.local',
@@ -830,9 +812,8 @@ class NativeCurlClientTest extends TestCase
 
     /**
      * @covers \Redmine\Client\NativeCurlClient
-     * @test
      */
-    public function getApiShouldThrowException()
+    public function testGetApiShouldThrowException()
     {
         $client = new NativeCurlClient(
             'http://test.local',

--- a/tests/Unit/Client/Psr18Client/RequestTest.php
+++ b/tests/Unit/Client/Psr18Client/RequestTest.php
@@ -3,6 +3,7 @@
 namespace Redmine\Tests\Unit\Client\Psr18ClientTest;
 
 use Exception;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Client\ClientExceptionInterface;
@@ -17,11 +18,7 @@ use Redmine\Exception\ClientException;
 use Redmine\Http\Request;
 use Redmine\Http\Response;
 
-/**
- * @covers \Redmine\Client\Psr18Client::request
- * @covers \Redmine\Client\Psr18Client::runRequest
- * @covers \Redmine\Client\Psr18Client::createRequest
- */
+#[CoversClass(Psr18Client::class)]
 class RequestTest extends TestCase
 {
     /**

--- a/tests/Unit/Client/Psr18Client/RequestTest.php
+++ b/tests/Unit/Client/Psr18Client/RequestTest.php
@@ -3,6 +3,7 @@
 namespace Redmine\Tests\Unit\Client\Psr18ClientTest;
 
 use Exception;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
@@ -26,6 +27,7 @@ class RequestTest extends TestCase
     /**
      * @dataProvider getRequestReponseData
      */
+    #[DataProvider('getRequestReponseData')]
     public function testRequestReturnsCorrectResponse($method, $data, $statusCode, $contentType, $content)
     {
         $httpClient = $this->createConfiguredMock(ClientInterface::class, [

--- a/tests/Unit/Client/Psr18ClientTest.php
+++ b/tests/Unit/Client/Psr18ClientTest.php
@@ -4,6 +4,7 @@ namespace Redmine\Tests\Unit\Client;
 
 use Exception;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Client\ClientInterface;
@@ -19,11 +20,9 @@ use Redmine\Client\Psr18Client;
 use Redmine\Http\HttpClient;
 use stdClass;
 
+#[CoversClass(Psr18Client::class)]
 class Psr18ClientTest extends TestCase
 {
-    /**
-     * @covers \Redmine\Client\Psr18Client
-     */
     public function testShouldPassApiKeyToConstructor()
     {
         $client = new Psr18Client(
@@ -39,9 +38,6 @@ class Psr18ClientTest extends TestCase
         $this->assertInstanceOf(HttpClient::class, $client);
     }
 
-    /**
-     * @covers \Redmine\Client\Psr18Client
-     */
     public function testServerRequestFactoryIsAcceptedInConstructorForBC()
     {
         $client = new Psr18Client(
@@ -66,9 +62,6 @@ class Psr18ClientTest extends TestCase
         $client->requestGet('/path.xml');
     }
 
-    /**
-     * @covers \Redmine\Client\Psr18Client
-     */
     public function testShouldPassUsernameAndPasswordToConstructor()
     {
         $client = new Psr18Client(
@@ -84,9 +77,6 @@ class Psr18ClientTest extends TestCase
         $this->assertInstanceOf(Client::class, $client);
     }
 
-    /**
-     * @covers \Redmine\Client\Psr18Client
-     */
     public function testGetLastResponseStatusCodeIsInitialZero()
     {
         $client = new Psr18Client(
@@ -100,9 +90,6 @@ class Psr18ClientTest extends TestCase
         $this->assertSame(0, $client->getLastResponseStatusCode());
     }
 
-    /**
-     * @covers \Redmine\Client\Psr18Client
-     */
     public function testGetLastResponseContentTypeIsInitialEmpty()
     {
         $client = new Psr18Client(
@@ -116,9 +103,6 @@ class Psr18ClientTest extends TestCase
         $this->assertSame('', $client->getLastResponseContentType());
     }
 
-    /**
-     * @covers \Redmine\Client\Psr18Client
-     */
     public function testGetLastResponseBodyIsInitialEmpty()
     {
         $client = new Psr18Client(
@@ -132,9 +116,6 @@ class Psr18ClientTest extends TestCase
         $this->assertSame('', $client->getLastResponseBody());
     }
 
-    /**
-     * @covers \Redmine\Client\Psr18Client
-     */
     public function testStartAndStopImpersonateUser()
     {
         $request = $this->createMock(RequestInterface::class);
@@ -165,9 +146,6 @@ class Psr18ClientTest extends TestCase
         $client->requestGet('/path');
     }
 
-    /**
-     * @covers \Redmine\Client\Psr18Client
-     */
     public function testRequestGetReturnsFalse()
     {
         $response = $this->createMock(ResponseInterface::class);
@@ -194,7 +172,6 @@ class Psr18ClientTest extends TestCase
     }
 
     /**
-     * @covers \Redmine\Client\Psr18Client
      * @dataProvider getRequestReponseData
      */
     #[DataProvider('getRequestReponseData')]
@@ -259,14 +236,10 @@ class Psr18ClientTest extends TestCase
     }
 
     /**
-     * @covers \Redmine\Client\Psr18Client
-     *
-     * @param string $apiName
-     * @param string $class
      * @dataProvider getApiClassesProvider
      */
     #[DataProvider('getApiClassesProvider')]
-    public function testGetApiShouldReturnApiInstance($apiName, $class)
+    public function testGetApiShouldReturnApiInstance(string $apiName, string $class)
     {
         $client = new Psr18Client(
             $this->createMock(ClientInterface::class),
@@ -304,9 +277,6 @@ class Psr18ClientTest extends TestCase
         ];
     }
 
-    /**
-     * @covers \Redmine\Client\Psr18Client::__construct
-     */
     public function testCreateWithoutFactoryThrowsException()
     {
         $this->expectException(Exception::class);
@@ -322,9 +292,6 @@ class Psr18ClientTest extends TestCase
         );
     }
 
-    /**
-     * @covers \Redmine\Client\Psr18Client
-     */
     public function testGetApiShouldThrowException()
     {
         $client = new Psr18Client(

--- a/tests/Unit/Client/Psr18ClientTest.php
+++ b/tests/Unit/Client/Psr18ClientTest.php
@@ -23,9 +23,8 @@ class Psr18ClientTest extends TestCase
 {
     /**
      * @covers \Redmine\Client\Psr18Client
-     * @test
      */
-    public function shouldPassApiKeyToConstructor()
+    public function testShouldPassApiKeyToConstructor()
     {
         $client = new Psr18Client(
             $this->createMock(ClientInterface::class),
@@ -69,9 +68,8 @@ class Psr18ClientTest extends TestCase
 
     /**
      * @covers \Redmine\Client\Psr18Client
-     * @test
      */
-    public function shouldPassUsernameAndPasswordToConstructor()
+    public function testShouldPassUsernameAndPasswordToConstructor()
     {
         $client = new Psr18Client(
             $this->createMock(ClientInterface::class),
@@ -88,7 +86,6 @@ class Psr18ClientTest extends TestCase
 
     /**
      * @covers \Redmine\Client\Psr18Client
-     * @test
      */
     public function testGetLastResponseStatusCodeIsInitialZero()
     {
@@ -105,7 +102,6 @@ class Psr18ClientTest extends TestCase
 
     /**
      * @covers \Redmine\Client\Psr18Client
-     * @test
      */
     public function testGetLastResponseContentTypeIsInitialEmpty()
     {
@@ -122,7 +118,6 @@ class Psr18ClientTest extends TestCase
 
     /**
      * @covers \Redmine\Client\Psr18Client
-     * @test
      */
     public function testGetLastResponseBodyIsInitialEmpty()
     {
@@ -139,7 +134,6 @@ class Psr18ClientTest extends TestCase
 
     /**
      * @covers \Redmine\Client\Psr18Client
-     * @test
      */
     public function testStartAndStopImpersonateUser()
     {
@@ -173,7 +167,6 @@ class Psr18ClientTest extends TestCase
 
     /**
      * @covers \Redmine\Client\Psr18Client
-     * @test
      */
     public function testRequestGetReturnsFalse()
     {
@@ -202,7 +195,6 @@ class Psr18ClientTest extends TestCase
 
     /**
      * @covers \Redmine\Client\Psr18Client
-     * @test
      * @dataProvider getRequestReponseData
      */
     #[DataProvider('getRequestReponseData')]
@@ -268,14 +260,13 @@ class Psr18ClientTest extends TestCase
 
     /**
      * @covers \Redmine\Client\Psr18Client
-     * @test
      *
      * @param string $apiName
      * @param string $class
      * @dataProvider getApiClassesProvider
      */
     #[DataProvider('getApiClassesProvider')]
-    public function getApiShouldReturnApiInstance($apiName, $class)
+    public function testGetApiShouldReturnApiInstance($apiName, $class)
     {
         $client = new Psr18Client(
             $this->createMock(ClientInterface::class),
@@ -333,9 +324,8 @@ class Psr18ClientTest extends TestCase
 
     /**
      * @covers \Redmine\Client\Psr18Client
-     * @test
      */
-    public function getApiShouldThrowException()
+    public function testGetApiShouldThrowException()
     {
         $client = new Psr18Client(
             $this->createMock(ClientInterface::class),

--- a/tests/Unit/Client/Psr18ClientTest.php
+++ b/tests/Unit/Client/Psr18ClientTest.php
@@ -4,6 +4,7 @@ namespace Redmine\Tests\Unit\Client;
 
 use Exception;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
@@ -204,6 +205,7 @@ class Psr18ClientTest extends TestCase
      * @test
      * @dataProvider getRequestReponseData
      */
+    #[DataProvider('getRequestReponseData')]
     public function testRequestsReturnsCorrectContent($method, $data, $boolReturn, $statusCode, $contentType, $content)
     {
         $stream = $this->createMock(StreamInterface::class);
@@ -272,6 +274,7 @@ class Psr18ClientTest extends TestCase
      * @param string $class
      * @dataProvider getApiClassesProvider
      */
+    #[DataProvider('getApiClassesProvider')]
     public function getApiShouldReturnApiInstance($apiName, $class)
     {
         $client = new Psr18Client(

--- a/tests/Unit/Exception/ClientExceptionTest.php
+++ b/tests/Unit/Exception/ClientExceptionTest.php
@@ -3,13 +3,12 @@
 namespace Redmine\Tests\Unit\Exception;
 
 use Exception;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Redmine\Exception as RedmineException;
 use Redmine\Exception\ClientException;
 
-/**
- * @coversDefaultClass \Redmine\Exception\ClientException
- */
+#[CoversClass(ClientException::class)]
 class ClientExceptionTest extends TestCase
 {
     public function testClientException()

--- a/tests/Unit/Exception/InvalidApiNameExceptionTest.php
+++ b/tests/Unit/Exception/InvalidApiNameExceptionTest.php
@@ -3,13 +3,12 @@
 namespace Redmine\Tests\Unit\Exception;
 
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Redmine\Exception as RedmineException;
 use Redmine\Exception\InvalidApiNameException;
 
-/**
- * @coversDefaultClass \Redmine\Exception\InvalidApiNameException
- */
+#[CoversClass(InvalidApiNameException::class)]
 class InvalidApiNameExceptionTest extends TestCase
 {
     public function testInvalidApiNameException()

--- a/tests/Unit/Exception/InvalidParameterExceptionTest.php
+++ b/tests/Unit/Exception/InvalidParameterExceptionTest.php
@@ -10,9 +10,6 @@ use Redmine\Exception\InvalidParameterException;
 
 class InvalidParameterExceptionTest extends TestCase
 {
-    /**
-     * @test
-     */
     public function testInvalidParameterException()
     {
         $exception = new InvalidParameterException();

--- a/tests/Unit/Exception/MissingParameterExceptionTest.php
+++ b/tests/Unit/Exception/MissingParameterExceptionTest.php
@@ -10,9 +10,6 @@ use Redmine\Exception\MissingParameterException;
 
 class MissingParameterExceptionTest extends TestCase
 {
-    /**
-     * @test
-     */
     public function testMissingParameterException()
     {
         $exception = new MissingParameterException();

--- a/tests/Unit/Http/HttpFactory/MakeJsonRequestTest.php
+++ b/tests/Unit/Http/HttpFactory/MakeJsonRequestTest.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace Redmine\Tests\Unit\Http\HttpFactory;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Redmine\Http\HttpFactory;
 use Redmine\Http\Request;
 
-/**
- * @covers \Redmine\Http\HttpFactory::makeJsonRequest
- */
+#[CoversClass(HttpFactory::class)]
 class MakeJsonRequestTest extends TestCase
 {
     public function testMakeJsonRequest()

--- a/tests/Unit/Http/HttpFactory/MakeRequestTest.php
+++ b/tests/Unit/Http/HttpFactory/MakeRequestTest.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace Redmine\Tests\Unit\Http\HttpFactory;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Redmine\Http\HttpFactory;
 use Redmine\Http\Request;
 
-/**
- * @covers \Redmine\Http\HttpFactory::makeRequest
- */
+#[CoversClass(HttpFactory::class)]
 class MakeRequestTest extends TestCase
 {
     public function testMakeRequest()

--- a/tests/Unit/Http/HttpFactory/MakeResponseTest.php
+++ b/tests/Unit/Http/HttpFactory/MakeResponseTest.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace Redmine\Tests\Unit\Http\HttpFactory;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Redmine\Http\HttpFactory;
 use Redmine\Http\Response;
 
-/**
- * @covers \Redmine\Http\HttpFactory::makeResponse
- */
+#[CoversClass(HttpFactory::class)]
 class MakeResponseTest extends TestCase
 {
     public function testMakeResponse()

--- a/tests/Unit/Http/HttpFactory/MakeXmlRequestTest.php
+++ b/tests/Unit/Http/HttpFactory/MakeXmlRequestTest.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace Redmine\Tests\Unit\Http\HttpFactory;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Redmine\Http\HttpFactory;
 use Redmine\Http\Request;
 
-/**
- * @covers \Redmine\Http\HttpFactory::makeXmlRequest
- */
+#[CoversClass(HttpFactory::class)]
 class MakeXmlRequestTest extends TestCase
 {
     public function testMakeXmlRequest()

--- a/tests/Unit/Serializer/JsonSerializerTest.php
+++ b/tests/Unit/Serializer/JsonSerializerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Redmine\Tests\Unit\Serializer;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Exception\SerializerException;
 use Redmine\Serializer\JsonSerializer;
@@ -64,6 +65,7 @@ class JsonSerializerTest extends TestCase
      *
      * @dataProvider getEncodedToNormalizedData
      */
+    #[DataProvider('getEncodedToNormalizedData')]
     public function createFromStringDecodesToExpectedNormalizedData(string $data, $expected)
     {
         $serializer = JsonSerializer::createFromString($data);
@@ -90,6 +92,7 @@ class JsonSerializerTest extends TestCase
      *
      * @dataProvider getInvalidEncodedData
      */
+    #[DataProvider('getInvalidEncodedData')]
     public function createFromStringWithInvalidStringThrowsException(string $message, string $data)
     {
         $this->expectException(SerializerException::class);
@@ -187,6 +190,7 @@ class JsonSerializerTest extends TestCase
      *
      * @dataProvider getNormalizedToEncodedData
      */
+    #[DataProvider('getNormalizedToEncodedData')]
     public function createFromArrayEncodesToExpectedString(array $data, $expected)
     {
         $serializer = JsonSerializer::createFromArray($data);
@@ -209,6 +213,7 @@ class JsonSerializerTest extends TestCase
      *
      * @dataProvider getInvalidSerializedData
      */
+    #[DataProvider('getInvalidSerializedData')]
     public function createFromArrayWithInvalidDataThrowsException(string $message, array $data)
     {
         $this->expectException(SerializerException::class);

--- a/tests/Unit/Serializer/JsonSerializerTest.php
+++ b/tests/Unit/Serializer/JsonSerializerTest.php
@@ -61,12 +61,10 @@ class JsonSerializerTest extends TestCase
     }
 
     /**
-     * @test
-     *
      * @dataProvider getEncodedToNormalizedData
      */
     #[DataProvider('getEncodedToNormalizedData')]
-    public function createFromStringDecodesToExpectedNormalizedData(string $data, $expected)
+    public function testCreateFromStringDecodesToExpectedNormalizedData(string $data, $expected)
     {
         $serializer = JsonSerializer::createFromString($data);
 
@@ -88,12 +86,10 @@ class JsonSerializerTest extends TestCase
     }
 
     /**
-     * @test
-     *
      * @dataProvider getInvalidEncodedData
      */
     #[DataProvider('getInvalidEncodedData')]
-    public function createFromStringWithInvalidStringThrowsException(string $message, string $data)
+    public function testCreateFromStringWithInvalidStringThrowsException(string $message, string $data)
     {
         $this->expectException(SerializerException::class);
         $this->expectExceptionMessage($message);
@@ -186,12 +182,10 @@ class JsonSerializerTest extends TestCase
     }
 
     /**
-     * @test
-     *
      * @dataProvider getNormalizedToEncodedData
      */
     #[DataProvider('getNormalizedToEncodedData')]
-    public function createFromArrayEncodesToExpectedString(array $data, $expected)
+    public function testCreateFromArrayEncodesToExpectedString(array $data, $expected)
     {
         $serializer = JsonSerializer::createFromArray($data);
 
@@ -209,12 +203,10 @@ class JsonSerializerTest extends TestCase
     }
 
     /**
-     * @test
-     *
      * @dataProvider getInvalidSerializedData
      */
     #[DataProvider('getInvalidSerializedData')]
-    public function createFromArrayWithInvalidDataThrowsException(string $message, array $data)
+    public function testCreateFromArrayWithInvalidDataThrowsException(string $message, array $data)
     {
         $this->expectException(SerializerException::class);
         $this->expectExceptionMessage($message);

--- a/tests/Unit/Serializer/JsonSerializerTest.php
+++ b/tests/Unit/Serializer/JsonSerializerTest.php
@@ -4,14 +4,13 @@ declare(strict_types=1);
 
 namespace Redmine\Tests\Unit\Serializer;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Exception\SerializerException;
 use Redmine\Serializer\JsonSerializer;
 
-/**
- * @coversDefaultClass \Redmine\Serializer\JsonSerializer
- */
+#[CoversClass(JsonSerializer::class)]
 class JsonSerializerTest extends TestCase
 {
     public static function getEncodedToNormalizedData(): array

--- a/tests/Unit/Serializer/PathSerializerTest.php
+++ b/tests/Unit/Serializer/PathSerializerTest.php
@@ -52,12 +52,10 @@ class PathSerializerTest extends TestCase
     }
 
     /**
-     * @test
-     *
      * @dataProvider getPathData
      */
     #[DataProvider('getPathData')]
-    public function getPathShouldReturnExpectedString(string $path, array $params, string $expected)
+    public function testGetPathShouldReturnExpectedString(string $path, array $params, string $expected)
     {
         $serializer = PathSerializer::create($path, $params);
 

--- a/tests/Unit/Serializer/PathSerializerTest.php
+++ b/tests/Unit/Serializer/PathSerializerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Redmine\Tests\Unit\Serializer;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Serializer\PathSerializer;
 
@@ -55,6 +56,7 @@ class PathSerializerTest extends TestCase
      *
      * @dataProvider getPathData
      */
+    #[DataProvider('getPathData')]
     public function getPathShouldReturnExpectedString(string $path, array $params, string $expected)
     {
         $serializer = PathSerializer::create($path, $params);

--- a/tests/Unit/Serializer/PathSerializerTest.php
+++ b/tests/Unit/Serializer/PathSerializerTest.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace Redmine\Tests\Unit\Serializer;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Serializer\PathSerializer;
 
-/**
- * @coversDefaultClass \Redmine\Serializer\PathSerializer
- */
+#[CoversClass(PathSerializer::class)]
 class PathSerializerTest extends TestCase
 {
     public static function getPathData(): array

--- a/tests/Unit/Serializer/XmlSerializerTest.php
+++ b/tests/Unit/Serializer/XmlSerializerTest.php
@@ -14,6 +14,17 @@ use Redmine\Serializer\XmlSerializer;
  */
 class XmlSerializerTest extends TestCase
 {
+    /**
+     * @dataProvider getEncodedToNormalizedData
+     */
+    #[DataProvider('getEncodedToNormalizedData')]
+    public function testCreateFromStringDecodesToExpectedNormalizedData(string $data, $expected)
+    {
+        $serializer = XmlSerializer::createFromString($data);
+
+        $this->assertSame($expected, $serializer->getNormalized());
+    }
+
     public static function getEncodedToNormalizedData(): array
     {
         return [
@@ -64,16 +75,15 @@ class XmlSerializerTest extends TestCase
     }
 
     /**
-     * @test
-     *
-     * @dataProvider getEncodedToNormalizedData
+     * @dataProvider getInvalidEncodedData
      */
-    #[DataProvider('getEncodedToNormalizedData')]
-    public function createFromStringDecodesToExpectedNormalizedData(string $data, $expected)
+    #[DataProvider('getInvalidEncodedData')]
+    public function testCreateFromStringWithInvalidStringThrowsException(string $message, string $data)
     {
-        $serializer = XmlSerializer::createFromString($data);
+        $this->expectException(SerializerException::class);
+        $this->expectExceptionMessage($message);
 
-        $this->assertSame($expected, $serializer->getNormalized());
+        XmlSerializer::createFromString($data);
     }
 
     public static function getInvalidEncodedData(): array
@@ -103,17 +113,14 @@ class XmlSerializerTest extends TestCase
     }
 
     /**
-     * @test
-     *
-     * @dataProvider getInvalidEncodedData
+     * @dataProvider getNormalizedToEncodedData
      */
-    #[DataProvider('getInvalidEncodedData')]
-    public function createFromStringWithInvalidStringThrowsException(string $message, string $data)
+    #[DataProvider('getNormalizedToEncodedData')]
+    public function testCreateFromArrayEncodesToExpectedString(array $data, $expected)
     {
-        $this->expectException(SerializerException::class);
-        $this->expectExceptionMessage($message);
+        $serializer = XmlSerializer::createFromArray($data);
 
-        XmlSerializer::createFromString($data);
+        $this->assertXmlStringEqualsXmlString($expected, $serializer->__toString());
     }
 
     public static function getNormalizedToEncodedData(): array
@@ -256,16 +263,15 @@ class XmlSerializerTest extends TestCase
     }
 
     /**
-     * @test
-     *
-     * @dataProvider getNormalizedToEncodedData
+     * @dataProvider getInvalidSerializedData
      */
-    #[DataProvider('getNormalizedToEncodedData')]
-    public function createFromArrayEncodesToExpectedString(array $data, $expected)
+    #[DataProvider('getInvalidSerializedData')]
+    public function testCreateFromArrayWithInvalidDataThrowsException(string $message, array $data)
     {
-        $serializer = XmlSerializer::createFromArray($data);
+        $this->expectException(SerializerException::class);
+        $this->expectExceptionMessage($message);
 
-        $this->assertXmlStringEqualsXmlString($expected, $serializer->__toString());
+        XmlSerializer::createFromArray($data);
     }
 
     public static function getInvalidSerializedData(): array
@@ -276,19 +282,5 @@ class XmlSerializerTest extends TestCase
                 ['0' => ['foobar']],
             ]
         ];
-    }
-
-    /**
-     * @test
-     *
-     * @dataProvider getInvalidSerializedData
-     */
-    #[DataProvider('getInvalidSerializedData')]
-    public function createFromArrayWithInvalidDataThrowsException(string $message, array $data)
-    {
-        $this->expectException(SerializerException::class);
-        $this->expectExceptionMessage($message);
-
-        XmlSerializer::createFromArray($data);
     }
 }

--- a/tests/Unit/Serializer/XmlSerializerTest.php
+++ b/tests/Unit/Serializer/XmlSerializerTest.php
@@ -4,14 +4,13 @@ declare(strict_types=1);
 
 namespace Redmine\Tests\Unit\Serializer;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Exception\SerializerException;
 use Redmine\Serializer\XmlSerializer;
 
-/**
- * @coversDefaultClass \Redmine\Serializer\XmlSerializer
- */
+#[CoversClass(XmlSerializer::class)]
 class XmlSerializerTest extends TestCase
 {
     /**

--- a/tests/Unit/Serializer/XmlSerializerTest.php
+++ b/tests/Unit/Serializer/XmlSerializerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Redmine\Tests\Unit\Serializer;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Exception\SerializerException;
 use Redmine\Serializer\XmlSerializer;
@@ -67,6 +68,7 @@ class XmlSerializerTest extends TestCase
      *
      * @dataProvider getEncodedToNormalizedData
      */
+    #[DataProvider('getEncodedToNormalizedData')]
     public function createFromStringDecodesToExpectedNormalizedData(string $data, $expected)
     {
         $serializer = XmlSerializer::createFromString($data);
@@ -105,6 +107,7 @@ class XmlSerializerTest extends TestCase
      *
      * @dataProvider getInvalidEncodedData
      */
+    #[DataProvider('getInvalidEncodedData')]
     public function createFromStringWithInvalidStringThrowsException(string $message, string $data)
     {
         $this->expectException(SerializerException::class);
@@ -257,6 +260,7 @@ class XmlSerializerTest extends TestCase
      *
      * @dataProvider getNormalizedToEncodedData
      */
+    #[DataProvider('getNormalizedToEncodedData')]
     public function createFromArrayEncodesToExpectedString(array $data, $expected)
     {
         $serializer = XmlSerializer::createFromArray($data);
@@ -279,6 +283,7 @@ class XmlSerializerTest extends TestCase
      *
      * @dataProvider getInvalidSerializedData
      */
+    #[DataProvider('getInvalidSerializedData')]
     public function createFromArrayWithInvalidDataThrowsException(string $message, array $data)
     {
         $this->expectException(SerializerException::class);


### PR DESCRIPTION
This PR updates all dependencies:

- PHP 8.3.3
- Redmine 5.0.8
- Redmine 5.1.2
- codecov/codecov-action v4

The update for PHPUnit 11 is postponed due to deprecation warnings in the php-mock/php-mock-phpunit library, see https://github.com/php-mock/php-mock-phpunit/pull/67#issuecomment-1937702275
Nevertheless all `@dataProvider`, `@covers` and `@coversDefaultClass` annotations where replaced with the new Attributes provided by PHPUnit, so we are ready to update to PHPUnit 11 anytime.

Closes #375.