### PR TITLE
Create Github issue on new redmine releases

### DIFF
--- a/.github/workflows/check-for-releases.yml
+++ b/.github/workflows/check-for-releases.yml
@@ -3,8 +3,8 @@ name: Check for new Redmine releases
 on:
   workflow_dispatch:
   schedule:
-    # Run this Action at every 5th minute
-    - cron: "*/2 * * * *"
+    # Run this Action every day a 5:35am UTC
+    - cron: "37 5 * * *"
 
 jobs:
   redmine-release:
@@ -20,5 +20,5 @@ jobs:
           prefix: "Update the Behat tests: "
           #character-limit: 255
           dry-run: false
-          max-age: 511h
+          max-age: 3360h
           labels: "enhancement"

--- a/.github/workflows/check-for-releases.yml
+++ b/.github/workflows/check-for-releases.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   schedule:
     # Run this Action at every 5th minute
-    - cron: "*/5 * * * *"
+    - cron: "*/2 * * * *"
 
 jobs:
   redmine-release:

--- a/.github/workflows/check-for-releases.yml
+++ b/.github/workflows/check-for-releases.yml
@@ -1,6 +1,7 @@
 name: Check for new Redmine releases
 
 on:
+  workflow_dispatch:
   schedule:
     # Run this Action at every 5th minute
     - cron: "*/5 * * * *"

--- a/.github/workflows/check-for-releases.yml
+++ b/.github/workflows/check-for-releases.yml
@@ -17,8 +17,8 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           feed: https://www.redmine.org/projects/redmine/news.atom
-          prefix: "Update tests: "
+          prefix: "Update the Behat tests: "
           #character-limit: 255
-          dry-run: true
+          dry-run: false
           max-age: 511h
           labels: "enhancement"

--- a/.github/workflows/check-for-releases.yml
+++ b/.github/workflows/check-for-releases.yml
@@ -20,5 +20,5 @@ jobs:
           prefix: "Update the Behat tests: "
           #character-limit: 255
           dry-run: false
-          max-age: 3360h
+          max-age: 72h
           labels: "enhancement"

--- a/.github/workflows/check-for-releases.yml
+++ b/.github/workflows/check-for-releases.yml
@@ -1,0 +1,20 @@
+name: Check for new Redmine releases
+
+on:
+  schedule:
+    # Run this Action at every 5th minute
+    - cron: "*/5 * * * *"
+
+jobs:
+  redmine-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: git-for-windows/rss-to-issues@v0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          feed: https://www.redmine.org/projects/redmine/news.atom
+          prefix: "Update tests: "
+          character-limit: 255
+          dry-run: true
+          max-age: 100h
+          labels: "enhancement"

--- a/.github/workflows/check-for-releases.yml
+++ b/.github/workflows/check-for-releases.yml
@@ -16,5 +16,5 @@ jobs:
           prefix: "Update tests: "
           character-limit: 255
           dry-run: true
-          max-age: 100h
+          max-age: 511h
           labels: "enhancement"

--- a/.github/workflows/check-for-releases.yml
+++ b/.github/workflows/check-for-releases.yml
@@ -18,7 +18,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           feed: https://www.redmine.org/projects/redmine/news.atom
           prefix: "Update tests: "
-          character-limit: 255
+          #character-limit: 255
           dry-run: true
           max-age: 511h
           labels: "enhancement"

--- a/.github/workflows/check-for-releases.yml
+++ b/.github/workflows/check-for-releases.yml
@@ -3,7 +3,7 @@ name: Check for new Redmine releases
 on:
   workflow_dispatch:
   schedule:
-    # Run this Action every day a 5:35am UTC
+    # Run this Action every day a 5:37am UTC
     - cron: "37 5 * * *"
 
 jobs:

--- a/.github/workflows/check-for-releases.yml
+++ b/.github/workflows/check-for-releases.yml
@@ -8,9 +8,12 @@ on:
 
 jobs:
   redmine-release:
+    name: Check for Redmine updates
     runs-on: ubuntu-latest
+
     steps:
-      - uses: git-for-windows/rss-to-issues@v0
+      - name: Check for updates
+        uses: git-for-windows/rss-to-issues@v0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           feed: https://www.redmine.org/projects/redmine/news.atom


### PR DESCRIPTION
This PR uses the [RSS to Issues GitHub Action](https://github.com/marketplace/actions/rss-to-issues) to check the [Redmine news RSS feed](https://www.redmine.org/projects/redmine/news.atom) every 24h for new Redmine releases. If a new post is published, a Github issue will be created. See [here](https://github.com/Art4/php-redmine-api/issues/1) and [here](https://github.com/Art4/php-redmine-api/issues/2) as example.

This way we will get notified if a new Redmine version is released.