### PR TITLE
Fix CS errors

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -15,7 +15,7 @@ return $config->setRules([
         'linebreak_after_opening_tag' => true,
         'ordered_imports' => true,
         'phpdoc_order' => true,
-        'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['arrays']], // Remove this rule after dropping support for PHP 7.4
+        'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['arguments', 'arrays']], // Remove this rule after dropping support for PHP 7.4
     ])
     ->setFinder($finder)
     ->setRiskyAllowed(true)

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -15,6 +15,7 @@ return $config->setRules([
         'linebreak_after_opening_tag' => true,
         'ordered_imports' => true,
         'phpdoc_order' => true,
+        'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['arrays']], // Remove this rule after dropping support for PHP 7.4
     ])
     ->setFinder($finder)
     ->setRiskyAllowed(true)

--- a/src/Redmine/Api/AbstractApi.php
+++ b/src/Redmine/Api/AbstractApi.php
@@ -49,7 +49,7 @@ abstract class AbstractApi implements Api
                 __METHOD__,
                 Client::class,
                 HttpClient::class,
-                (is_object($client)) ? get_class($client) : gettype($client)
+                (is_object($client)) ? get_class($client) : gettype($client),
             ));
         }
 
@@ -117,7 +117,7 @@ abstract class AbstractApi implements Api
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeRequest(
             'GET',
             strval($path),
-            $this->getContentTypeFromPath(strval($path))
+            $this->getContentTypeFromPath(strval($path)),
         ));
 
         $body = $this->lastResponse->getContent();
@@ -158,7 +158,7 @@ abstract class AbstractApi implements Api
             'POST',
             strval($path),
             $this->getContentTypeFromPath(strval($path)),
-            $data
+            $data,
         ));
 
         $body = $this->lastResponse->getContent();
@@ -191,7 +191,7 @@ abstract class AbstractApi implements Api
             'PUT',
             strval($path),
             $this->getContentTypeFromPath(strval($path)),
-            $data
+            $data,
         ));
 
         $body = $this->lastResponse->getContent();
@@ -222,7 +222,7 @@ abstract class AbstractApi implements Api
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeRequest(
             'DELETE',
             strval($path),
-            $this->getContentTypeFromPath(strval($path))
+            $this->getContentTypeFromPath(strval($path)),
         ));
 
         return $this->lastResponse->getContent();
@@ -251,7 +251,7 @@ abstract class AbstractApi implements Api
     {
         return array_filter(
             array_merge($defaults, $params),
-            [$this, 'isNotNull']
+            [$this, 'isNotNull'],
         );
     }
 
@@ -301,7 +301,7 @@ abstract class AbstractApi implements Api
             $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeRequest(
                 'GET',
                 strval($endpoint),
-                $this->getContentTypeFromPath(strval($endpoint))
+                $this->getContentTypeFromPath(strval($endpoint)),
             ));
 
             return $this->getResponseAsArray($this->lastResponse);
@@ -312,7 +312,7 @@ abstract class AbstractApi implements Api
                 'limit' => 25,
                 'offset' => 0,
             ],
-            $params
+            $params,
         );
 
         $returnData = [];
@@ -334,7 +334,7 @@ abstract class AbstractApi implements Api
             $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeRequest(
                 'GET',
                 PathSerializer::create($endpoint, $params)->getPath(),
-                $this->getContentTypeFromPath($endpoint)
+                $this->getContentTypeFromPath($endpoint),
             ));
 
             $newDataSet = $this->getResponseAsArray($this->lastResponse);
@@ -457,7 +457,7 @@ abstract class AbstractApi implements Api
                 return HttpFactory::makeResponse(
                     $this->client->getLastResponseStatusCode(),
                     $this->client->getLastResponseContentType(),
-                    $this->client->getLastResponseBody()
+                    $this->client->getLastResponseBody(),
                 );
             }
         };

--- a/src/Redmine/Api/Attachment.php
+++ b/src/Redmine/Api/Attachment.php
@@ -70,7 +70,7 @@ class Attachment extends AbstractApi
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeJsonRequest(
             'PUT',
             '/attachments/' . $id . '.json',
-            JsonSerializer::createFromArray(['attachment' => $params])->getEncoded()
+            JsonSerializer::createFromArray(['attachment' => $params])->getEncoded(),
         ));
 
         if ($this->lastResponse->getStatusCode() !== 204) {
@@ -91,7 +91,7 @@ class Attachment extends AbstractApi
     {
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeRequest(
             'GET',
-            '/attachments/download/' . urlencode(strval($id))
+            '/attachments/download/' . urlencode(strval($id)),
         ));
 
         if (200 !== $this->lastResponse->getStatusCode()) {
@@ -119,7 +119,7 @@ class Attachment extends AbstractApi
             'POST',
             PathSerializer::create('/uploads.json', $params)->getPath(),
             'application/octet-stream',
-            $attachment
+            $attachment,
         ));
 
         return $this->lastResponse->getContent();
@@ -138,7 +138,7 @@ class Attachment extends AbstractApi
     {
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeXmlRequest(
             'DELETE',
-            '/attachments/' . urlencode(strval($id)) . '.xml'
+            '/attachments/' . urlencode(strval($id)) . '.xml',
         ));
 
         return $this->lastResponse->getContent();

--- a/src/Redmine/Api/Group.php
+++ b/src/Redmine/Api/Group.php
@@ -151,7 +151,7 @@ class Group extends AbstractApi
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeXmlRequest(
             'POST',
             '/groups.xml',
-            XmlSerializer::createFromArray(['group' => $params])->getEncoded()
+            XmlSerializer::createFromArray(['group' => $params])->getEncoded(),
         ));
 
         $body = $this->lastResponse->getContent();
@@ -185,7 +185,7 @@ class Group extends AbstractApi
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeXmlRequest(
             'PUT',
             '/groups/' . $id . '.xml',
-            XmlSerializer::createFromArray(['group' => $params])->getEncoded()
+            XmlSerializer::createFromArray(['group' => $params])->getEncoded(),
         ));
 
         return $this->lastResponse->getContent();
@@ -207,7 +207,7 @@ class Group extends AbstractApi
     {
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeJsonRequest(
             'GET',
-            PathSerializer::create('/groups/' . urlencode(strval($id)) . '.json', $params)->getPath()
+            PathSerializer::create('/groups/' . urlencode(strval($id)) . '.json', $params)->getPath(),
         ));
 
         $body = $this->lastResponse->getContent();
@@ -236,7 +236,7 @@ class Group extends AbstractApi
     {
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeXmlRequest(
             'DELETE',
-            '/groups/' . $id . '.xml'
+            '/groups/' . $id . '.xml',
         ));
 
         return $this->lastResponse->getContent();
@@ -257,7 +257,7 @@ class Group extends AbstractApi
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeXmlRequest(
             'POST',
             '/groups/' . $id . '/users.xml',
-            XmlSerializer::createFromArray(['user_id' => $userId])->getEncoded()
+            XmlSerializer::createFromArray(['user_id' => $userId])->getEncoded(),
         ));
 
         $body = $this->lastResponse->getContent();
@@ -283,7 +283,7 @@ class Group extends AbstractApi
     {
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeXmlRequest(
             'DELETE',
-            '/groups/' . $id . '/users/' . $userId . '.xml'
+            '/groups/' . $id . '/users/' . $userId . '.xml',
         ));
 
         return $this->lastResponse->getContent();

--- a/src/Redmine/Api/Issue.php
+++ b/src/Redmine/Api/Issue.php
@@ -163,7 +163,7 @@ class Issue extends AbstractApi
 
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeJsonRequest(
             'GET',
-            PathSerializer::create('/issues/' . urlencode(strval($id)) . '.json', $params)->getPath()
+            PathSerializer::create('/issues/' . urlencode(strval($id)) . '.json', $params)->getPath(),
         ));
 
         $body = $this->lastResponse->getContent();
@@ -217,7 +217,7 @@ class Issue extends AbstractApi
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeXmlRequest(
             'POST',
             '/issues.xml',
-            XmlSerializer::createFromArray(['issue' => $params])->getEncoded()
+            XmlSerializer::createFromArray(['issue' => $params])->getEncoded(),
         ));
 
         $body = $this->lastResponse->getContent();
@@ -263,7 +263,7 @@ class Issue extends AbstractApi
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeXmlRequest(
             'PUT',
             '/issues/' . urlencode(strval($id)) . '.xml',
-            XmlSerializer::createFromArray(['issue' => $sanitizedParams])->getEncoded()
+            XmlSerializer::createFromArray(['issue' => $sanitizedParams])->getEncoded(),
         ));
 
         return $this->lastResponse->getContent();
@@ -280,7 +280,7 @@ class Issue extends AbstractApi
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeXmlRequest(
             'POST',
             '/issues/' . urlencode(strval($id)) . '/watchers.xml',
-            XmlSerializer::createFromArray(['user_id' => urlencode(strval($watcherUserId))])->getEncoded()
+            XmlSerializer::createFromArray(['user_id' => urlencode(strval($watcherUserId))])->getEncoded(),
         ));
 
         $body = $this->lastResponse->getContent();
@@ -302,7 +302,7 @@ class Issue extends AbstractApi
     {
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeXmlRequest(
             'DELETE',
-            '/issues/' . urlencode(strval($id)) . '/watchers/' . urlencode(strval($watcherUserId)) . '.xml'
+            '/issues/' . urlencode(strval($id)) . '/watchers/' . urlencode(strval($watcherUserId)) . '.xml',
         ));
 
         return $this->lastResponse->getContent();
@@ -428,7 +428,7 @@ class Issue extends AbstractApi
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeJsonRequest(
             'PUT',
             '/issues/' . urlencode(strval($id)) . '.json',
-            JsonSerializer::createFromArray(['issue' => $params])->getEncoded()
+            JsonSerializer::createFromArray(['issue' => $params])->getEncoded(),
         ));
 
         return $this->lastResponse->getContent();
@@ -445,7 +445,7 @@ class Issue extends AbstractApi
     {
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeXmlRequest(
             'DELETE',
-            '/issues/' . urlencode(strval($id)) . '.xml'
+            '/issues/' . urlencode(strval($id)) . '.xml',
         ));
 
         return $this->lastResponse->getContent();

--- a/src/Redmine/Api/IssueCategory.php
+++ b/src/Redmine/Api/IssueCategory.php
@@ -42,7 +42,7 @@ class IssueCategory extends AbstractApi
         if (! is_int($projectIdentifier) && ! is_string($projectIdentifier)) {
             throw new InvalidParameterException(sprintf(
                 '%s(): Argument #1 ($projectIdentifier) must be of type int or string',
-                __METHOD__
+                __METHOD__,
             ));
         }
 
@@ -182,7 +182,7 @@ class IssueCategory extends AbstractApi
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeXmlRequest(
             'POST',
             '/projects/' . $project . '/issue_categories.xml',
-            XmlSerializer::createFromArray(['issue_category' => $params])->getEncoded()
+            XmlSerializer::createFromArray(['issue_category' => $params])->getEncoded(),
         ));
 
         $body = $this->lastResponse->getContent();
@@ -214,7 +214,7 @@ class IssueCategory extends AbstractApi
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeXmlRequest(
             'PUT',
             '/issue_categories/' . urlencode(strval($id)) . '.xml',
-            XmlSerializer::createFromArray(['issue_category' => $params])->getEncoded()
+            XmlSerializer::createFromArray(['issue_category' => $params])->getEncoded(),
         ));
 
         return $this->lastResponse->getContent();
@@ -236,7 +236,7 @@ class IssueCategory extends AbstractApi
     {
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeXmlRequest(
             'DELETE',
-            PathSerializer::create('/issue_categories/' . urlencode(strval($id)) . '.xml', $params)->getPath()
+            PathSerializer::create('/issue_categories/' . urlencode(strval($id)) . '.xml', $params)->getPath(),
         ));
 
         return $this->lastResponse->getContent();

--- a/src/Redmine/Api/IssueRelation.php
+++ b/src/Redmine/Api/IssueRelation.php
@@ -124,7 +124,7 @@ class IssueRelation extends AbstractApi
     {
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeXmlRequest(
             'DELETE',
-            '/relations/' . $id . '.xml'
+            '/relations/' . $id . '.xml',
         ));
 
         return $this->lastResponse->getContent();
@@ -164,7 +164,7 @@ class IssueRelation extends AbstractApi
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeJsonRequest(
             'POST',
             '/issues/' . urlencode(strval($issueId)) . '/relations.json',
-            JsonSerializer::createFromArray(['relation' => $params])->getEncoded()
+            JsonSerializer::createFromArray(['relation' => $params])->getEncoded(),
         ));
 
         $body = $this->lastResponse->getContent();

--- a/src/Redmine/Api/Membership.php
+++ b/src/Redmine/Api/Membership.php
@@ -40,7 +40,7 @@ class Membership extends AbstractApi
         if (! is_int($projectIdentifier) && ! is_string($projectIdentifier)) {
             throw new InvalidParameterException(sprintf(
                 '%s(): Argument #1 ($projectIdentifier) must be of type int or string',
-                __METHOD__
+                __METHOD__,
             ));
         }
 
@@ -112,7 +112,7 @@ class Membership extends AbstractApi
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeXmlRequest(
             'POST',
             '/projects/' . $project . '/memberships.xml',
-            XmlSerializer::createFromArray(['membership' => $params])->getEncoded()
+            XmlSerializer::createFromArray(['membership' => $params])->getEncoded(),
         ));
 
         $body = $this->lastResponse->getContent();
@@ -150,7 +150,7 @@ class Membership extends AbstractApi
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeXmlRequest(
             'PUT',
             '/memberships/' . $id . '.xml',
-            XmlSerializer::createFromArray(['membership' => $params])->getEncoded()
+            XmlSerializer::createFromArray(['membership' => $params])->getEncoded(),
         ));
 
         return $this->lastResponse->getContent();
@@ -169,7 +169,7 @@ class Membership extends AbstractApi
     {
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeXmlRequest(
             'DELETE',
-            '/memberships/' . $id . '.xml'
+            '/memberships/' . $id . '.xml',
         ));
 
         return $this->lastResponse->getContent();

--- a/src/Redmine/Api/News.php
+++ b/src/Redmine/Api/News.php
@@ -34,7 +34,7 @@ class News extends AbstractApi
         if (! is_int($projectIdentifier) && ! is_string($projectIdentifier)) {
             throw new InvalidParameterException(sprintf(
                 '%s(): Argument #1 ($projectIdentifier) must be of type int or string',
-                __METHOD__
+                __METHOD__,
             ));
         }
 

--- a/src/Redmine/Api/Project.php
+++ b/src/Redmine/Api/Project.php
@@ -138,7 +138,7 @@ class Project extends AbstractApi
 
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeJsonRequest(
             'GET',
-            PathSerializer::create('/projects/' . urlencode(strval($id)) . '.json', $params)->getPath()
+            PathSerializer::create('/projects/' . urlencode(strval($id)) . '.json', $params)->getPath(),
         ));
 
         $body = $this->lastResponse->getContent();
@@ -184,7 +184,7 @@ class Project extends AbstractApi
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeXmlRequest(
             'POST',
             '/projects.xml',
-            XmlSerializer::createFromArray(['project' => $params])->getEncoded()
+            XmlSerializer::createFromArray(['project' => $params])->getEncoded(),
         ));
 
         $body = $this->lastResponse->getContent();
@@ -218,7 +218,7 @@ class Project extends AbstractApi
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeXmlRequest(
             'PUT',
             '/projects/' . urlencode(strval($id)) . '.xml',
-            XmlSerializer::createFromArray(['project' => $params])->getEncoded()
+            XmlSerializer::createFromArray(['project' => $params])->getEncoded(),
         ));
 
         return $this->lastResponse->getContent();
@@ -241,14 +241,14 @@ class Project extends AbstractApi
         if (! is_int($projectIdentifier) && ! is_string($projectIdentifier)) {
             throw new InvalidArgumentException(sprintf(
                 '%s(): Argument #1 ($projectIdentifier) must be of type int or string',
-                __METHOD__
+                __METHOD__,
             ));
         }
 
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeXmlRequest(
             'PUT',
             '/projects/' . strval($projectIdentifier) . '/close.xml',
-            ''
+            '',
         ));
 
         $lastResponse = $this->getLastResponse();
@@ -277,14 +277,14 @@ class Project extends AbstractApi
         if (! is_int($projectIdentifier) && ! is_string($projectIdentifier)) {
             throw new InvalidArgumentException(sprintf(
                 '%s(): Argument #1 ($projectIdentifier) must be of type int or string',
-                __METHOD__
+                __METHOD__,
             ));
         }
 
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeXmlRequest(
             'PUT',
             '/projects/' . strval($projectIdentifier) . '/reopen.xml',
-            ''
+            '',
         ));
 
         $lastResponse = $this->getLastResponse();
@@ -313,14 +313,14 @@ class Project extends AbstractApi
         if (! is_int($projectIdentifier) && ! is_string($projectIdentifier)) {
             throw new InvalidArgumentException(sprintf(
                 '%s(): Argument #1 ($projectIdentifier) must be of type int or string',
-                __METHOD__
+                __METHOD__,
             ));
         }
 
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeXmlRequest(
             'PUT',
             '/projects/' . strval($projectIdentifier) . '/archive.xml',
-            ''
+            '',
         ));
 
         $lastResponse = $this->getLastResponse();
