### PR TITLE
Update BDD tests to redmine 5.1.3 and 5.0.9

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
             - ./:/var/www/project/ # Location of the project for php-fpm. Note this should be the same for NGINX.*
 
     redmine-dev:
-        image: redmine:5.1.2
+        image: redmine:5.1.3
         user: "1000:1000"
         ports:
             - "3000:3000"
@@ -24,28 +24,30 @@ services:
             - ./.docker/redmine-dev_data/files:/usr/src/redmine/files
             - ./.docker/redmine-dev_data/sqlite:/usr/src/redmine/sqlite
 
-    # Make sure the following services are supported in /tests/RedmineExtension/RedmineInstance.php
+    # Make sure the following services are configured in:
+    # - /tests/RedmineExtension/RedmineInstance.php
+    # - /tests/Behat/behat.yml
 
-    redmine-50102:
-        image: redmine:5.1.2
+    redmine-50103:
+        image: redmine:5.1.3
         user: "1000:1000"
         ports:
-            - "5101:3000"
+            - "5103:3000"
         environment:
             REDMINE_SECRET_KEY_BASE: supersecretkey
             REDMINE_PLUGINS_MIGRATE: true
         volumes:
-            - ./.docker/redmine-50102_data/files:/usr/src/redmine/files
-            - ./.docker/redmine-50102_data/sqlite:/usr/src/redmine/sqlite
+            - ./.docker/redmine-50103_data/files:/usr/src/redmine/files
+            - ./.docker/redmine-50103_data/sqlite:/usr/src/redmine/sqlite
 
-    redmine-50008:
-        image: redmine:5.0.8
+    redmine-50009:
+        image: redmine:5.0.9
         user: "1000:1000"
         ports:
-            - "5007:3000"
+            - "5009:3000"
         environment:
             REDMINE_SECRET_KEY_BASE: supersecretkey
             REDMINE_PLUGINS_MIGRATE: true
         volumes:
-            - ./.docker/redmine-50008_data/files:/usr/src/redmine/files
-            - ./.docker/redmine-50008_data/sqlite:/usr/src/redmine/sqlite
+            - ./.docker/redmine-50009_data/files:/usr/src/redmine/files
+            - ./.docker/redmine-50009_data/sqlite:/usr/src/redmine/sqlite

--- a/tests/Behat/behat.yml
+++ b/tests/Behat/behat.yml
@@ -1,14 +1,14 @@
 default:
     suites:
-        redmine_50102:
+        redmine_50103:
             paths:
                 - '%paths.base%/features'
             contexts:
                 - Redmine\Tests\Behat\Bootstrap\FeatureContext:
-                    redmineVersion: '5.1.2'
-        redmine_50008:
+                    redmineVersion: '5.1.3'
+        redmine_50009:
             paths:
                 - '%paths.base%/features'
             contexts:
                 - Redmine\Tests\Behat\Bootstrap\FeatureContext:
-                    redmineVersion: '5.0.8'
+                    redmineVersion: '5.0.9'

--- a/tests/RedmineExtension/RedmineInstance.php
+++ b/tests/RedmineExtension/RedmineInstance.php
@@ -12,12 +12,13 @@ final class RedmineInstance
 {
     /**
      * Make sure that supported versions have a service in /docker-composer.yml
+     * and are configured in /tests/Behat/behat.yml
      */
     public static function getSupportedVersions(): array
     {
         return [
-            RedmineVersion::V5_1_2,
-            RedmineVersion::V5_0_8,
+            RedmineVersion::V5_1_3,
+            RedmineVersion::V5_0_9,
         ];
     }
 

--- a/tests/RedmineExtension/RedmineVersion.php
+++ b/tests/RedmineExtension/RedmineVersion.php
@@ -7,6 +7,14 @@ namespace Redmine\Tests\RedmineExtension;
 enum RedmineVersion: string
 {
     /**
+     * Redmine 5.1.3
+     *
+     * @link https://www.redmine.org/versions/195
+     * @link https://www.redmine.org/projects/redmine/wiki/Changelog_5_1#513-2024-06-12
+     */
+    case V5_1_3 = '5.1.3';
+
+    /**
      * Redmine 5.1.2
      *
      * @link https://www.redmine.org/versions/193
@@ -29,6 +37,15 @@ enum RedmineVersion: string
      * @link https://www.redmine.org/projects/redmine/wiki/Changelog_5_1#510-2023-10-31
      */
     case V5_1_0 = '5.1.0';
+
+    /**
+     * Redmine 5.0.9
+     *
+     * @link https://www.redmine.org/versions/194
+     * @link https://www.redmine.org/projects/redmine/wiki/Changelog_5_0#509-2024-06-11
+     */
+
+    case V5_0_9 = '5.0.9';
 
     /**
      * Redmine 5.0.8


### PR DESCRIPTION
[Redmine 5.1.3 and 5.0.9 has been released](https://www.redmine.org/news/145) on 2024-06-12. This PR adjusts the BDD tests so the Behat tests can be run against the newest versions.

I'm thinking about whether it makes sense to automatically create a Github issue when a new Redmine version is released. We could use this RSS feed: https://www.redmine.org/projects/redmine/news.atom

**Update:** see #405 