@@ -349,14 +349,14 @@ class Project extends AbstractApi
         if (! is_int($projectIdentifier) && ! is_string($projectIdentifier)) {
             throw new InvalidArgumentException(sprintf(
                 '%s(): Argument #1 ($projectIdentifier) must be of type int or string',
-                __METHOD__
+                __METHOD__,
             ));
         }
 
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeXmlRequest(
             'PUT',
             '/projects/' . strval($projectIdentifier) . '/unarchive.xml',
-            ''
+            '',
         ));
 
         $lastResponse = $this->getLastResponse();
@@ -381,7 +381,7 @@ class Project extends AbstractApi
         @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.3.0, use `\Redmine\Serializer\XmlSerializer::createFromArray()` instead.', E_USER_DEPRECATED);
 
         return new SimpleXMLElement(
-            XmlSerializer::createFromArray(['project' => $params])->getEncoded()
+            XmlSerializer::createFromArray(['project' => $params])->getEncoded(),
         );
     }
 
@@ -398,7 +398,7 @@ class Project extends AbstractApi
     {
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeXmlRequest(
             'DELETE',
-            '/projects/' . $id . '.xml'
+            '/projects/' . $id . '.xml',
         ));
 
         return $this->lastResponse->getContent();

--- a/src/Redmine/Api/Role.php
+++ b/src/Redmine/Api/Role.php
@@ -105,7 +105,7 @@ class Role extends AbstractApi
     {
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeJsonRequest(
             'GET',
-            '/roles/' . urlencode(strval($id)) . '.json'
+            '/roles/' . urlencode(strval($id)) . '.json',
         ));
 
         $body = $this->lastResponse->getContent();

--- a/src/Redmine/Api/TimeEntry.php
+++ b/src/Redmine/Api/TimeEntry.php
@@ -88,7 +88,7 @@ class TimeEntry extends AbstractApi
     {
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeJsonRequest(
             'GET',
-            '/time_entries/' . urlencode(strval($id)) . '.json'
+            '/time_entries/' . urlencode(strval($id)) . '.json',
         ));
 
         $body = $this->lastResponse->getContent();
@@ -137,7 +137,7 @@ class TimeEntry extends AbstractApi
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeXmlRequest(
             'POST',
             '/time_entries.xml',
-            XmlSerializer::createFromArray(['time_entry' => $params])->getEncoded()
+            XmlSerializer::createFromArray(['time_entry' => $params])->getEncoded(),
         ));
 
         $body = $this->lastResponse->getContent();
@@ -174,7 +174,7 @@ class TimeEntry extends AbstractApi
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeXmlRequest(
             'PUT',
             '/time_entries/' . $id . '.xml',
-            XmlSerializer::createFromArray(['time_entry' => $params])->getEncoded()
+            XmlSerializer::createFromArray(['time_entry' => $params])->getEncoded(),
         ));
 
         return $this->lastResponse->getContent();
@@ -193,7 +193,7 @@ class TimeEntry extends AbstractApi
     {
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeXmlRequest(
             'DELETE',
-            '/time_entries/' . $id . '.xml'
+            '/time_entries/' . $id . '.xml',
         ));
 
         return $this->lastResponse->getContent();

--- a/src/Redmine/Api/User.php
+++ b/src/Redmine/Api/User.php
@@ -157,8 +157,8 @@ class User extends AbstractApi
                 [
                     'memberships',
                     'groups',
-                ]
-            )
+                ],
+            ),
         );
         $params['include'] = implode(',', $params['include']);
 
@@ -214,7 +214,7 @@ class User extends AbstractApi
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeXmlRequest(
             'POST',
             '/users.xml',
-            XmlSerializer::createFromArray(['user' => $params])->getEncoded()
+            XmlSerializer::createFromArray(['user' => $params])->getEncoded(),
         ));
 
         $body = $this->lastResponse->getContent();
@@ -250,7 +250,7 @@ class User extends AbstractApi
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeXmlRequest(
             'PUT',
             '/users/' . urlencode(strval($id)) . '.xml',
-            XmlSerializer::createFromArray(['user' => $params])->getEncoded()
+            XmlSerializer::createFromArray(['user' => $params])->getEncoded(),
         ));
 
         return $this->lastResponse->getContent();
@@ -269,7 +269,7 @@ class User extends AbstractApi
     {
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeXmlRequest(
             'DELETE',
-            '/users/' . $id . '.xml'
+            '/users/' . $id . '.xml',
         ));
 
         return $this->lastResponse->getContent();

--- a/src/Redmine/Api/Version.php
+++ b/src/Redmine/Api/Version.php
@@ -40,7 +40,7 @@ class Version extends AbstractApi
         if (! is_int($projectIdentifier) && ! is_string($projectIdentifier)) {
             throw new InvalidParameterException(sprintf(
                 '%s(): Argument #1 ($projectIdentifier) must be of type int or string',
-                __METHOD__
+                __METHOD__,
             ));
         }
 
@@ -190,7 +190,7 @@ class Version extends AbstractApi
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeXmlRequest(
             'POST',
             '/projects/' . $project . '/versions.xml',
-            XmlSerializer::createFromArray(['version' => $params])->getEncoded()
+            XmlSerializer::createFromArray(['version' => $params])->getEncoded(),
         ));
 
         $body = $this->lastResponse->getContent();
@@ -227,7 +227,7 @@ class Version extends AbstractApi
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeXmlRequest(
             'PUT',
             '/versions/' . $id . '.xml',
-            XmlSerializer::createFromArray(['version' => $params])->getEncoded()
+            XmlSerializer::createFromArray(['version' => $params])->getEncoded(),
         ));
 
         return $this->lastResponse->getContent();
@@ -272,7 +272,7 @@ class Version extends AbstractApi
     {
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeXmlRequest(
             'DELETE',
-            '/versions/' . $id . '.xml'
+            '/versions/' . $id . '.xml',
         ));
 
         return $this->lastResponse->getContent();

--- a/src/Redmine/Api/Wiki.php
+++ b/src/Redmine/Api/Wiki.php
@@ -40,7 +40,7 @@ class Wiki extends AbstractApi
         if (! is_int($projectIdentifier) && ! is_string($projectIdentifier)) {
             throw new InvalidParameterException(sprintf(
                 '%s(): Argument #1 ($projectIdentifier) must be of type int or string',
-                __METHOD__
+                __METHOD__,
             ));
         }
 
@@ -148,7 +148,7 @@ class Wiki extends AbstractApi
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeXmlRequest(
             'PUT',
             '/projects/' . $project . '/wiki/' . urlencode($page) . '.xml',
-            XmlSerializer::createFromArray(['wiki_page' => $params])->getEncoded()
+            XmlSerializer::createFromArray(['wiki_page' => $params])->getEncoded(),
         ));
 
         $body = $this->lastResponse->getContent();
@@ -190,7 +190,7 @@ class Wiki extends AbstractApi
     {
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeXmlRequest(
             'DELETE',
-            '/projects/' . $project . '/wiki/' . urlencode($page) . '.xml'
+            '/projects/' . $project . '/wiki/' . urlencode($page) . '.xml',
         ));
 
         return $this->lastResponse->getContent();

--- a/src/Redmine/Client/NativeCurlClient.php
+++ b/src/Redmine/Client/NativeCurlClient.php
@@ -70,13 +70,13 @@ final class NativeCurlClient implements Client, HttpClient
             $request->getMethod(),
             $request->getPath(),
             $request->getContent(),
-            $request->getContentType()
+            $request->getContentType(),
         );
 
         return HttpFactory::makeResponse(
             $this->lastResponseStatusCode,
             $this->lastResponseContentType,
-            $this->lastResponseBody
+            $this->lastResponseBody,
         );
     }
 

--- a/src/Redmine/Client/Psr18Client.php
+++ b/src/Redmine/Client/Psr18Client.php
@@ -53,9 +53,9 @@ final class Psr18Client implements Client, HttpClient
                     '%s(): Providing Argument #2 ($requestFactory) as %s is deprecated since v2.3.0, please provide as %s instead.',
                     __METHOD__,
                     ServerRequestFactoryInterface::class,
-                    RequestFactoryInterface::class
+                    RequestFactoryInterface::class,
                 ),
-                E_USER_DEPRECATED
+                E_USER_DEPRECATED,
             );
 
             $requestFactory = $this->handleServerRequestFactory($requestFactory);
@@ -65,7 +65,7 @@ final class Psr18Client implements Client, HttpClient
             throw new Exception(sprintf(
                 '%s(): Argument #2 ($requestFactory) must be of type %s',
                 __METHOD__,
-                RequestFactoryInterface::class
+                RequestFactoryInterface::class,
             ));
         }
 
@@ -88,13 +88,13 @@ final class Psr18Client implements Client, HttpClient
             $request->getMethod(),
             $request->getPath(),
             $request->getContent(),
-            $request->getContentType()
+            $request->getContentType(),
         );
 
         return HttpFactory::makeResponse(
             $response->getStatusCode(),
             $response->getHeaderLine('Content-Type'),
-            strval($response->getBody())
+            strval($response->getBody()),
         );
     }
 
@@ -231,7 +231,7 @@ final class Psr18Client implements Client, HttpClient
     {
         $request = $this->requestFactory->createRequest(
             $method,
-            $this->url . $path
+            $this->url . $path,
         );
 
         // Set Authentication header
@@ -239,7 +239,7 @@ final class Psr18Client implements Client, HttpClient
         if (null !== $this->password) {
             $request = $request->withHeader(
                 'Authorization',
-                'Basic ' . base64_encode($this->apikeyOrUsername . ':' . $this->password)
+                'Basic ' . base64_encode($this->apikeyOrUsername . ':' . $this->password),
             );
         } else {
             $request = $request->withHeader('X-Redmine-API-Key', $this->apikeyOrUsername);
@@ -257,18 +257,18 @@ final class Psr18Client implements Client, HttpClient
                     @trigger_error('Uploading an attachment by filepath is deprecated since v2.1.0, use file_get_contents() to upload the file content instead.', E_USER_DEPRECATED);
 
                     $request = $request->withBody(
-                        $this->streamFactory->createStreamFromFile($body)
+                        $this->streamFactory->createStreamFromFile($body),
                     );
                 } elseif ('' !== $body) {
                     $request = $request->withBody(
-                        $this->streamFactory->createStream($body)
+                        $this->streamFactory->createStream($body),
                     );
                 }
                 break;
             case 'PUT':
                 if ('' !== $body) {
                     $request = $request->withBody(
-                        $this->streamFactory->createStream($body)
+                        $this->streamFactory->createStream($body),
                     );
                 }
                 break;

--- a/src/Redmine/Exception/UnexpectedResponseException.php
+++ b/src/Redmine/Exception/UnexpectedResponseException.php
@@ -26,7 +26,7 @@ final class UnexpectedResponseException extends RuntimeException implements Redm
         $e = new self(
             'The Redmine server replied with an unexpected response.',
             ($prev !== null) ? $prev->getCode() : 1,
-            $prev
+            $prev,
         );
 
         $e->response = $response;

--- a/src/Redmine/Serializer/JsonSerializer.php
+++ b/src/Redmine/Serializer/JsonSerializer.php
@@ -70,7 +70,7 @@ final class JsonSerializer implements Stringable
                 $encoded,
                 true,
                 512,
-                \JSON_THROW_ON_ERROR
+                \JSON_THROW_ON_ERROR,
             );
         } catch (JsonException $e) {
             throw new SerializerException('Catched error "' . $e->getMessage() . '" while decoding JSON: ' . $encoded, $e->getCode(), $e);
@@ -85,13 +85,13 @@ final class JsonSerializer implements Stringable
             $this->encoded = json_encode(
                 $normalized,
                 \JSON_THROW_ON_ERROR,
-                512
+                512,
             );
         } catch (JsonException $e) {
             throw new SerializerException(
                 'Could not encode JSON from array: ' . $e->getMessage(),
                 $e->getCode(),
-                $e
+                $e,
             );
         }
     }

--- a/src/Redmine/Serializer/XmlSerializer.php
+++ b/src/Redmine/Serializer/XmlSerializer.php
@@ -85,7 +85,7 @@ final class XmlSerializer implements Stringable
             throw new SerializerException(
                 'Catched errors: "' . implode('", "', $errors) . '" while decoding XML: ' . $encoded,
                 $e->getCode(),
-                $e
+                $e,
             );
         } finally {
             libxml_use_internal_errors($prevSetting);
@@ -127,7 +127,7 @@ final class XmlSerializer implements Stringable
             throw new SerializerException(
                 'Could not create XML from array: "' . implode('", "', $errors) . '"',
                 $e->getCode(),
-                $e
+                $e,
             );
         } finally {
             libxml_use_internal_errors($prevSetting);

--- a/tests/Behat/Bootstrap/AttachmentContextTrait.php
+++ b/tests/Behat/Bootstrap/AttachmentContextTrait.php
@@ -27,7 +27,7 @@ trait AttachmentContextTrait
 
         $this->registerClientResponse(
             $api->upload(file_get_contents($filepath), $data),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 
@@ -47,7 +47,7 @@ trait AttachmentContextTrait
 
         $this->registerClientResponse(
             $api->update($attachmentId, $data),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 
@@ -61,7 +61,7 @@ trait AttachmentContextTrait
 
         $this->registerClientResponse(
             $api->show($attachmentId),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 
@@ -75,7 +75,7 @@ trait AttachmentContextTrait
 
         $this->registerClientResponse(
             $api->download($attachmentId),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 
@@ -89,7 +89,7 @@ trait AttachmentContextTrait
 
         $this->registerClientResponse(
             $api->remove($attachmentId),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 }

--- a/tests/Behat/Bootstrap/FeatureContext.php
+++ b/tests/Behat/Bootstrap/FeatureContext.php
@@ -101,7 +101,7 @@ final class FeatureContext extends TestCase implements Context
 
         $this->client = new NativeCurlClient(
             $this->redmine->getRedmineUrl(),
-            $this->redmine->getApiKey()
+            $this->redmine->getApiKey(),
         );
     }
 
@@ -125,7 +125,7 @@ final class FeatureContext extends TestCase implements Context
         $this->assertSame(
             $statusCode,
             $this->lastResponse->getStatusCode(),
-            'Raw response content: ' . $this->lastResponse->getContent()
+            'Raw response content: ' . $this->lastResponse->getContent(),
         );
     }
 
@@ -137,7 +137,7 @@ final class FeatureContext extends TestCase implements Context
         $this->assertStringStartsWith(
             $contentType,
             $this->lastResponse->getContentType(),
-            'Raw response content: ' . $this->lastResponse->getContent()
+            'Raw response content: ' . $this->lastResponse->getContent(),
         );
     }
 

--- a/tests/Behat/Bootstrap/GroupContextTrait.php
+++ b/tests/Behat/Bootstrap/GroupContextTrait.php
@@ -39,7 +39,7 @@ trait GroupContextTrait
 
         $this->registerClientResponse(
             $api->create($data),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 
@@ -53,7 +53,7 @@ trait GroupContextTrait
 
         $this->registerClientResponse(
             $api->list(),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 
@@ -67,7 +67,7 @@ trait GroupContextTrait
 
         $this->registerClientResponse(
             $api->listNames(),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 
@@ -81,7 +81,7 @@ trait GroupContextTrait
 
         $this->registerClientResponse(
             $api->show($groupId),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 
@@ -101,7 +101,7 @@ trait GroupContextTrait
 
         $this->registerClientResponse(
             $api->update($groupId, $data),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 
@@ -115,7 +115,7 @@ trait GroupContextTrait
 
         $this->registerClientResponse(
             $api->addUser($groupId, $userId),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 
@@ -129,7 +129,7 @@ trait GroupContextTrait
 
         $this->registerClientResponse(
             $api->removeUser($groupId, $userId),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 
@@ -143,7 +143,7 @@ trait GroupContextTrait
 
         $this->registerClientResponse(
             $api->remove($groupId),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 }

--- a/tests/Behat/Bootstrap/IssueCategoryContextTrait.php
+++ b/tests/Behat/Bootstrap/IssueCategoryContextTrait.php
@@ -25,7 +25,7 @@ trait IssueCategoryContextTrait
 
         $this->registerClientResponse(
             $api->create($identifier, $data),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 
@@ -45,7 +45,7 @@ trait IssueCategoryContextTrait
 
         $this->registerClientResponse(
             $api->update($id, $data),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 
@@ -59,7 +59,7 @@ trait IssueCategoryContextTrait
 
         $this->registerClientResponse(
             $api->remove($id),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 }

--- a/tests/Behat/Bootstrap/IssueContextTrait.php
+++ b/tests/Behat/Bootstrap/IssueContextTrait.php
@@ -26,7 +26,7 @@ trait IssueContextTrait
 
         $this->registerClientResponse(
             $api->create($data),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 
@@ -46,7 +46,7 @@ trait IssueContextTrait
 
         $this->registerClientResponse(
             $api->update($issueId, $data),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 
@@ -60,7 +60,7 @@ trait IssueContextTrait
 
         $this->registerClientResponse(
             $api->show($issueId),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 
@@ -74,7 +74,7 @@ trait IssueContextTrait
 
         $this->registerClientResponse(
             $api->addWatcher($issueId, $userId),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 
@@ -88,7 +88,7 @@ trait IssueContextTrait
 
         $this->registerClientResponse(
             $api->removeWatcher($issueId, $userId),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 
@@ -102,7 +102,7 @@ trait IssueContextTrait
 
         $this->registerClientResponse(
             $api->remove($issueId),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 }

--- a/tests/Behat/Bootstrap/IssueRelationContextTrait.php
+++ b/tests/Behat/Bootstrap/IssueRelationContextTrait.php
@@ -25,7 +25,7 @@ trait IssueRelationContextTrait
 
         $this->registerClientResponse(
             $api->create($issueId, $data),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 
@@ -39,7 +39,7 @@ trait IssueRelationContextTrait
 
         $this->registerClientResponse(
             $api->remove($relationId),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 }

--- a/tests/Behat/Bootstrap/MembershipContextTrait.php
+++ b/tests/Behat/Bootstrap/MembershipContextTrait.php
@@ -29,7 +29,7 @@ trait MembershipContextTrait
 
         $this->registerClientResponse(
             $api->create($identifier, $data),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 
@@ -53,7 +53,7 @@ trait MembershipContextTrait
 
         $this->registerClientResponse(
             $api->update($id, $data),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 
@@ -67,7 +67,7 @@ trait MembershipContextTrait
 
         $this->registerClientResponse(
             $api->remove($id),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 
@@ -81,7 +81,7 @@ trait MembershipContextTrait
 
         $this->registerClientResponse(
             $api->removeMember($identifier, (int) $userId),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 }

--- a/tests/Behat/Bootstrap/ProjectContextTrait.php
+++ b/tests/Behat/Bootstrap/ProjectContextTrait.php
@@ -39,7 +39,7 @@ trait ProjectContextTrait
 
         $this->registerClientResponse(
             $api->create($data),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 
@@ -53,7 +53,7 @@ trait ProjectContextTrait
 
         $this->registerClientResponse(
             $api->list(),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 
@@ -67,7 +67,7 @@ trait ProjectContextTrait
 
         $this->registerClientResponse(
             $api->show($identifier),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 
@@ -87,7 +87,7 @@ trait ProjectContextTrait
 
         $this->registerClientResponse(
             $api->update($identifier, $data),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 
@@ -101,7 +101,7 @@ trait ProjectContextTrait
 
         $this->registerClientResponse(
             $api->close($identifier),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 
@@ -115,7 +115,7 @@ trait ProjectContextTrait
 
         $this->registerClientResponse(
             $api->reopen($identifier),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 
@@ -129,7 +129,7 @@ trait ProjectContextTrait
 
         $this->registerClientResponse(
             $api->archive($identifier),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 
@@ -143,7 +143,7 @@ trait ProjectContextTrait
 
         $this->registerClientResponse(
             $api->unarchive($identifier),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 
@@ -157,7 +157,7 @@ trait ProjectContextTrait
 
         $this->registerClientResponse(
             $api->remove($identifier),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 }

--- a/tests/Behat/Bootstrap/TimeEntryContextTrait.php
+++ b/tests/Behat/Bootstrap/TimeEntryContextTrait.php
@@ -25,7 +25,7 @@ trait TimeEntryContextTrait
 
         $this->registerClientResponse(
             $api->create($data),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 
@@ -45,7 +45,7 @@ trait TimeEntryContextTrait
 
         $this->registerClientResponse(
             $api->update($id, $data),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 
@@ -59,7 +59,7 @@ trait TimeEntryContextTrait
 
         $this->registerClientResponse(
             $api->show($activityId),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 
@@ -73,7 +73,7 @@ trait TimeEntryContextTrait
 
         $this->registerClientResponse(
             $api->remove($activityId),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 }

--- a/tests/Behat/Bootstrap/UserContextTrait.php
+++ b/tests/Behat/Bootstrap/UserContextTrait.php
@@ -25,7 +25,7 @@ trait UserContextTrait
 
         $this->registerClientResponse(
             $api->create($data),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 
@@ -45,7 +45,7 @@ trait UserContextTrait
 
         $this->registerClientResponse(
             $api->update($id, $data),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 
@@ -59,7 +59,7 @@ trait UserContextTrait
 
         $this->registerClientResponse(
             $api->show($userId),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 
@@ -73,7 +73,7 @@ trait UserContextTrait
 
         $this->registerClientResponse(
             $api->remove($userId),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 }

--- a/tests/Behat/Bootstrap/VersionContextTrait.php
+++ b/tests/Behat/Bootstrap/VersionContextTrait.php
@@ -20,7 +20,7 @@ trait VersionContextTrait
             new TableNode([
                 ['property', 'value'],
                 ['name', $versionName],
-            ])
+            ]),
         );
     }
 
@@ -40,7 +40,7 @@ trait VersionContextTrait
 
         $this->registerClientResponse(
             $api->create($identifier, $data),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 
@@ -60,7 +60,7 @@ trait VersionContextTrait
 
         $this->registerClientResponse(
             $api->update($id, $data),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 
@@ -74,7 +74,7 @@ trait VersionContextTrait
 
         $this->registerClientResponse(
             $api->show($versionId),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 
@@ -88,7 +88,7 @@ trait VersionContextTrait
 
         $this->registerClientResponse(
             $api->remove($versionId),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 }

--- a/tests/Behat/Bootstrap/WikiContextTrait.php
+++ b/tests/Behat/Bootstrap/WikiContextTrait.php
@@ -18,7 +18,7 @@ trait WikiContextTrait
         $this->iCreateAWikiPageWithNameAndProjectIdentifierWithTheFollowingData(
             $pageName,
             $identifier,
-            new TableNode([['property', 'value']])
+            new TableNode([['property', 'value']]),
         );
     }
 
@@ -34,7 +34,7 @@ trait WikiContextTrait
 
         $this->registerClientResponse(
             $api->create($identifier, $pageName, $data),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 
@@ -48,7 +48,7 @@ trait WikiContextTrait
 
         $this->registerClientResponse(
             $api->show($identifier, $pageName),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 
@@ -64,7 +64,7 @@ trait WikiContextTrait
 
         $this->registerClientResponse(
             $api->update($identifier, $pageName, $data),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 
@@ -78,7 +78,7 @@ trait WikiContextTrait
 
         $this->registerClientResponse(
             $api->remove($identifier, $pageName),
-            $api->getLastResponse()
+            $api->getLastResponse(),
         );
     }
 

--- a/tests/Fixtures/AssertingHttpClient.php
+++ b/tests/Fixtures/AssertingHttpClient.php
@@ -80,7 +80,7 @@ final class AssertingHttpClient implements HttpClient
                 'Mssing request data for Request "%s %s" with Content-Type "%s".',
                 $request->getMethod(),
                 $request->getPath(),
-                $request->getContentType()
+                $request->getContentType(),
             ));
         }
 

--- a/tests/Integration/Psr18ClientRequestGenerationTest.php
+++ b/tests/Integration/Psr18ClientRequestGenerationTest.php
@@ -51,7 +51,7 @@ class Psr18ClientRequestGenerationTest extends TestCase
                 '%s %s HTTP/%s',
                 $request->getMethod(),
                 $request->getUri()->__toString(),
-                $request->getProtocolVersion()
+                $request->getProtocolVersion(),
             );
 
             $fullRequest = $statusLine . \PHP_EOL .
@@ -92,7 +92,7 @@ class Psr18ClientRequestGenerationTest extends TestCase
             $streamFactory,
             $url,
             $apikeyOrUsername,
-            $pwd
+            $pwd,
         );
 
         if (null !== $impersonateUser) {

--- a/tests/Unit/Api/AbstractApi/DeleteTest.php
+++ b/tests/Unit/Api/AbstractApi/DeleteTest.php
@@ -27,7 +27,7 @@ class DeleteTest extends TestCase
                 200,
                 'application/xml',
                 '<?xml version="1.0"?><issue/>',
-            ]
+            ],
         );
 
         $api = new class ($client) extends AbstractApi {};

--- a/tests/Unit/Api/AbstractApi/DeleteTest.php
+++ b/tests/Unit/Api/AbstractApi/DeleteTest.php
@@ -26,7 +26,7 @@ class DeleteTest extends TestCase
                 '',
                 200,
                 'application/xml',
-                '<?xml version="1.0"?><issue/>'
+                '<?xml version="1.0"?><issue/>',
             ]
         );
 

--- a/tests/Unit/Api/AbstractApi/GetTest.php
+++ b/tests/Unit/Api/AbstractApi/GetTest.php
@@ -28,7 +28,7 @@ class GetTest extends TestCase
                 200,
                 'application/json',
                 '{"foo_bar": 12345}',
-            ]
+            ],
         );
 
         $api = new class ($client) extends AbstractApi {};
@@ -39,7 +39,7 @@ class GetTest extends TestCase
         // Perform the tests
         $this->assertSame(
             ['foo_bar' => 12345],
-            $method->invoke($api, 'path.json')
+            $method->invoke($api, 'path.json'),
         );
     }
 

--- a/tests/Unit/Api/AbstractApi/GetTest.php
+++ b/tests/Unit/Api/AbstractApi/GetTest.php
@@ -27,7 +27,7 @@ class GetTest extends TestCase
                 '',
                 200,
                 'application/json',
-                '{"foo_bar": 12345}'
+                '{"foo_bar": 12345}',
             ]
         );
 

--- a/tests/Unit/Api/AbstractApi/PostTest.php
+++ b/tests/Unit/Api/AbstractApi/PostTest.php
@@ -27,7 +27,7 @@ class PostTest extends TestCase
                 '',
                 200,
                 'application/xml',
-                '<?xml version="1.0"?><issue/>'
+                '<?xml version="1.0"?><issue/>',
             ]
         );
 

--- a/tests/Unit/Api/AbstractApi/PostTest.php
+++ b/tests/Unit/Api/AbstractApi/PostTest.php
@@ -28,7 +28,7 @@ class PostTest extends TestCase
                 200,
                 'application/xml',
                 '<?xml version="1.0"?><issue/>',
-            ]
+            ],
         );
 
         $api = new class ($client) extends AbstractApi {};

--- a/tests/Unit/Api/AbstractApi/PutTest.php
+++ b/tests/Unit/Api/AbstractApi/PutTest.php
@@ -27,7 +27,7 @@ class PutTest extends TestCase
                 '',
                 200,
                 'application/xml',
-                '<?xml version="1.0"?><issue/>'
+                '<?xml version="1.0"?><issue/>',
             ]
         );
 

--- a/tests/Unit/Api/AbstractApi/PutTest.php
+++ b/tests/Unit/Api/AbstractApi/PutTest.php
@@ -28,7 +28,7 @@ class PutTest extends TestCase
                 200,
                 'application/xml',
                 '<?xml version="1.0"?><issue/>',
-            ]
+            ],
         );
 
         $api = new class ($client) extends AbstractApi {};

--- a/tests/Unit/Api/AbstractApiTest.php
+++ b/tests/Unit/Api/AbstractApiTest.php
@@ -219,14 +219,14 @@ class AbstractApiTest extends TestCase
                 '200.json',
                 'application/json',
                 '',
-                200
+                200,
             ],
             [
                 'GET',
                 '500.json',
                 'application/json',
                 '',
-                500
+                500,
             ]
         );
 

--- a/tests/Unit/Api/AbstractApiTest.php
+++ b/tests/Unit/Api/AbstractApiTest.php
@@ -67,13 +67,13 @@ class AbstractApiTest extends TestCase
             function ($errno, $errstr): bool {
                 $this->assertSame(
                     '`Redmine\Api\AbstractApi::get()` is deprecated since v2.6.0, use `\Redmine\Http\HttpClient::request()` instead.',
-                    $errstr
+                    $errstr,
                 );
 
                 restore_error_handler();
                 return true;
             },
-            E_USER_DEPRECATED
+            E_USER_DEPRECATED,
         );
 
         $api->runGet('/path.json');
@@ -104,13 +104,13 @@ class AbstractApiTest extends TestCase
             function ($errno, $errstr): bool {
                 $this->assertSame(
                     '`Redmine\Api\AbstractApi::post()` is deprecated since v2.6.0, use `\Redmine\Http\HttpClient::request()` instead.',
-                    $errstr
+                    $errstr,
                 );
 
                 restore_error_handler();
                 return true;
             },
-            E_USER_DEPRECATED
+            E_USER_DEPRECATED,
         );
 
         $api->runPost('/path.json', 'data');
@@ -132,13 +132,13 @@ class AbstractApiTest extends TestCase
             function ($errno, $errstr): bool {
                 $this->assertSame(
                     '`Redmine\Api\AbstractApi::put()` is deprecated since v2.6.0, use `\Redmine\Http\HttpClient::request()` instead.',
-                    $errstr
+                    $errstr,
                 );
 
                 restore_error_handler();
                 return true;
             },
-            E_USER_DEPRECATED
+            E_USER_DEPRECATED,
         );
 
         $api->runPut('/path.json', 'data');
@@ -160,13 +160,13 @@ class AbstractApiTest extends TestCase
             function ($errno, $errstr): bool {
                 $this->assertSame(
                     '`Redmine\Api\AbstractApi::delete()` is deprecated since v2.6.0, use `\Redmine\Http\HttpClient::request()` instead.',
-                    $errstr
+                    $errstr,
                 );
 
                 restore_error_handler();
                 return true;
             },
-            E_USER_DEPRECATED
+            E_USER_DEPRECATED,
         );
 
         $api->runDelete('/path.json');
@@ -227,7 +227,7 @@ class AbstractApiTest extends TestCase
                 'application/json',
                 '',
                 500,
-            ]
+            ],
         );
 
         $api1 = new class ($client) extends AbstractApi {

--- a/tests/Unit/Api/Attachment/DownloadTest.php
+++ b/tests/Unit/Api/Attachment/DownloadTest.php
@@ -26,7 +26,7 @@ class DownloadTest extends TestCase
                 '',
                 $responseCode,
                 'application/json',
-                $response
+                $response,
             ]
         );
 

--- a/tests/Unit/Api/Attachment/DownloadTest.php
+++ b/tests/Unit/Api/Attachment/DownloadTest.php
@@ -27,7 +27,7 @@ class DownloadTest extends TestCase
                 $responseCode,
                 'application/json',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/Attachment/RemoveTest.php
+++ b/tests/Unit/Api/Attachment/RemoveTest.php
@@ -23,7 +23,7 @@ class RemoveTest extends TestCase
                 '',
                 204,
                 '',
-                ''
+                '',
             ]
         );
 

--- a/tests/Unit/Api/Attachment/RemoveTest.php
+++ b/tests/Unit/Api/Attachment/RemoveTest.php
@@ -24,7 +24,7 @@ class RemoveTest extends TestCase
                 204,
                 '',
                 '',
-            ]
+            ],
         );
 
         $api = new Attachment($client);

--- a/tests/Unit/Api/Attachment/ShowTest.php
+++ b/tests/Unit/Api/Attachment/ShowTest.php
@@ -26,7 +26,7 @@ class ShowTest extends TestCase
                 '',
                 200,
                 'application/json',
-                $response
+                $response,
             ]
         );
 

--- a/tests/Unit/Api/Attachment/ShowTest.php
+++ b/tests/Unit/Api/Attachment/ShowTest.php
@@ -27,7 +27,7 @@ class ShowTest extends TestCase
                 200,
                 'application/json',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/Attachment/UpdateTest.php
+++ b/tests/Unit/Api/Attachment/UpdateTest.php
@@ -28,7 +28,7 @@ class UpdateTest extends TestCase
                 204,
                 '',
                 '',
-            ]
+            ],
         );
 
         // Create the object under test
@@ -66,7 +66,7 @@ class UpdateTest extends TestCase
                 403,
                 '',
                 '',
-            ]
+            ],
         );
 
         $api = new Attachment($client);

--- a/tests/Unit/Api/Attachment/UpdateTest.php
+++ b/tests/Unit/Api/Attachment/UpdateTest.php
@@ -27,7 +27,7 @@ class UpdateTest extends TestCase
                 $expectedContent,
                 204,
                 '',
-                ''
+                '',
             ]
         );
 

--- a/tests/Unit/Api/Attachment/UploadTest.php
+++ b/tests/Unit/Api/Attachment/UploadTest.php
@@ -26,7 +26,7 @@ class UploadTest extends TestCase
                 $expectedAttachment,
                 $responseCode,
                 'application/json',
-                $response
+                $response,
             ]
         );
 
@@ -61,7 +61,7 @@ class UploadTest extends TestCase
             'test attachment with params' => [
                 'attachment-content',
                 [
-                    'filename' => 'testfile.txt'
+                    'filename' => 'testfile.txt',
                 ],
                 'attachment-content',
                 '/uploads.json?filename=testfile.txt',
@@ -72,7 +72,7 @@ class UploadTest extends TestCase
             'test attachment with filepath' => [
                 '/path/to/testfile_01.txt',
                 [
-                    'filename' => 'testfile.txt'
+                    'filename' => 'testfile.txt',
                 ],
                 '/path/to/testfile_01.txt',
                 '/uploads.json?filename=testfile.txt',

--- a/tests/Unit/Api/Attachment/UploadTest.php
+++ b/tests/Unit/Api/Attachment/UploadTest.php
@@ -27,7 +27,7 @@ class UploadTest extends TestCase
                 $responseCode,
                 'application/json',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/CustomField/ListTest.php
+++ b/tests/Unit/Api/CustomField/ListTest.php
@@ -79,7 +79,7 @@ class ListTest extends TestCase
         $client->expects($this->exactly(3))
             ->method('requestGet')
             ->with(
-                $this->stringStartsWith('/custom_fields.json')
+                $this->stringStartsWith('/custom_fields.json'),
             )
             ->willReturn(true);
         $client->expects($this->exactly(3))
@@ -113,7 +113,7 @@ class ListTest extends TestCase
         $client->expects($this->once())
             ->method('requestGet')
             ->with(
-                $this->stringStartsWith('/custom_fields.json')
+                $this->stringStartsWith('/custom_fields.json'),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))

--- a/tests/Unit/Api/CustomFieldTest.php
+++ b/tests/Unit/Api/CustomFieldTest.php
@@ -27,13 +27,13 @@ class CustomFieldTest extends TestCase
             function ($errno, $errstr): bool {
                 $this->assertSame(
                     '`Redmine\Api\CustomField::all()` is deprecated since v2.4.0, use `Redmine\Api\CustomField::list()` instead.',
-                    $errstr
+                    $errstr,
                 );
 
                 restore_error_handler();
                 return true;
             },
-            E_USER_DEPRECATED
+            E_USER_DEPRECATED,
         );
 
         $api->all();
@@ -91,7 +91,7 @@ class CustomFieldTest extends TestCase
         $client->expects($this->once())
             ->method('requestGet')
             ->with(
-                $this->stringContains('not-used')
+                $this->stringContains('not-used'),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))
@@ -126,7 +126,7 @@ class CustomFieldTest extends TestCase
         $client->expects($this->exactly(3))
             ->method('requestGet')
             ->with(
-                $this->stringStartsWith('/custom_fields.json')
+                $this->stringStartsWith('/custom_fields.json'),
             )
             ->willReturn(true);
         $client->expects($this->exactly(3))
@@ -163,7 +163,7 @@ class CustomFieldTest extends TestCase
         $client->expects($this->once())
             ->method('requestGet')
             ->with(
-                $this->stringStartsWith('/custom_fields.json')
+                $this->stringStartsWith('/custom_fields.json'),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))
@@ -200,7 +200,7 @@ class CustomFieldTest extends TestCase
         $client->expects($this->once())
             ->method('requestGet')
             ->with(
-                $this->stringStartsWith('/custom_fields.json')
+                $this->stringStartsWith('/custom_fields.json'),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))
@@ -234,7 +234,7 @@ class CustomFieldTest extends TestCase
         $client->expects($this->once())
             ->method('requestGet')
             ->with(
-                $this->stringStartsWith('/custom_fields.json')
+                $this->stringStartsWith('/custom_fields.json'),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))
@@ -269,7 +269,7 @@ class CustomFieldTest extends TestCase
         $client->expects($this->exactly(2))
             ->method('requestGet')
             ->with(
-                $this->stringStartsWith('/custom_fields.json')
+                $this->stringStartsWith('/custom_fields.json'),
             )
             ->willReturn(true);
         $client->expects($this->exactly(2))
@@ -300,7 +300,7 @@ class CustomFieldTest extends TestCase
         $client->expects($this->once())
             ->method('requestGet')
             ->with(
-                $this->stringStartsWith('/custom_fields.json')
+                $this->stringStartsWith('/custom_fields.json'),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))

--- a/tests/Unit/Api/Group/AddUserTest.php
+++ b/tests/Unit/Api/Group/AddUserTest.php
@@ -27,7 +27,7 @@ class AddUserTest extends TestCase
                 $expectedBody,
                 $responseCode,
                 'application/xml',
-                $response
+                $response,
             ]
         );
 
@@ -69,7 +69,7 @@ class AddUserTest extends TestCase
                 '<?xml version="1.0" encoding="UTF-8"?><user_id>2</user_id>',
                 500,
                 '',
-                ''
+                '',
             ]
         );
 

--- a/tests/Unit/Api/Group/AddUserTest.php
+++ b/tests/Unit/Api/Group/AddUserTest.php
@@ -28,7 +28,7 @@ class AddUserTest extends TestCase
                 $responseCode,
                 'application/xml',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test
@@ -70,7 +70,7 @@ class AddUserTest extends TestCase
                 500,
                 '',
                 '',
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/Group/CreateTest.php
+++ b/tests/Unit/Api/Group/CreateTest.php
@@ -32,7 +32,7 @@ class CreateTest extends TestCase
                 $responseCode,
                 'application/xml',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test
@@ -119,7 +119,7 @@ class CreateTest extends TestCase
                 500,
                 '',
                 '',
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/Group/CreateTest.php
+++ b/tests/Unit/Api/Group/CreateTest.php
@@ -31,7 +31,7 @@ class CreateTest extends TestCase
                 $expectedBody,
                 $responseCode,
                 'application/xml',
-                $response
+                $response,
             ]
         );
 
@@ -118,7 +118,7 @@ class CreateTest extends TestCase
                 '<?xml version="1.0" encoding="UTF-8"?><group><name>Group Name</name></group>',
                 500,
                 '',
-                ''
+                '',
             ]
         );
 

--- a/tests/Unit/Api/Group/ListNamesTest.php
+++ b/tests/Unit/Api/Group/ListNamesTest.php
@@ -29,7 +29,7 @@ class ListNamesTest extends TestCase
                 $responseCode,
                 'application/json',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test
@@ -94,7 +94,7 @@ class ListNamesTest extends TestCase
                     ]
                 }
                 JSON,
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/Group/ListNamesTest.php
+++ b/tests/Unit/Api/Group/ListNamesTest.php
@@ -50,7 +50,7 @@ class ListNamesTest extends TestCase
                     "groups": []
                 }
                 JSON,
-                []
+                [],
             ],
             'test with multiple groups' => [
                 '/groups.json',
@@ -68,7 +68,7 @@ class ListNamesTest extends TestCase
                     9 => "Group 1",
                     8 => "Group 2",
                     7 => "Group 3",
-                ]
+                ],
             ],
         ];
     }

--- a/tests/Unit/Api/Group/RemoveTest.php
+++ b/tests/Unit/Api/Group/RemoveTest.php
@@ -23,7 +23,7 @@ class RemoveTest extends TestCase
                 '',
                 204,
                 '',
-                ''
+                '',
             ]
         );
 

--- a/tests/Unit/Api/Group/RemoveTest.php
+++ b/tests/Unit/Api/Group/RemoveTest.php
@@ -24,7 +24,7 @@ class RemoveTest extends TestCase
                 204,
                 '',
                 '',
-            ]
+            ],
         );
 
         $api = new Group($client);

--- a/tests/Unit/Api/Group/RemoveUserTest.php
+++ b/tests/Unit/Api/Group/RemoveUserTest.php
@@ -23,7 +23,7 @@ class RemoveUserTest extends TestCase
                 '',
                 204,
                 '',
-                ''
+                '',
             ]
         );
 

--- a/tests/Unit/Api/Group/RemoveUserTest.php
+++ b/tests/Unit/Api/Group/RemoveUserTest.php
@@ -24,7 +24,7 @@ class RemoveUserTest extends TestCase
                 204,
                 '',
                 '',
-            ]
+            ],
         );
 
         $api = new Group($client);

--- a/tests/Unit/Api/Group/ShowTest.php
+++ b/tests/Unit/Api/Group/ShowTest.php
@@ -26,7 +26,7 @@ class ShowTest extends TestCase
                 '',
                 200,
                 'application/json',
-                $response
+                $response,
             ]
         );
 

--- a/tests/Unit/Api/Group/ShowTest.php
+++ b/tests/Unit/Api/Group/ShowTest.php
@@ -27,7 +27,7 @@ class ShowTest extends TestCase
                 200,
                 'application/json',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/Group/UpdateTest.php
+++ b/tests/Unit/Api/Group/UpdateTest.php
@@ -29,7 +29,7 @@ class UpdateTest extends TestCase
                 $responseCode,
                 '',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/Group/UpdateTest.php
+++ b/tests/Unit/Api/Group/UpdateTest.php
@@ -28,7 +28,7 @@ class UpdateTest extends TestCase
                 $expectedBody,
                 $responseCode,
                 '',
-                $response
+                $response,
             ]
         );
 

--- a/tests/Unit/Api/GroupTest.php
+++ b/tests/Unit/Api/GroupTest.php
@@ -29,13 +29,13 @@ class GroupTest extends TestCase
             function ($errno, $errstr): bool {
                 $this->assertSame(
                     '`Redmine\Api\Group::all()` is deprecated since v2.4.0, use `Redmine\Api\Group::list()` instead.',
-                    $errstr
+                    $errstr,
                 );
 
                 restore_error_handler();
                 return true;
             },
-            E_USER_DEPRECATED
+            E_USER_DEPRECATED,
         );
 
         $api->all();
@@ -95,8 +95,8 @@ class GroupTest extends TestCase
             ->with(
                 $this->logicalAnd(
                     $this->stringStartsWith('/groups.json'),
-                    $this->stringContains('not-used')
-                )
+                    $this->stringContains('not-used'),
+                ),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))
@@ -133,13 +133,13 @@ class GroupTest extends TestCase
             function ($errno, $errstr): bool {
                 $this->assertSame(
                     '`Redmine\Api\Group::listing()` is deprecated since v2.7.0, use `Redmine\Api\Group::listNames()` instead.',
-                    $errstr
+                    $errstr,
                 );
 
                 restore_error_handler();
                 return true;
             },
-            E_USER_DEPRECATED
+            E_USER_DEPRECATED,
         );
 
         $api->listing();
@@ -162,7 +162,7 @@ class GroupTest extends TestCase
         $client->expects($this->once())
             ->method('requestGet')
             ->with(
-                $this->stringStartsWith('/groups.json')
+                $this->stringStartsWith('/groups.json'),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))
@@ -196,7 +196,7 @@ class GroupTest extends TestCase
         $client->expects($this->once())
             ->method('requestGet')
             ->with(
-                $this->stringStartsWith('/groups.json')
+                $this->stringStartsWith('/groups.json'),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))
@@ -231,7 +231,7 @@ class GroupTest extends TestCase
         $client->expects($this->exactly(2))
             ->method('requestGet')
             ->with(
-                $this->stringStartsWith('/groups.json')
+                $this->stringStartsWith('/groups.json'),
             )
             ->willReturn(true);
         $client->expects($this->exactly(2))

--- a/tests/Unit/Api/Issue/AddNoteToIssueTest.php
+++ b/tests/Unit/Api/Issue/AddNoteToIssueTest.php
@@ -29,7 +29,7 @@ class AddNoteToIssueTest extends TestCase
                 $responseCode,
                 '',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/Issue/AddNoteToIssueTest.php
+++ b/tests/Unit/Api/Issue/AddNoteToIssueTest.php
@@ -28,7 +28,7 @@ class AddNoteToIssueTest extends TestCase
                 $expectedBody,
                 $responseCode,
                 '',
-                $response
+                $response,
             ]
         );
 

--- a/tests/Unit/Api/Issue/AddWatcherTest.php
+++ b/tests/Unit/Api/Issue/AddWatcherTest.php
@@ -27,7 +27,7 @@ class AddWatcherTest extends TestCase
                 $expectedBody,
                 $responseCode,
                 'application/xml',
-                $response
+                $response,
             ]
         );
 
@@ -69,7 +69,7 @@ class AddWatcherTest extends TestCase
                 '<?xml version="1.0" encoding="UTF-8"?><user_id>2</user_id>',
                 500,
                 '',
-                ''
+                '',
             ]
         );
 

--- a/tests/Unit/Api/Issue/AddWatcherTest.php
+++ b/tests/Unit/Api/Issue/AddWatcherTest.php
@@ -28,7 +28,7 @@ class AddWatcherTest extends TestCase
                 $responseCode,
                 'application/xml',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test
@@ -70,7 +70,7 @@ class AddWatcherTest extends TestCase
                 500,
                 '',
                 '',
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/Issue/AttachManyTest.php
+++ b/tests/Unit/Api/Issue/AttachManyTest.php
@@ -26,7 +26,7 @@ class AttachManyTest extends TestCase
                 $expectedBody,
                 $responseCode,
                 '',
-                $response
+                $response,
             ]
         );
 

--- a/tests/Unit/Api/Issue/AttachManyTest.php
+++ b/tests/Unit/Api/Issue/AttachManyTest.php
@@ -27,7 +27,7 @@ class AttachManyTest extends TestCase
                 $responseCode,
                 '',
                 $response,
-            ]
+            ],
         );
 
         // AttachMany the object under test

--- a/tests/Unit/Api/Issue/AttachTest.php
+++ b/tests/Unit/Api/Issue/AttachTest.php
@@ -26,7 +26,7 @@ class AttachTest extends TestCase
                 $expectedBody,
                 $responseCode,
                 '',
-                $response
+                $response,
             ]
         );
 

--- a/tests/Unit/Api/Issue/AttachTest.php
+++ b/tests/Unit/Api/Issue/AttachTest.php
@@ -27,7 +27,7 @@ class AttachTest extends TestCase
                 $responseCode,
                 '',
                 $response,
-            ]
+            ],
         );
 
         // Attach the object under test

--- a/tests/Unit/Api/Issue/CreateTest.php
+++ b/tests/Unit/Api/Issue/CreateTest.php
@@ -28,7 +28,7 @@ class CreateTest extends TestCase
                 $responseCode,
                 'application/xml',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test
@@ -244,7 +244,7 @@ class CreateTest extends TestCase
                 500,
                 '',
                 '',
-            ]
+            ],
         );
 
         // Create the object under test
@@ -277,7 +277,7 @@ class CreateTest extends TestCase
                 200,
                 'application/xml',
                 '<?xml version="1.0"?><issue></issue>',
-            ]
+            ],
         );
 
         // Create the object under test
@@ -314,7 +314,7 @@ class CreateTest extends TestCase
                 200,
                 'application/xml',
                 '<?xml version="1.0"?><issue></issue>',
-            ]
+            ],
         );
 
         // Create the object under test
@@ -351,7 +351,7 @@ class CreateTest extends TestCase
                 200,
                 'application/xml',
                 '<?xml version="1.0"?><issue></issue>',
-            ]
+            ],
         );
 
         // Create the object under test
@@ -388,7 +388,7 @@ class CreateTest extends TestCase
                 200,
                 'application/xml',
                 '<?xml version="1.0"?><issue></issue>',
-            ]
+            ],
         );
 
         // Create the object under test
@@ -425,7 +425,7 @@ class CreateTest extends TestCase
                 200,
                 'application/xml',
                 '<?xml version="1.0"?><issue></issue>',
-            ]
+            ],
         );
 
         // Create the object under test
@@ -511,7 +511,7 @@ class CreateTest extends TestCase
                 200,
                 'application/xml',
                 '<?xml version="1.0"?><issue></issue>',
-            ]
+            ],
         );
 
         $parameters = [

--- a/tests/Unit/Api/Issue/CreateTest.php
+++ b/tests/Unit/Api/Issue/CreateTest.php
@@ -27,7 +27,7 @@ class CreateTest extends TestCase
                 $expectedBody,
                 $responseCode,
                 'application/xml',
-                $response
+                $response,
             ]
         );
 
@@ -243,7 +243,7 @@ class CreateTest extends TestCase
                 '<?xml version="1.0" encoding="UTF-8"?><issue/>',
                 500,
                 '',
-                ''
+                '',
             ]
         );
 
@@ -267,7 +267,7 @@ class CreateTest extends TestCase
                 '',
                 200,
                 'application/json',
-                '{"issue_statuses":[{"name":"Status Name","id":123}]}'
+                '{"issue_statuses":[{"name":"Status Name","id":123}]}',
             ],
             [
                 'POST',
@@ -276,7 +276,7 @@ class CreateTest extends TestCase
                 '<?xml version="1.0"?><issue><status_id>123</status_id></issue>',
                 200,
                 'application/xml',
-                '<?xml version="1.0"?><issue></issue>'
+                '<?xml version="1.0"?><issue></issue>',
             ]
         );
 
@@ -304,7 +304,7 @@ class CreateTest extends TestCase
                 '',
                 200,
                 'application/json',
-                '{"projects":[{"name":"Project Name","id":3}]}'
+                '{"projects":[{"name":"Project Name","id":3}]}',
             ],
             [
                 'POST',
@@ -313,7 +313,7 @@ class CreateTest extends TestCase
                 '<?xml version="1.0"?><issue><project_id>3</project_id></issue>',
                 200,
                 'application/xml',
-                '<?xml version="1.0"?><issue></issue>'
+                '<?xml version="1.0"?><issue></issue>',
             ]
         );
 
@@ -341,7 +341,7 @@ class CreateTest extends TestCase
                 '',
                 200,
                 'application/json',
-                '{"issue_categories":[{"name":"Category Name","id":45}]}'
+                '{"issue_categories":[{"name":"Category Name","id":45}]}',
             ],
             [
                 'POST',
@@ -350,7 +350,7 @@ class CreateTest extends TestCase
                 '<?xml version="1.0"?><issue><project_id>3</project_id><category_id>45</category_id></issue>',
                 200,
                 'application/xml',
-                '<?xml version="1.0"?><issue></issue>'
+                '<?xml version="1.0"?><issue></issue>',
             ]
         );
 
@@ -378,7 +378,7 @@ class CreateTest extends TestCase
                 '',
                 200,
                 'application/json',
-                '{"trackers":[{"name":"Tracker Name","id":9}]}'
+                '{"trackers":[{"name":"Tracker Name","id":9}]}',
             ],
             [
                 'POST',
@@ -387,7 +387,7 @@ class CreateTest extends TestCase
                 '<?xml version="1.0"?><issue><tracker_id>9</tracker_id></issue>',
                 200,
                 'application/xml',
-                '<?xml version="1.0"?><issue></issue>'
+                '<?xml version="1.0"?><issue></issue>',
             ]
         );
 
@@ -415,7 +415,7 @@ class CreateTest extends TestCase
                 '',
                 200,
                 'application/json',
-                '{"users":[{"login":"Author Name","id":5},{"login":"Assigned to User Name","id":6}]}'
+                '{"users":[{"login":"Author Name","id":5},{"login":"Assigned to User Name","id":6}]}',
             ],
             [
                 'POST',
@@ -424,7 +424,7 @@ class CreateTest extends TestCase
                 '<?xml version="1.0"?><issue><assigned_to_id>6</assigned_to_id><author_id>5</author_id></issue>',
                 200,
                 'application/xml',
-                '<?xml version="1.0"?><issue></issue>'
+                '<?xml version="1.0"?><issue></issue>',
             ]
         );
 
@@ -455,7 +455,7 @@ class CreateTest extends TestCase
                 '',
                 200,
                 'application/json',
-                '{"projects":[{"name":"Project Name","id":3}]}'
+                '{"projects":[{"name":"Project Name","id":3}]}',
             ],
             [
                 'GET',
@@ -464,7 +464,7 @@ class CreateTest extends TestCase
                 '',
                 200,
                 'application/json',
-                '{"issue_categories":[{"name":"Category Name","id":45}]}'
+                '{"issue_categories":[{"name":"Category Name","id":45}]}',
             ],
             [
                 'GET',
@@ -473,7 +473,7 @@ class CreateTest extends TestCase
                 '',
                 200,
                 'application/json',
-                '{"issue_statuses":[{"name":"Status Name","id":123}]}'
+                '{"issue_statuses":[{"name":"Status Name","id":123}]}',
             ],
             [
                 'GET',
@@ -482,7 +482,7 @@ class CreateTest extends TestCase
                 '',
                 200,
                 'application/json',
-                '{"trackers":[{"name":"Tracker Name","id":9}]}'
+                '{"trackers":[{"name":"Tracker Name","id":9}]}',
             ],
             [
                 'GET',
@@ -491,7 +491,7 @@ class CreateTest extends TestCase
                 '',
                 200,
                 'application/json',
-                '{"users":[{"login":"Author Name","id":5},{"login":"Assigned to User Name","id":6}]}'
+                '{"users":[{"login":"Author Name","id":5},{"login":"Assigned to User Name","id":6}]}',
             ],
             [
                 'POST',
@@ -510,7 +510,7 @@ class CreateTest extends TestCase
                 XML,
                 200,
                 'application/xml',
-                '<?xml version="1.0"?><issue></issue>'
+                '<?xml version="1.0"?><issue></issue>',
             ]
         );
 

--- a/tests/Unit/Api/Issue/RemoveTest.php
+++ b/tests/Unit/Api/Issue/RemoveTest.php
@@ -26,7 +26,7 @@ class RemoveTest extends TestCase
                 '',
                 $responseCode,
                 '',
-                $response
+                $response,
             ]
         );
 

--- a/tests/Unit/Api/Issue/RemoveTest.php
+++ b/tests/Unit/Api/Issue/RemoveTest.php
@@ -27,7 +27,7 @@ class RemoveTest extends TestCase
                 $responseCode,
                 '',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/Issue/RemoveWatcherTest.php
+++ b/tests/Unit/Api/Issue/RemoveWatcherTest.php
@@ -26,7 +26,7 @@ class RemoveWatcherTest extends TestCase
                 '',
                 $responseCode,
                 '',
-                $response
+                $response,
             ]
         );
 

--- a/tests/Unit/Api/Issue/RemoveWatcherTest.php
+++ b/tests/Unit/Api/Issue/RemoveWatcherTest.php
@@ -27,7 +27,7 @@ class RemoveWatcherTest extends TestCase
                 $responseCode,
                 '',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/Issue/SetIssueStatusTest.php
+++ b/tests/Unit/Api/Issue/SetIssueStatusTest.php
@@ -31,7 +31,7 @@ class SetIssueStatusTest extends TestCase
                 204,
                 '',
                 '',
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/Issue/SetIssueStatusTest.php
+++ b/tests/Unit/Api/Issue/SetIssueStatusTest.php
@@ -21,7 +21,7 @@ class SetIssueStatusTest extends TestCase
                 '',
                 200,
                 'application/json',
-                '{"issue_statuses":[{"name":"Status Name","id":123}]}'
+                '{"issue_statuses":[{"name":"Status Name","id":123}]}',
             ],
             [
                 'PUT',
@@ -30,7 +30,7 @@ class SetIssueStatusTest extends TestCase
                 '<?xml version="1.0"?><issue><id>5</id><status_id>123</status_id></issue>',
                 204,
                 '',
-                ''
+                '',
             ]
         );
 

--- a/tests/Unit/Api/Issue/ShowTest.php
+++ b/tests/Unit/Api/Issue/ShowTest.php
@@ -26,7 +26,7 @@ class ShowTest extends TestCase
                 '',
                 200,
                 'application/json',
-                $response
+                $response,
             ]
         );
 

--- a/tests/Unit/Api/Issue/ShowTest.php
+++ b/tests/Unit/Api/Issue/ShowTest.php
@@ -27,7 +27,7 @@ class ShowTest extends TestCase
                 200,
                 'application/json',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/Issue/UpdateTest.php
+++ b/tests/Unit/Api/Issue/UpdateTest.php
@@ -29,7 +29,7 @@ class UpdateTest extends TestCase
                 $responseCode,
                 '',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test
@@ -181,7 +181,7 @@ class UpdateTest extends TestCase
                 204,
                 '',
                 '',
-            ]
+            ],
         );
 
         $parameters = [

--- a/tests/Unit/Api/Issue/UpdateTest.php
+++ b/tests/Unit/Api/Issue/UpdateTest.php
@@ -28,7 +28,7 @@ class UpdateTest extends TestCase
                 $expectedBody,
                 $responseCode,
                 '',
-                $response
+                $response,
             ]
         );
 
@@ -124,7 +124,7 @@ class UpdateTest extends TestCase
                 '',
                 200,
                 'application/json',
-                '{"projects":[{"name":"Project Name","id":3}]}'
+                '{"projects":[{"name":"Project Name","id":3}]}',
             ],
             [
                 'GET',
@@ -133,7 +133,7 @@ class UpdateTest extends TestCase
                 '',
                 200,
                 'application/json',
-                '{"issue_categories":[{"name":"Category Name","id":45}]}'
+                '{"issue_categories":[{"name":"Category Name","id":45}]}',
             ],
             [
                 'GET',
@@ -142,7 +142,7 @@ class UpdateTest extends TestCase
                 '',
                 200,
                 'application/json',
-                '{"issue_statuses":[{"name":"Status Name","id":123}]}'
+                '{"issue_statuses":[{"name":"Status Name","id":123}]}',
             ],
             [
                 'GET',
@@ -151,7 +151,7 @@ class UpdateTest extends TestCase
                 '',
                 200,
                 'application/json',
-                '{"trackers":[{"name":"Tracker Name","id":9}]}'
+                '{"trackers":[{"name":"Tracker Name","id":9}]}',
             ],
             [
                 'GET',
@@ -160,7 +160,7 @@ class UpdateTest extends TestCase
                 '',
                 200,
                 'application/json',
-                '{"users":[{"login":"Author Name","id":5},{"login":"Assigned to User Name","id":6}]}'
+                '{"users":[{"login":"Author Name","id":5},{"login":"Assigned to User Name","id":6}]}',
             ],
             [
                 'PUT',
@@ -180,7 +180,7 @@ class UpdateTest extends TestCase
                 XML,
                 204,
                 '',
-                ''
+                '',
             ]
         );
 

--- a/tests/Unit/Api/IssueCategory/CreateTest.php
+++ b/tests/Unit/Api/IssueCategory/CreateTest.php
@@ -29,7 +29,7 @@ class CreateTest extends TestCase
                 $expectedBody,
                 $responseCode,
                 'application/xml',
-                $response
+                $response,
             ]
         );
 
@@ -84,7 +84,7 @@ class CreateTest extends TestCase
                 '<?xml version="1.0" encoding="UTF-8"?><issue_category><name>Test Category</name></issue_category>',
                 500,
                 '',
-                ''
+                '',
             ]
         );
 

--- a/tests/Unit/Api/IssueCategory/CreateTest.php
+++ b/tests/Unit/Api/IssueCategory/CreateTest.php
@@ -30,7 +30,7 @@ class CreateTest extends TestCase
                 $responseCode,
                 'application/xml',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test
@@ -85,7 +85,7 @@ class CreateTest extends TestCase
                 500,
                 '',
                 '',
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/IssueCategory/RemoveTest.php
+++ b/tests/Unit/Api/IssueCategory/RemoveTest.php
@@ -26,7 +26,7 @@ class RemoveTest extends TestCase
                 '',
                 $responseCode,
                 '',
-                $response
+                $response,
             ]
         );
 

--- a/tests/Unit/Api/IssueCategory/RemoveTest.php
+++ b/tests/Unit/Api/IssueCategory/RemoveTest.php
@@ -27,7 +27,7 @@ class RemoveTest extends TestCase
                 $responseCode,
                 '',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/IssueCategory/ShowTest.php
+++ b/tests/Unit/Api/IssueCategory/ShowTest.php
@@ -26,7 +26,7 @@ class ShowTest extends TestCase
                 '',
                 200,
                 'application/json',
-                $response
+                $response,
             ]
         );
 

--- a/tests/Unit/Api/IssueCategory/ShowTest.php
+++ b/tests/Unit/Api/IssueCategory/ShowTest.php
@@ -27,7 +27,7 @@ class ShowTest extends TestCase
                 200,
                 'application/json',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/IssueCategory/UpdateTest.php
+++ b/tests/Unit/Api/IssueCategory/UpdateTest.php
@@ -29,7 +29,7 @@ class UpdateTest extends TestCase
                 $responseCode,
                 '',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/IssueCategory/UpdateTest.php
+++ b/tests/Unit/Api/IssueCategory/UpdateTest.php
@@ -28,7 +28,7 @@ class UpdateTest extends TestCase
                 $expectedBody,
                 $responseCode,
                 '',
-                $response
+                $response,
             ]
         );
 

--- a/tests/Unit/Api/IssueCategoryTest.php
+++ b/tests/Unit/Api/IssueCategoryTest.php
@@ -27,13 +27,13 @@ class IssueCategoryTest extends TestCase
             function ($errno, $errstr): bool {
                 $this->assertSame(
                     '`Redmine\Api\IssueCategory::all()` is deprecated since v2.4.0, use `Redmine\Api\IssueCategory::listByProject()` instead.',
-                    $errstr
+                    $errstr,
                 );
 
                 restore_error_handler();
                 return true;
             },
-            E_USER_DEPRECATED
+            E_USER_DEPRECATED,
         );
 
         $api->all(5);
@@ -97,8 +97,8 @@ class IssueCategoryTest extends TestCase
             ->with(
                 $this->logicalAnd(
                     $this->stringStartsWith('/projects/5/issue_categories.json'),
-                    $this->stringContains('not-used')
-                )
+                    $this->stringContains('not-used'),
+                ),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))
@@ -132,7 +132,7 @@ class IssueCategoryTest extends TestCase
         $client->expects($this->once())
             ->method('requestGet')
             ->with(
-                $this->stringStartsWith('/projects/5/issue_categories')
+                $this->stringStartsWith('/projects/5/issue_categories'),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))
@@ -166,7 +166,7 @@ class IssueCategoryTest extends TestCase
         $client->expects($this->once())
             ->method('requestGet')
             ->with(
-                $this->stringStartsWith('/projects/5/issue_categories')
+                $this->stringStartsWith('/projects/5/issue_categories'),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))
@@ -201,7 +201,7 @@ class IssueCategoryTest extends TestCase
         $client->expects($this->exactly(2))
             ->method('requestGet')
             ->with(
-                $this->stringStartsWith('/projects/5/issue_categories')
+                $this->stringStartsWith('/projects/5/issue_categories'),
             )
             ->willReturn(true);
         $client->expects($this->exactly(2))
@@ -232,7 +232,7 @@ class IssueCategoryTest extends TestCase
         $client->expects($this->once())
             ->method('requestGet')
             ->with(
-                $this->stringStartsWith('/projects/5/issue_categories.json')
+                $this->stringStartsWith('/projects/5/issue_categories.json'),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))

--- a/tests/Unit/Api/IssuePriorityTest.php
+++ b/tests/Unit/Api/IssuePriorityTest.php
@@ -27,13 +27,13 @@ class IssuePriorityTest extends TestCase
             function ($errno, $errstr): bool {
                 $this->assertSame(
                     '`Redmine\Api\IssuePriority::all()` is deprecated since v2.4.0, use `Redmine\Api\IssuePriority::list()` instead.',
-                    $errstr
+                    $errstr,
                 );
 
                 restore_error_handler();
                 return true;
             },
-            E_USER_DEPRECATED
+            E_USER_DEPRECATED,
         );
 
         $api->all();
@@ -91,7 +91,7 @@ class IssuePriorityTest extends TestCase
         $client->expects($this->once())
             ->method('requestGet')
             ->with(
-                $this->stringContains('not-used')
+                $this->stringContains('not-used'),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))

--- a/tests/Unit/Api/IssueRelation/CreateTest.php
+++ b/tests/Unit/Api/IssueRelation/CreateTest.php
@@ -30,7 +30,7 @@ class CreateTest extends TestCase
                 $responseCode,
                 'application/json',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test
@@ -70,7 +70,7 @@ class CreateTest extends TestCase
                 500,
                 '',
                 '',
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/IssueRelation/CreateTest.php
+++ b/tests/Unit/Api/IssueRelation/CreateTest.php
@@ -29,7 +29,7 @@ class CreateTest extends TestCase
                 $expectedBody,
                 $responseCode,
                 'application/json',
-                $response
+                $response,
             ]
         );
 
@@ -69,7 +69,7 @@ class CreateTest extends TestCase
                 '{"relation":{"issue_to_id":10,"relation_type":"relates"}}',
                 500,
                 '',
-                ''
+                '',
             ]
         );
 

--- a/tests/Unit/Api/IssueRelation/RemoveTest.php
+++ b/tests/Unit/Api/IssueRelation/RemoveTest.php
@@ -26,7 +26,7 @@ class RemoveTest extends TestCase
                 '',
                 $responseCode,
                 '',
-                $response
+                $response,
             ]
         );
 

--- a/tests/Unit/Api/IssueRelation/RemoveTest.php
+++ b/tests/Unit/Api/IssueRelation/RemoveTest.php
@@ -27,7 +27,7 @@ class RemoveTest extends TestCase
                 $responseCode,
                 '',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/IssueRelation/ShowTest.php
+++ b/tests/Unit/Api/IssueRelation/ShowTest.php
@@ -26,7 +26,7 @@ class ShowTest extends TestCase
                 '',
                 200,
                 'application/json',
-                $response
+                $response,
             ]
         );
 

--- a/tests/Unit/Api/IssueRelation/ShowTest.php
+++ b/tests/Unit/Api/IssueRelation/ShowTest.php
@@ -27,7 +27,7 @@ class ShowTest extends TestCase
                 200,
                 'application/json',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/IssueRelationTest.php
+++ b/tests/Unit/Api/IssueRelationTest.php
@@ -27,13 +27,13 @@ class IssueRelationTest extends TestCase
             function ($errno, $errstr): bool {
                 $this->assertSame(
                     '`Redmine\Api\IssueRelation::all()` is deprecated since v2.4.0, use `Redmine\Api\IssueRelation::listByIssueId()` instead.',
-                    $errstr
+                    $errstr,
                 );
 
                 restore_error_handler();
                 return true;
             },
-            E_USER_DEPRECATED
+            E_USER_DEPRECATED,
         );
 
         $api->all(5);
@@ -93,8 +93,8 @@ class IssueRelationTest extends TestCase
             ->with(
                 $this->logicalAnd(
                     $this->stringStartsWith('/issues/5/relations.json'),
-                    $this->stringContains('not-used')
-                )
+                    $this->stringContains('not-used'),
+                ),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))

--- a/tests/Unit/Api/IssueStatusTest.php
+++ b/tests/Unit/Api/IssueStatusTest.php
@@ -27,13 +27,13 @@ class IssueStatusTest extends TestCase
             function ($errno, $errstr): bool {
                 $this->assertSame(
                     '`Redmine\Api\IssueStatus::all()` is deprecated since v2.4.0, use `Redmine\Api\IssueStatus::list()` instead.',
-                    $errstr
+                    $errstr,
                 );
 
                 restore_error_handler();
                 return true;
             },
-            E_USER_DEPRECATED
+            E_USER_DEPRECATED,
         );
 
         $api->all();
@@ -93,8 +93,8 @@ class IssueStatusTest extends TestCase
             ->with(
                 $this->logicalAnd(
                     $this->stringStartsWith('/issue_statuses.json'),
-                    $this->stringContains('not-used')
-                )
+                    $this->stringContains('not-used'),
+                ),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))
@@ -128,7 +128,7 @@ class IssueStatusTest extends TestCase
         $client->expects($this->once())
             ->method('requestGet')
             ->with(
-                $this->stringStartsWith('/issue_statuses.json')
+                $this->stringStartsWith('/issue_statuses.json'),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))
@@ -162,7 +162,7 @@ class IssueStatusTest extends TestCase
         $client->expects($this->once())
             ->method('requestGet')
             ->with(
-                $this->stringStartsWith('/issue_statuses.json')
+                $this->stringStartsWith('/issue_statuses.json'),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))
@@ -197,7 +197,7 @@ class IssueStatusTest extends TestCase
         $client->expects($this->exactly(2))
             ->method('requestGet')
             ->with(
-                $this->stringStartsWith('/issue_statuses.json')
+                $this->stringStartsWith('/issue_statuses.json'),
             )
             ->willReturn(true);
         $client->expects($this->exactly(2))
@@ -228,7 +228,7 @@ class IssueStatusTest extends TestCase
         $client->expects($this->once())
             ->method('requestGet')
             ->with(
-                $this->stringStartsWith('/issue_statuses.json')
+                $this->stringStartsWith('/issue_statuses.json'),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))

--- a/tests/Unit/Api/IssueTest.php
+++ b/tests/Unit/Api/IssueTest.php
@@ -49,13 +49,13 @@ class IssueTest extends TestCase
             function ($errno, $errstr): bool {
                 $this->assertSame(
                     '`Redmine\Api\Issue::all()` is deprecated since v2.4.0, use `Redmine\Api\Issue::list()` instead.',
-                    $errstr
+                    $errstr,
                 );
 
                 restore_error_handler();
                 return true;
             },
-            E_USER_DEPRECATED
+            E_USER_DEPRECATED,
         );
 
         $api->all();
@@ -115,8 +115,8 @@ class IssueTest extends TestCase
             ->with(
                 $this->logicalAnd(
                     $this->stringStartsWith('/issues.json'),
-                    $this->stringContains('not-used')
-                )
+                    $this->stringContains('not-used'),
+                ),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))
@@ -173,7 +173,7 @@ class IssueTest extends TestCase
                     ['issue_status', $getIdByNameApi],
                     ['tracker', $getIdByNameApi],
                     ['user', $getIdByUsernameApi],
-                ]
+                ],
             );
 
         $client->expects($this->once())
@@ -188,8 +188,8 @@ class IssueTest extends TestCase
                     $this->stringContains('<status_id>cleanedValue</status_id>'),
                     $this->stringContains('<tracker_id>cleanedValue</tracker_id>'),
                     $this->stringContains('<assigned_to_id>cleanedValue</assigned_to_id>'),
-                    $this->stringContains('<author_id>cleanedValue</author_id>')
-                )
+                    $this->stringContains('<author_id>cleanedValue</author_id>'),
+                ),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))

--- a/tests/Unit/Api/Membership/CreateTest.php
+++ b/tests/Unit/Api/Membership/CreateTest.php
@@ -29,7 +29,7 @@ class CreateTest extends TestCase
                 $expectedBody,
                 $responseCode,
                 'application/xml',
-                $response
+                $response,
             ]
         );
 
@@ -76,7 +76,7 @@ class CreateTest extends TestCase
                 '<?xml version="1.0" encoding="UTF-8"?><membership><user_id>4</user_id><role_ids>2</role_ids></membership>',
                 500,
                 '',
-                ''
+                '',
             ]
         );
 

--- a/tests/Unit/Api/Membership/CreateTest.php
+++ b/tests/Unit/Api/Membership/CreateTest.php
@@ -30,7 +30,7 @@ class CreateTest extends TestCase
                 $responseCode,
                 'application/xml',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test
@@ -77,7 +77,7 @@ class CreateTest extends TestCase
                 500,
                 '',
                 '',
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/Membership/RemoveMemberTest.php
+++ b/tests/Unit/Api/Membership/RemoveMemberTest.php
@@ -36,7 +36,7 @@ class RemoveMemberTest extends TestCase
                 $responseCode,
                 '',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test
@@ -80,7 +80,7 @@ class RemoveMemberTest extends TestCase
                 200,
                 'application/json',
                 '{"memberships":[{"id":5,"user":{"id":404}}]}',
-            ]
+            ],
         );
 
         // Create the object under test
@@ -102,7 +102,7 @@ class RemoveMemberTest extends TestCase
                 200,
                 'application/json',
                 '{"error":"this response is invalid"}',
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/Membership/RemoveMemberTest.php
+++ b/tests/Unit/Api/Membership/RemoveMemberTest.php
@@ -26,7 +26,7 @@ class RemoveMemberTest extends TestCase
                 '',
                 200,
                 'application/json',
-                '{"memberships":[{"id":2,"user":{"id":' . $userId . '}}]}'
+                '{"memberships":[{"id":2,"user":{"id":' . $userId . '}}]}',
             ],
             [
                 'DELETE',
@@ -35,7 +35,7 @@ class RemoveMemberTest extends TestCase
                 '',
                 $responseCode,
                 '',
-                $response
+                $response,
             ]
         );
 
@@ -79,7 +79,7 @@ class RemoveMemberTest extends TestCase
                 '',
                 200,
                 'application/json',
-                '{"memberships":[{"id":5,"user":{"id":404}}]}'
+                '{"memberships":[{"id":5,"user":{"id":404}}]}',
             ]
         );
 
@@ -101,7 +101,7 @@ class RemoveMemberTest extends TestCase
                 '',
                 200,
                 'application/json',
-                '{"error":"this response is invalid"}'
+                '{"error":"this response is invalid"}',
             ]
         );
 

--- a/tests/Unit/Api/Membership/RemoveTest.php
+++ b/tests/Unit/Api/Membership/RemoveTest.php
@@ -26,7 +26,7 @@ class RemoveTest extends TestCase
                 '',
                 $responseCode,
                 '',
-                $response
+                $response,
             ]
         );
 

--- a/tests/Unit/Api/Membership/RemoveTest.php
+++ b/tests/Unit/Api/Membership/RemoveTest.php
@@ -27,7 +27,7 @@ class RemoveTest extends TestCase
                 $responseCode,
                 '',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/Membership/UpdateTest.php
+++ b/tests/Unit/Api/Membership/UpdateTest.php
@@ -28,7 +28,7 @@ class UpdateTest extends TestCase
                 $expectedBody,
                 $responseCode,
                 '',
-                $response
+                $response,
             ]
         );
 
@@ -73,7 +73,7 @@ class UpdateTest extends TestCase
                 '<?xml version="1.0" encoding="UTF-8"?><membership><role_ids>2</role_ids><user_id>4</user_id></membership>',
                 500,
                 '',
-                ''
+                '',
             ]
         );
 

--- a/tests/Unit/Api/Membership/UpdateTest.php
+++ b/tests/Unit/Api/Membership/UpdateTest.php
@@ -29,7 +29,7 @@ class UpdateTest extends TestCase
                 $responseCode,
                 '',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test
@@ -74,7 +74,7 @@ class UpdateTest extends TestCase
                 500,
                 '',
                 '',
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/MembershipTest.php
+++ b/tests/Unit/Api/MembershipTest.php
@@ -27,13 +27,13 @@ class MembershipTest extends TestCase
             function ($errno, $errstr): bool {
                 $this->assertSame(
                     '`Redmine\Api\Membership::all()` is deprecated since v2.4.0, use `Redmine\Api\Membership::listByProject()` instead.',
-                    $errstr
+                    $errstr,
                 );
 
                 restore_error_handler();
                 return true;
             },
-            E_USER_DEPRECATED
+            E_USER_DEPRECATED,
         );
 
         $api->all(5);
@@ -93,8 +93,8 @@ class MembershipTest extends TestCase
             ->with(
                 $this->logicalAnd(
                     $this->stringStartsWith('/projects/5/memberships.json'),
-                    $this->stringContains('not-used')
-                )
+                    $this->stringContains('not-used'),
+                ),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))

--- a/tests/Unit/Api/NewsTest.php
+++ b/tests/Unit/Api/NewsTest.php
@@ -27,13 +27,13 @@ class NewsTest extends TestCase
             function ($errno, $errstr): bool {
                 $this->assertSame(
                     '`Redmine\Api\News::all()` is deprecated since v2.4.0, use `Redmine\Api\News::list()` or `Redmine\Api\News::listByProject()` instead.',
-                    $errstr
+                    $errstr,
                 );
 
                 restore_error_handler();
                 return true;
             },
-            E_USER_DEPRECATED
+            E_USER_DEPRECATED,
         );
 
         $api->all(5);
@@ -91,7 +91,7 @@ class NewsTest extends TestCase
         $client->expects($this->once())
             ->method('requestGet')
             ->with(
-                $this->stringStartsWith('/projects/5/news.json')
+                $this->stringStartsWith('/projects/5/news.json'),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))
@@ -124,7 +124,7 @@ class NewsTest extends TestCase
         $client->expects($this->once())
             ->method('requestGet')
             ->with(
-                $this->stringContains('not-used')
+                $this->stringContains('not-used'),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))

--- a/tests/Unit/Api/Project/ArchiveTest.php
+++ b/tests/Unit/Api/Project/ArchiveTest.php
@@ -24,7 +24,7 @@ class ArchiveTest extends TestCase
                 '/projects/5/archive.xml',
                 'application/xml',
                 '',
-                204
+                204,
             ]
         );
 
@@ -42,7 +42,7 @@ class ArchiveTest extends TestCase
                 '/projects/5/archive.xml',
                 'application/xml',
                 '',
-                403
+                403,
             ]
         );
 

--- a/tests/Unit/Api/Project/ArchiveTest.php
+++ b/tests/Unit/Api/Project/ArchiveTest.php
@@ -25,7 +25,7 @@ class ArchiveTest extends TestCase
                 'application/xml',
                 '',
                 204,
-            ]
+            ],
         );
 
         $api = new Project($client);
@@ -43,7 +43,7 @@ class ArchiveTest extends TestCase
                 'application/xml',
                 '',
                 403,
-            ]
+            ],
         );
 
         $api = new Project($client);

--- a/tests/Unit/Api/Project/CloseTest.php
+++ b/tests/Unit/Api/Project/CloseTest.php
@@ -22,7 +22,7 @@ class CloseTest extends TestCase
                 '/projects/5/close.xml',
                 'application/xml',
                 '',
-                204
+                204,
             ]
         );
 
@@ -40,7 +40,7 @@ class CloseTest extends TestCase
                 '/projects/5/close.xml',
                 'application/xml',
                 '',
-                403
+                403,
             ]
         );
 

--- a/tests/Unit/Api/Project/CloseTest.php
+++ b/tests/Unit/Api/Project/CloseTest.php
@@ -23,7 +23,7 @@ class CloseTest extends TestCase
                 'application/xml',
                 '',
                 204,
-            ]
+            ],
         );
 
         $api = new Project($client);
@@ -41,7 +41,7 @@ class CloseTest extends TestCase
                 'application/xml',
                 '',
                 403,
-            ]
+            ],
         );
 
         $api = new Project($client);

--- a/tests/Unit/Api/Project/CreateTest.php
+++ b/tests/Unit/Api/Project/CreateTest.php
@@ -29,7 +29,7 @@ class CreateTest extends TestCase
                 $expectedBody,
                 $responseCode,
                 'application/xml',
-                $response
+                $response,
             ]
         );
 
@@ -142,7 +142,7 @@ class CreateTest extends TestCase
                 '<?xml version="1.0" encoding="UTF-8"?><project><name>Test Project</name><identifier>test-project</identifier></project>',
                 500,
                 '',
-                ''
+                '',
             ]
         );
 

--- a/tests/Unit/Api/Project/CreateTest.php
+++ b/tests/Unit/Api/Project/CreateTest.php
@@ -30,7 +30,7 @@ class CreateTest extends TestCase
                 $responseCode,
                 'application/xml',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test
@@ -143,7 +143,7 @@ class CreateTest extends TestCase
                 500,
                 '',
                 '',
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/Project/RemoveTest.php
+++ b/tests/Unit/Api/Project/RemoveTest.php
@@ -26,7 +26,7 @@ class RemoveTest extends TestCase
                 '',
                 $responseCode,
                 '',
-                $response
+                $response,
             ]
         );
 

--- a/tests/Unit/Api/Project/RemoveTest.php
+++ b/tests/Unit/Api/Project/RemoveTest.php
@@ -27,7 +27,7 @@ class RemoveTest extends TestCase
                 $responseCode,
                 '',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/Project/ReopenTest.php
+++ b/tests/Unit/Api/Project/ReopenTest.php
@@ -23,7 +23,7 @@ class ReopenTest extends TestCase
                 'application/xml',
                 '',
                 204,
-            ]
+            ],
         );
 
         $api = new Project($client);
@@ -41,7 +41,7 @@ class ReopenTest extends TestCase
                 'application/xml',
                 '',
                 403,
-            ]
+            ],
         );
 
         $api = new Project($client);

--- a/tests/Unit/Api/Project/ReopenTest.php
+++ b/tests/Unit/Api/Project/ReopenTest.php
@@ -22,7 +22,7 @@ class ReopenTest extends TestCase
                 '/projects/5/reopen.xml',
                 'application/xml',
                 '',
-                204
+                204,
             ]
         );
 
@@ -40,7 +40,7 @@ class ReopenTest extends TestCase
                 '/projects/5/reopen.xml',
                 'application/xml',
                 '',
-                403
+                403,
             ]
         );
 

--- a/tests/Unit/Api/Project/ShowTest.php
+++ b/tests/Unit/Api/Project/ShowTest.php
@@ -26,7 +26,7 @@ class ShowTest extends TestCase
                 '',
                 200,
                 'application/json',
-                $response
+                $response,
             ]
         );
 

--- a/tests/Unit/Api/Project/ShowTest.php
+++ b/tests/Unit/Api/Project/ShowTest.php
@@ -27,7 +27,7 @@ class ShowTest extends TestCase
                 200,
                 'application/json',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/Project/UnarchiveTest.php
+++ b/tests/Unit/Api/Project/UnarchiveTest.php
@@ -22,7 +22,7 @@ class UnarchiveTest extends TestCase
                 '/projects/5/unarchive.xml',
                 'application/xml',
                 '',
-                204
+                204,
             ]
         );
 
@@ -40,7 +40,7 @@ class UnarchiveTest extends TestCase
                 '/projects/5/unarchive.xml',
                 'application/xml',
                 '',
-                403
+                403,
             ]
         );
 

--- a/tests/Unit/Api/Project/UnarchiveTest.php
+++ b/tests/Unit/Api/Project/UnarchiveTest.php
@@ -23,7 +23,7 @@ class UnarchiveTest extends TestCase
                 'application/xml',
                 '',
                 204,
-            ]
+            ],
         );
 
         $api = new Project($client);
@@ -41,7 +41,7 @@ class UnarchiveTest extends TestCase
                 'application/xml',
                 '',
                 403,
-            ]
+            ],
         );
 
         $api = new Project($client);

--- a/tests/Unit/Api/Project/UpdateTest.php
+++ b/tests/Unit/Api/Project/UpdateTest.php
@@ -29,7 +29,7 @@ class UpdateTest extends TestCase
                 $responseCode,
                 '',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/Project/UpdateTest.php
+++ b/tests/Unit/Api/Project/UpdateTest.php
@@ -28,7 +28,7 @@ class UpdateTest extends TestCase
                 $expectedBody,
                 $responseCode,
                 '',
-                $response
+                $response,
             ]
         );
 

--- a/tests/Unit/Api/ProjectTest.php
+++ b/tests/Unit/Api/ProjectTest.php
@@ -29,13 +29,13 @@ class ProjectTest extends TestCase
             function ($errno, $errstr): bool {
                 $this->assertSame(
                     '`Redmine\Api\Project::all()` is deprecated since v2.4.0, use `Redmine\Api\Project::list()` instead.',
-                    $errstr
+                    $errstr,
                 );
 
                 restore_error_handler();
                 return true;
             },
-            E_USER_DEPRECATED
+            E_USER_DEPRECATED,
         );
 
         $api->all();
@@ -95,8 +95,8 @@ class ProjectTest extends TestCase
             ->with(
                 $this->logicalAnd(
                     $this->stringStartsWith('/projects.json'),
-                    $this->stringContains('not-used')
-                )
+                    $this->stringContains('not-used'),
+                ),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))
@@ -130,7 +130,7 @@ class ProjectTest extends TestCase
         $client->expects($this->once())
             ->method('requestGet')
             ->with(
-                $this->stringStartsWith('/projects.json')
+                $this->stringStartsWith('/projects.json'),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))
@@ -164,7 +164,7 @@ class ProjectTest extends TestCase
         $client->expects($this->once())
             ->method('requestGet')
             ->with(
-                $this->stringStartsWith('/projects.json')
+                $this->stringStartsWith('/projects.json'),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))
@@ -199,7 +199,7 @@ class ProjectTest extends TestCase
         $client->expects($this->exactly(2))
             ->method('requestGet')
             ->with(
-                $this->stringStartsWith('/projects.json')
+                $this->stringStartsWith('/projects.json'),
             )
             ->willReturn(true);
         $client->expects($this->exactly(2))
@@ -230,7 +230,7 @@ class ProjectTest extends TestCase
         $client->expects($this->once())
             ->method('requestGet')
             ->with(
-                $this->stringStartsWith('/projects.json')
+                $this->stringStartsWith('/projects.json'),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))

--- a/tests/Unit/Api/QueryTest.php
+++ b/tests/Unit/Api/QueryTest.php
@@ -27,13 +27,13 @@ class QueryTest extends TestCase
             function ($errno, $errstr): bool {
                 $this->assertSame(
                     '`Redmine\Api\Query::all()` is deprecated since v2.4.0, use `Redmine\Api\Query::list()` instead.',
-                    $errstr
+                    $errstr,
                 );
 
                 restore_error_handler();
                 return true;
             },
-            E_USER_DEPRECATED
+            E_USER_DEPRECATED,
         );
 
         $api->all();
@@ -93,8 +93,8 @@ class QueryTest extends TestCase
             ->with(
                 $this->logicalAnd(
                     $this->stringStartsWith('/queries.json'),
-                    $this->stringContains('not-used')
-                )
+                    $this->stringContains('not-used'),
+                ),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))

--- a/tests/Unit/Api/Role/ShowTest.php
+++ b/tests/Unit/Api/Role/ShowTest.php
@@ -26,7 +26,7 @@ class ShowTest extends TestCase
                 '',
                 200,
                 'application/json',
-                $response
+                $response,
             ]
         );
 

--- a/tests/Unit/Api/Role/ShowTest.php
+++ b/tests/Unit/Api/Role/ShowTest.php
@@ -27,7 +27,7 @@ class ShowTest extends TestCase
                 200,
                 'application/json',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/RoleTest.php
+++ b/tests/Unit/Api/RoleTest.php
@@ -27,13 +27,13 @@ class RoleTest extends TestCase
             function ($errno, $errstr): bool {
                 $this->assertSame(
                     '`Redmine\Api\Role::all()` is deprecated since v2.4.0, use `Redmine\Api\Role::list()` instead.',
-                    $errstr
+                    $errstr,
                 );
 
                 restore_error_handler();
                 return true;
             },
-            E_USER_DEPRECATED
+            E_USER_DEPRECATED,
         );
 
         $api->all();
@@ -93,8 +93,8 @@ class RoleTest extends TestCase
             ->with(
                 $this->logicalAnd(
                     $this->stringStartsWith('/roles.json'),
-                    $this->stringContains('not-used')
-                )
+                    $this->stringContains('not-used'),
+                ),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))
@@ -128,7 +128,7 @@ class RoleTest extends TestCase
         $client->expects($this->once())
             ->method('requestGet')
             ->with(
-                $this->stringStartsWith('/roles.json')
+                $this->stringStartsWith('/roles.json'),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))
@@ -162,7 +162,7 @@ class RoleTest extends TestCase
         $client->expects($this->once())
             ->method('requestGet')
             ->with(
-                $this->stringStartsWith('/roles.json')
+                $this->stringStartsWith('/roles.json'),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))
@@ -197,7 +197,7 @@ class RoleTest extends TestCase
         $client->expects($this->exactly(2))
             ->method('requestGet')
             ->with(
-                $this->stringStartsWith('/roles.json')
+                $this->stringStartsWith('/roles.json'),
             )
             ->willReturn(true);
         $client->expects($this->exactly(2))

--- a/tests/Unit/Api/Search/SearchTest.php
+++ b/tests/Unit/Api/Search/SearchTest.php
@@ -21,13 +21,13 @@ class SearchTest extends TestCase
             function ($errno, $errstr): bool {
                 $this->assertSame(
                     '`Redmine\Api\Search::search()` is deprecated since v2.4.0, use `Redmine\Api\Search::listByQuery()` instead.',
-                    $errstr
+                    $errstr,
                 );
 
                 restore_error_handler();
                 return true;
             },
-            E_USER_DEPRECATED
+            E_USER_DEPRECATED,
         );
 
         $api->search('query');

--- a/tests/Unit/Api/TimeEntry/CreateTest.php
+++ b/tests/Unit/Api/TimeEntry/CreateTest.php
@@ -29,7 +29,7 @@ class CreateTest extends TestCase
                 $expectedBody,
                 $responseCode,
                 'application/xml',
-                $response
+                $response,
             ]
         );
 
@@ -114,7 +114,7 @@ class CreateTest extends TestCase
                 '<?xml version="1.0" encoding="UTF-8"?><time_entry><issue_id>5</issue_id><hours>5.25</hours></time_entry>',
                 500,
                 '',
-                ''
+                '',
             ]
         );
 

--- a/tests/Unit/Api/TimeEntry/CreateTest.php
+++ b/tests/Unit/Api/TimeEntry/CreateTest.php
@@ -30,7 +30,7 @@ class CreateTest extends TestCase
                 $responseCode,
                 'application/xml',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test
@@ -115,7 +115,7 @@ class CreateTest extends TestCase
                 500,
                 '',
                 '',
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/TimeEntry/RemoveTest.php
+++ b/tests/Unit/Api/TimeEntry/RemoveTest.php
@@ -26,7 +26,7 @@ class RemoveTest extends TestCase
                 '',
                 $responseCode,
                 '',
-                $response
+                $response,
             ]
         );
 

--- a/tests/Unit/Api/TimeEntry/RemoveTest.php
+++ b/tests/Unit/Api/TimeEntry/RemoveTest.php
@@ -27,7 +27,7 @@ class RemoveTest extends TestCase
                 $responseCode,
                 '',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/TimeEntry/ShowTest.php
+++ b/tests/Unit/Api/TimeEntry/ShowTest.php
@@ -26,7 +26,7 @@ class ShowTest extends TestCase
                 '',
                 200,
                 'application/json',
-                $response
+                $response,
             ]
         );
 

--- a/tests/Unit/Api/TimeEntry/ShowTest.php
+++ b/tests/Unit/Api/TimeEntry/ShowTest.php
@@ -27,7 +27,7 @@ class ShowTest extends TestCase
                 200,
                 'application/json',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/TimeEntry/UpdateTest.php
+++ b/tests/Unit/Api/TimeEntry/UpdateTest.php
@@ -29,7 +29,7 @@ class UpdateTest extends TestCase
                 $responseCode,
                 '',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/TimeEntry/UpdateTest.php
+++ b/tests/Unit/Api/TimeEntry/UpdateTest.php
@@ -28,7 +28,7 @@ class UpdateTest extends TestCase
                 $expectedBody,
                 $responseCode,
                 '',
-                $response
+                $response,
             ]
         );
 

--- a/tests/Unit/Api/TimeEntryActivityTest.php
+++ b/tests/Unit/Api/TimeEntryActivityTest.php
@@ -27,13 +27,13 @@ class TimeEntryActivityTest extends TestCase
             function ($errno, $errstr): bool {
                 $this->assertSame(
                     '`Redmine\Api\TimeEntryActivity::all()` is deprecated since v2.4.0, use `Redmine\Api\TimeEntryActivity::list()` instead.',
-                    $errstr
+                    $errstr,
                 );
 
                 restore_error_handler();
                 return true;
             },
-            E_USER_DEPRECATED
+            E_USER_DEPRECATED,
         );
 
         $api->all();
@@ -93,8 +93,8 @@ class TimeEntryActivityTest extends TestCase
             ->with(
                 $this->logicalAnd(
                     $this->stringStartsWith('/enumerations/time_entry_activities.json'),
-                    $this->stringContains('not-used')
-                )
+                    $this->stringContains('not-used'),
+                ),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))
@@ -123,7 +123,7 @@ class TimeEntryActivityTest extends TestCase
         $client->expects($this->atLeastOnce())
             ->method('requestGet')
             ->with(
-                $this->stringStartsWith('/enumerations/time_entry_activities.json')
+                $this->stringStartsWith('/enumerations/time_entry_activities.json'),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))
@@ -150,7 +150,7 @@ class TimeEntryActivityTest extends TestCase
         $client->expects($this->exactly(2))
             ->method('requestGet')
             ->with(
-                $this->stringStartsWith('/enumerations/time_entry_activities.json')
+                $this->stringStartsWith('/enumerations/time_entry_activities.json'),
             )
             ->willReturn(true);
         $client->expects($this->exactly(2))
@@ -174,7 +174,7 @@ class TimeEntryActivityTest extends TestCase
         $client->expects($this->once())
             ->method('requestGet')
             ->with(
-                $this->stringStartsWith('/enumerations/time_entry_activities.json')
+                $this->stringStartsWith('/enumerations/time_entry_activities.json'),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))

--- a/tests/Unit/Api/TimeEntryTest.php
+++ b/tests/Unit/Api/TimeEntryTest.php
@@ -27,13 +27,13 @@ class TimeEntryTest extends TestCase
             function ($errno, $errstr): bool {
                 $this->assertSame(
                     '`Redmine\Api\TimeEntry::all()` is deprecated since v2.4.0, use `Redmine\Api\TimeEntry::list()` instead.',
-                    $errstr
+                    $errstr,
                 );
 
                 restore_error_handler();
                 return true;
             },
-            E_USER_DEPRECATED
+            E_USER_DEPRECATED,
         );
 
         $api->all();
@@ -99,8 +99,8 @@ class TimeEntryTest extends TestCase
                     $this->stringStartsWith('/time_entries.json?'),
                     $this->stringContains('project_id=5'),
                     $this->stringContains('user_id=10'),
-                    $this->stringContains('limit=2')
-                )
+                    $this->stringContains('limit=2'),
+                ),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))

--- a/tests/Unit/Api/TrackerTest.php
+++ b/tests/Unit/Api/TrackerTest.php
@@ -27,13 +27,13 @@ class TrackerTest extends TestCase
             function ($errno, $errstr): bool {
                 $this->assertSame(
                     '`Redmine\Api\Tracker::all()` is deprecated since v2.4.0, use `Redmine\Api\Tracker::list()` instead.',
-                    $errstr
+                    $errstr,
                 );
 
                 restore_error_handler();
                 return true;
             },
-            E_USER_DEPRECATED
+            E_USER_DEPRECATED,
         );
 
         $api->all();
@@ -93,8 +93,8 @@ class TrackerTest extends TestCase
             ->with(
                 $this->logicalAnd(
                     $this->stringStartsWith('/trackers.json'),
-                    $this->stringContains('not-used')
-                )
+                    $this->stringContains('not-used'),
+                ),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))
@@ -128,7 +128,7 @@ class TrackerTest extends TestCase
         $client->expects($this->once())
             ->method('requestGet')
             ->with(
-                $this->stringStartsWith('/trackers.json')
+                $this->stringStartsWith('/trackers.json'),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))
@@ -162,7 +162,7 @@ class TrackerTest extends TestCase
         $client->expects($this->once())
             ->method('requestGet')
             ->with(
-                $this->stringStartsWith('/trackers.json')
+                $this->stringStartsWith('/trackers.json'),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))
@@ -197,7 +197,7 @@ class TrackerTest extends TestCase
         $client->expects($this->exactly(2))
             ->method('requestGet')
             ->with(
-                $this->stringStartsWith('/trackers.json')
+                $this->stringStartsWith('/trackers.json'),
             )
             ->willReturn(true);
         $client->expects($this->exactly(2))
@@ -228,7 +228,7 @@ class TrackerTest extends TestCase
         $client->expects($this->once())
             ->method('requestGet')
             ->with(
-                $this->stringStartsWith('/trackers.json')
+                $this->stringStartsWith('/trackers.json'),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))

--- a/tests/Unit/Api/User/CreateTest.php
+++ b/tests/Unit/Api/User/CreateTest.php
@@ -30,7 +30,7 @@ class CreateTest extends TestCase
                 $responseCode,
                 'application/xml',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test
@@ -102,7 +102,7 @@ class CreateTest extends TestCase
                 500,
                 '',
                 '',
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/User/CreateTest.php
+++ b/tests/Unit/Api/User/CreateTest.php
@@ -29,7 +29,7 @@ class CreateTest extends TestCase
                 $expectedBody,
                 $responseCode,
                 'application/xml',
-                $response
+                $response,
             ]
         );
 
@@ -101,7 +101,7 @@ class CreateTest extends TestCase
                 '<?xml version="1.0" encoding="UTF-8"?><user><login>user</login><lastname>last</lastname><firstname>first</firstname><mail>mail@example.com</mail></user>',
                 500,
                 '',
-                ''
+                '',
             ]
         );
 

--- a/tests/Unit/Api/User/RemoveTest.php
+++ b/tests/Unit/Api/User/RemoveTest.php
@@ -26,7 +26,7 @@ class RemoveTest extends TestCase
                 '',
                 $responseCode,
                 '',
-                $response
+                $response,
             ]
         );
 

--- a/tests/Unit/Api/User/RemoveTest.php
+++ b/tests/Unit/Api/User/RemoveTest.php
@@ -27,7 +27,7 @@ class RemoveTest extends TestCase
                 $responseCode,
                 '',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/User/ShowTest.php
+++ b/tests/Unit/Api/User/ShowTest.php
@@ -26,7 +26,7 @@ class ShowTest extends TestCase
                 '',
                 200,
                 'application/json',
-                $response
+                $response,
             ]
         );
 

--- a/tests/Unit/Api/User/ShowTest.php
+++ b/tests/Unit/Api/User/ShowTest.php
@@ -27,7 +27,7 @@ class ShowTest extends TestCase
                 200,
                 'application/json',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/User/UpdateTest.php
+++ b/tests/Unit/Api/User/UpdateTest.php
@@ -29,7 +29,7 @@ class UpdateTest extends TestCase
                 $responseCode,
                 '',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/User/UpdateTest.php
+++ b/tests/Unit/Api/User/UpdateTest.php
@@ -28,7 +28,7 @@ class UpdateTest extends TestCase
                 $expectedBody,
                 $responseCode,
                 '',
-                $response
+                $response,
             ]
         );
 

--- a/tests/Unit/Api/UserTest.php
+++ b/tests/Unit/Api/UserTest.php
@@ -31,8 +31,8 @@ class UserTest extends TestCase
             ->with(
                 $this->logicalAnd(
                     $this->stringStartsWith('/users/current.json'),
-                    $this->stringContains(urlencode('memberships,groups'))
-                )
+                    $this->stringContains(urlencode('memberships,groups')),
+                ),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))
@@ -62,7 +62,7 @@ class UserTest extends TestCase
         $client->expects($this->once())
             ->method('requestGet')
             ->with(
-                $this->stringStartsWith('/users.json')
+                $this->stringStartsWith('/users.json'),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))
@@ -95,13 +95,13 @@ class UserTest extends TestCase
             function ($errno, $errstr): bool {
                 $this->assertSame(
                     '`Redmine\Api\User::all()` is deprecated since v2.4.0, use `Redmine\Api\User::list()` instead.',
-                    $errstr
+                    $errstr,
                 );
 
                 restore_error_handler();
                 return true;
             },
-            E_USER_DEPRECATED
+            E_USER_DEPRECATED,
         );
 
         $api->all();
@@ -165,8 +165,8 @@ class UserTest extends TestCase
                 $this->logicalAnd(
                     $this->stringStartsWith('/users.json?'),
                     $this->stringContains('offset=10'),
-                    $this->stringContains('limit=2')
-                )
+                    $this->stringContains('limit=2'),
+                ),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))
@@ -200,7 +200,7 @@ class UserTest extends TestCase
         $client->expects($this->once())
             ->method('requestGet')
             ->with(
-                $this->stringStartsWith('/users.json')
+                $this->stringStartsWith('/users.json'),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))
@@ -234,7 +234,7 @@ class UserTest extends TestCase
         $client->expects($this->once())
             ->method('requestGet')
             ->with(
-                $this->stringStartsWith('/users.json')
+                $this->stringStartsWith('/users.json'),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))
@@ -269,7 +269,7 @@ class UserTest extends TestCase
         $client->expects($this->exactly(2))
             ->method('requestGet')
             ->with(
-                $this->stringStartsWith('/users.json')
+                $this->stringStartsWith('/users.json'),
             )
             ->willReturn(true);
         $client->expects($this->exactly(2))

--- a/tests/Unit/Api/Version/CreateTest.php
+++ b/tests/Unit/Api/Version/CreateTest.php
@@ -31,7 +31,7 @@ class CreateTest extends TestCase
                 $responseCode,
                 'application/xml',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test
@@ -142,7 +142,7 @@ class CreateTest extends TestCase
                 500,
                 '',
                 '',
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/Version/CreateTest.php
+++ b/tests/Unit/Api/Version/CreateTest.php
@@ -30,7 +30,7 @@ class CreateTest extends TestCase
                 $expectedBody,
                 $responseCode,
                 'application/xml',
-                $response
+                $response,
             ]
         );
 
@@ -141,7 +141,7 @@ class CreateTest extends TestCase
                 '<?xml version="1.0" encoding="UTF-8"?><version><name>test</name></version>',
                 500,
                 '',
-                ''
+                '',
             ]
         );
 

--- a/tests/Unit/Api/Version/RemoveTest.php
+++ b/tests/Unit/Api/Version/RemoveTest.php
@@ -26,7 +26,7 @@ class RemoveTest extends TestCase
                 '',
                 $responseCode,
                 '',
-                $response
+                $response,
             ]
         );
 

--- a/tests/Unit/Api/Version/RemoveTest.php
+++ b/tests/Unit/Api/Version/RemoveTest.php
@@ -27,7 +27,7 @@ class RemoveTest extends TestCase
                 $responseCode,
                 '',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/Version/ShowTest.php
+++ b/tests/Unit/Api/Version/ShowTest.php
@@ -26,7 +26,7 @@ class ShowTest extends TestCase
                 '',
                 200,
                 'application/json',
-                $response
+                $response,
             ]
         );
 

--- a/tests/Unit/Api/Version/ShowTest.php
+++ b/tests/Unit/Api/Version/ShowTest.php
@@ -27,7 +27,7 @@ class ShowTest extends TestCase
                 200,
                 'application/json',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/Version/UpdateTest.php
+++ b/tests/Unit/Api/Version/UpdateTest.php
@@ -29,7 +29,7 @@ class UpdateTest extends TestCase
                 $responseCode,
                 '',
                 $response,
-            ]
+            ],
         );
 
         // Update the object under test

--- a/tests/Unit/Api/Version/UpdateTest.php
+++ b/tests/Unit/Api/Version/UpdateTest.php
@@ -28,7 +28,7 @@ class UpdateTest extends TestCase
                 $expectedBody,
                 $responseCode,
                 '',
-                $response
+                $response,
             ]
         );
 

--- a/tests/Unit/Api/VersionTest.php
+++ b/tests/Unit/Api/VersionTest.php
@@ -28,13 +28,13 @@ class VersionTest extends TestCase
             function ($errno, $errstr): bool {
                 $this->assertSame(
                     '`Redmine\Api\Version::all()` is deprecated since v2.4.0, use `Redmine\Api\Version::listByProject()` instead.',
-                    $errstr
+                    $errstr,
                 );
 
                 restore_error_handler();
                 return true;
             },
-            E_USER_DEPRECATED
+            E_USER_DEPRECATED,
         );
 
         $api->all(5);
@@ -98,8 +98,8 @@ class VersionTest extends TestCase
                 $this->logicalAnd(
                     $this->stringStartsWith('/projects/5/versions.json'),
                     $this->stringContains('offset=10'),
-                    $this->stringContains('limit=2')
-                )
+                    $this->stringContains('limit=2'),
+                ),
             )
             ->willReturn(true);
         $client->expects($this->once())
@@ -259,7 +259,7 @@ class VersionTest extends TestCase
         $client->expects($this->once())
             ->method('requestGet')
             ->with(
-                $this->stringStartsWith('/projects/5/versions.json')
+                $this->stringStartsWith('/projects/5/versions.json'),
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))

--- a/tests/Unit/Api/Wiki/CreateTest.php
+++ b/tests/Unit/Api/Wiki/CreateTest.php
@@ -30,7 +30,7 @@ class CreateTest extends TestCase
                 $responseCode,
                 'application/xml',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/Wiki/CreateTest.php
+++ b/tests/Unit/Api/Wiki/CreateTest.php
@@ -29,7 +29,7 @@ class CreateTest extends TestCase
                 $expectedBody,
                 $responseCode,
                 'application/xml',
-                $response
+                $response,
             ]
         );
 

--- a/tests/Unit/Api/Wiki/RemoveTest.php
+++ b/tests/Unit/Api/Wiki/RemoveTest.php
@@ -28,7 +28,7 @@ class RemoveTest extends TestCase
                 '',
                 $responseCode,
                 '',
-                $response
+                $response,
             ]
         );
 

--- a/tests/Unit/Api/Wiki/RemoveTest.php
+++ b/tests/Unit/Api/Wiki/RemoveTest.php
@@ -29,7 +29,7 @@ class RemoveTest extends TestCase
                 $responseCode,
                 '',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/Wiki/ShowTest.php
+++ b/tests/Unit/Api/Wiki/ShowTest.php
@@ -26,7 +26,7 @@ class ShowTest extends TestCase
                 '',
                 200,
                 'application/json',
-                $response
+                $response,
             ]
         );
 

--- a/tests/Unit/Api/Wiki/ShowTest.php
+++ b/tests/Unit/Api/Wiki/ShowTest.php
@@ -27,7 +27,7 @@ class ShowTest extends TestCase
                 200,
                 'application/json',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/Wiki/UpdateTest.php
+++ b/tests/Unit/Api/Wiki/UpdateTest.php
@@ -29,7 +29,7 @@ class UpdateTest extends TestCase
                 $responseCode,
                 '',
                 $response,
-            ]
+            ],
         );
 
         // Create the object under test

--- a/tests/Unit/Api/Wiki/UpdateTest.php
+++ b/tests/Unit/Api/Wiki/UpdateTest.php
@@ -28,7 +28,7 @@ class UpdateTest extends TestCase
                 $expectedBody,
                 $responseCode,
                 '',
-                $response
+                $response,
             ]
         );
 

--- a/tests/Unit/Api/WikiTest.php
+++ b/tests/Unit/Api/WikiTest.php
@@ -27,13 +27,13 @@ class WikiTest extends TestCase
             function ($errno, $errstr): bool {
                 $this->assertSame(
                     '`Redmine\Api\Wiki::all()` is deprecated since v2.4.0, use `Redmine\Api\Wiki::listByProject()` instead.',
-                    $errstr
+                    $errstr,
                 );
 
                 restore_error_handler();
                 return true;
             },
-            E_USER_DEPRECATED
+            E_USER_DEPRECATED,
         );
 
         $api->all(5);
@@ -97,8 +97,8 @@ class WikiTest extends TestCase
                 $this->logicalAnd(
                     $this->stringStartsWith('/projects/5/wiki/index.json'),
                     $this->stringContains('offset=10'),
-                    $this->stringContains('limit=2')
-                )
+                    $this->stringContains('limit=2'),
+                ),
             )
             ->willReturn(true);
         $client->expects($this->once())

--- a/tests/Unit/Client/NativeCurlClient/RequestTest.php
+++ b/tests/Unit/Client/NativeCurlClient/RequestTest.php
@@ -47,7 +47,7 @@ class RequestTest extends TestCase
 
         $client = new NativeCurlClient(
             'http://test.local',
-            'access_token'
+            'access_token',
         );
 
         /** @var Request|\PHPUnit\Framework\MockObject\MockObject */
@@ -120,7 +120,7 @@ class RequestTest extends TestCase
 
         $client = new NativeCurlClient(
             'http://test.local',
-            'access_token'
+            'access_token',
         );
 
         // PHPUnit 10 compatible way to test trigger_error().
@@ -128,13 +128,13 @@ class RequestTest extends TestCase
             function ($errno, $errstr): bool {
                 $this->assertSame(
                     'Uploading an attachment by filepath is deprecated since v2.1.0, use file_get_contents() to upload the file content instead.',
-                    $errstr
+                    $errstr,
                 );
 
                 restore_error_handler();
                 return true;
             },
-            E_USER_DEPRECATED
+            E_USER_DEPRECATED,
         );
 
         /** @var Request|\PHPUnit\Framework\MockObject\MockObject */

--- a/tests/Unit/Client/NativeCurlClientTest.php
+++ b/tests/Unit/Client/NativeCurlClientTest.php
@@ -39,7 +39,7 @@ class NativeCurlClientTest extends TestCase
     {
         $client = new NativeCurlClient(
             'http://test.local',
-            'access_token'
+            'access_token',
         );
 
         $this->assertInstanceOf(NativeCurlClient::class, $client);
@@ -52,7 +52,7 @@ class NativeCurlClientTest extends TestCase
         $client = new NativeCurlClient(
             'http://test.local',
             'username',
-            'password'
+            'password',
         );
 
         $this->assertInstanceOf(NativeCurlClient::class, $client);
@@ -63,7 +63,7 @@ class NativeCurlClientTest extends TestCase
     {
         $client = new NativeCurlClient(
             'http://test.local',
-            'access_token'
+            'access_token',
         );
 
         $this->assertSame(0, $client->getLastResponseStatusCode());
@@ -73,7 +73,7 @@ class NativeCurlClientTest extends TestCase
     {
         $client = new NativeCurlClient(
             'http://test.local',
-            'access_token'
+            'access_token',
         );
 
         $this->assertSame('', $client->getLastResponseContentType());
@@ -83,7 +83,7 @@ class NativeCurlClientTest extends TestCase
     {
         $client = new NativeCurlClient(
             'http://test.local',
-            'access_token'
+            'access_token',
         );
 
         $this->assertSame('', $client->getLastResponseBody());
@@ -135,7 +135,7 @@ class NativeCurlClientTest extends TestCase
 
         $client = new NativeCurlClient(
             'http://test.local',
-            'access_token'
+            'access_token',
         );
 
         $client->requestGet('/path');
@@ -190,7 +190,7 @@ class NativeCurlClientTest extends TestCase
 
         $client = new NativeCurlClient(
             'http://test.local',
-            'access_token'
+            'access_token',
         );
 
         $client->requestGet('/path');
@@ -246,7 +246,7 @@ class NativeCurlClientTest extends TestCase
 
         $client = new NativeCurlClient(
             'http://test.local',
-            'access_token'
+            'access_token',
         );
 
         $client->requestGet('/path');
@@ -302,7 +302,7 @@ class NativeCurlClientTest extends TestCase
 
         $client = new NativeCurlClient(
             'http://test.local',
-            'access_token'
+            'access_token',
         );
 
         $client->requestGet('/path');
@@ -359,7 +359,7 @@ class NativeCurlClientTest extends TestCase
 
         $client = new NativeCurlClient(
             'http://test.local',
-            'access_token'
+            'access_token',
         );
 
         $client->requestGet('/path');
@@ -420,7 +420,7 @@ class NativeCurlClientTest extends TestCase
 
         $client = new NativeCurlClient(
             'http://test.local',
-            'access_token'
+            'access_token',
         );
 
         $client->requestGet('/path');
@@ -477,7 +477,7 @@ class NativeCurlClientTest extends TestCase
 
         $client = new NativeCurlClient(
             'http://test.local',
-            'access_token'
+            'access_token',
         );
 
         $client->requestGet('/path');
@@ -531,7 +531,7 @@ class NativeCurlClientTest extends TestCase
 
         $client = new NativeCurlClient(
             'https://test.local',
-            'access_token'
+            'access_token',
         );
 
         $client->requestGet('/path');
@@ -570,7 +570,7 @@ class NativeCurlClientTest extends TestCase
         $curlSetoptArray->expects($this->exactly(1))
             ->with(
                 $this->anything(),
-                $this->identicalTo($expectedOptions)
+                $this->identicalTo($expectedOptions),
             )
         ;
 
@@ -581,7 +581,7 @@ class NativeCurlClientTest extends TestCase
 
         $client = new NativeCurlClient(
             'http://test.local:3456',
-            'access_token'
+            'access_token',
         );
 
         $client->requestGet('/path');
@@ -616,7 +616,7 @@ class NativeCurlClientTest extends TestCase
 
         $client = new NativeCurlClient(
             'http://test.local',
-            'access_token'
+            'access_token',
         );
 
         $this->assertSame($boolReturn, $client->$method('/path', $data));
@@ -680,7 +680,7 @@ class NativeCurlClientTest extends TestCase
 
         $client = new NativeCurlClient(
             'http://test.local',
-            'access_token'
+            'access_token',
         );
 
         $this->assertSame(true, $client->requestPut('/path', '{"foo":"bar"}'));
@@ -711,7 +711,7 @@ class NativeCurlClientTest extends TestCase
 
         $client = new NativeCurlClient(
             'http://test.local',
-            'access_token'
+            'access_token',
         );
 
         $this->expectException(Exception::class);
@@ -728,7 +728,7 @@ class NativeCurlClientTest extends TestCase
     {
         $client = new NativeCurlClient(
             'http://test.local',
-            'access_token'
+            'access_token',
         );
 
         $this->assertInstanceOf($class, $client->getApi($apiName));
@@ -763,7 +763,7 @@ class NativeCurlClientTest extends TestCase
     {
         $client = new NativeCurlClient(
             'http://test.local',
-            'access_token'
+            'access_token',
         );
 
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Unit/Client/Psr18Client/RequestTest.php
+++ b/tests/Unit/Client/Psr18Client/RequestTest.php
@@ -52,7 +52,7 @@ class RequestTest extends TestCase
             $requestFactory,
             $this->createMock(StreamFactoryInterface::class),
             'http://test.local',
-            'access_token'
+            'access_token',
         );
 
         $request = $this->createConfiguredMock(Request::class, [
@@ -101,7 +101,7 @@ class RequestTest extends TestCase
     {
         $httpClient = $this->createMock(ClientInterface::class);
         $httpClient->expects($this->exactly(1))->method('sendRequest')->willThrowException(
-            new class ('error message') extends Exception implements ClientExceptionInterface {}
+            new class ('error message') extends Exception implements ClientExceptionInterface {},
         );
 
         $requestFactory = $this->createConfiguredMock(RequestFactoryInterface::class, [
@@ -119,7 +119,7 @@ class RequestTest extends TestCase
             $requestFactory,
             $this->createMock(StreamFactoryInterface::class),
             'http://test.local',
-            'access_token'
+            'access_token',
         );
 
         $request = $this->createConfiguredMock(Request::class, [

--- a/tests/Unit/Client/Psr18Client/RequestTest.php
+++ b/tests/Unit/Client/Psr18Client/RequestTest.php
@@ -34,7 +34,7 @@ class RequestTest extends TestCase
                 'getBody' => $this->createConfiguredMock(StreamInterface::class, [
                     '__toString' => $content,
                 ]),
-            ])
+            ]),
         ]);
 
         $requestFactory = $this->createConfiguredMock(RequestFactoryInterface::class, [

--- a/tests/Unit/Client/Psr18ClientTest.php
+++ b/tests/Unit/Client/Psr18ClientTest.php
@@ -30,7 +30,7 @@ class Psr18ClientTest extends TestCase
             $this->createMock(RequestFactoryInterface::class),
             $this->createMock(StreamFactoryInterface::class),
             'http://test.local',
-            'access_token'
+            'access_token',
         );
 
         $this->assertInstanceOf(Psr18Client::class, $client);
@@ -53,7 +53,7 @@ class Psr18ClientTest extends TestCase
             ]),
             $this->createMock(StreamFactoryInterface::class),
             'http://test.local',
-            'access_token'
+            'access_token',
         );
 
         $this->assertInstanceOf(Psr18Client::class, $client);
@@ -70,7 +70,7 @@ class Psr18ClientTest extends TestCase
             $this->createMock(StreamFactoryInterface::class),
             'http://test.local',
             'username',
-            'password'
+            'password',
         );
 
         $this->assertInstanceOf(Psr18Client::class, $client);
@@ -84,7 +84,7 @@ class Psr18ClientTest extends TestCase
             $this->createMock(RequestFactoryInterface::class),
             $this->createMock(StreamFactoryInterface::class),
             'http://test.local',
-            'access_token'
+            'access_token',
         );
 
         $this->assertSame(0, $client->getLastResponseStatusCode());
@@ -97,7 +97,7 @@ class Psr18ClientTest extends TestCase
             $this->createMock(RequestFactoryInterface::class),
             $this->createMock(StreamFactoryInterface::class),
             'http://test.local',
-            'access_token'
+            'access_token',
         );
 
         $this->assertSame('', $client->getLastResponseContentType());
@@ -110,7 +110,7 @@ class Psr18ClientTest extends TestCase
             $this->createMock(RequestFactoryInterface::class),
             $this->createMock(StreamFactoryInterface::class),
             'http://test.local',
-            'access_token'
+            'access_token',
         );
 
         $this->assertSame('', $client->getLastResponseBody());
@@ -136,7 +136,7 @@ class Psr18ClientTest extends TestCase
             $requestFactory,
             $this->createMock(StreamFactoryInterface::class),
             'http://test.local',
-            'access_token'
+            'access_token',
         );
 
         $client->requestGet('/path');
@@ -165,7 +165,7 @@ class Psr18ClientTest extends TestCase
             $requestFactory,
             $this->createMock(StreamFactoryInterface::class),
             'http://test.local',
-            'access_token'
+            'access_token',
         );
 
         $this->assertSame(false, $client->requestGet('/path'));
@@ -200,7 +200,7 @@ class Psr18ClientTest extends TestCase
             $requestFactory,
             $this->createMock(StreamFactoryInterface::class),
             'http://test.local',
-            'access_token'
+            'access_token',
         );
 
         $this->assertSame($boolReturn, $client->$method('/path', $data));
@@ -246,7 +246,7 @@ class Psr18ClientTest extends TestCase
             $this->createMock(RequestFactoryInterface::class),
             $this->createMock(StreamFactoryInterface::class),
             'http://test.local',
-            'access_token'
+            'access_token',
         );
 
         $this->assertInstanceOf($class, $client->getApi($apiName));
@@ -288,7 +288,7 @@ class Psr18ClientTest extends TestCase
             new stdClass(),
             $this->createMock(StreamFactoryInterface::class),
             'http://test.local',
-            'access_token'
+            'access_token',
         );
     }
 
@@ -299,7 +299,7 @@ class Psr18ClientTest extends TestCase
             $this->createMock(RequestFactoryInterface::class),
             $this->createMock(StreamFactoryInterface::class),
             'http://test.local',
-            'access_token'
+            'access_token',
         );
 
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Unit/Serializer/XmlSerializerTest.php
+++ b/tests/Unit/Serializer/XmlSerializerTest.php
@@ -314,7 +314,7 @@ class XmlSerializerTest extends TestCase
             'invalid element name as start tag' => [
                 'Could not create XML from array: "StartTag: invalid element name' . "\n" . '", "Extra content at the end of the document' . "\n" . '"',
                 ['0' => ['foobar']],
-            ]
+            ],
         ];
     }
 }


### PR DESCRIPTION
PHP-CS-Fixer has updated the [PER-CS2.0 ruleset](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/ruleSets/PER-CS2.0.rst). It will now add trailing comma in multiline after `parameters` and `match`. This is only [supported since PHP 8.0](https://php.watch/versions/8.0/trailing-comma-parameter-use-list). So I've added a restriction for this rule to support PHP 7.4 for now. After dropping support for PHP 7.4 this rule restriction should be removed.