### PR TITLE
PHP 8.4 Fix implicitly nullable parameter declarations deprecations

### DIFF
--- a/src/Redmine/Client/NativeCurlClient.php
+++ b/src/Redmine/Client/NativeCurlClient.php
@@ -36,7 +36,7 @@ final class NativeCurlClient implements Client, HttpClient
     public function __construct(
         string $url,
         string $apikeyOrUsername,
-        string $password = null
+        ?string $password = null
     ) {
         $this->url = $url;
         $this->apikeyOrUsername = $apikeyOrUsername;

--- a/src/Redmine/Client/Psr18Client.php
+++ b/src/Redmine/Client/Psr18Client.php
@@ -45,7 +45,7 @@ final class Psr18Client implements Client, HttpClient
         StreamFactoryInterface $streamFactory,
         string $url,
         string $apikeyOrUsername,
-        string $password = null
+        ?string $password = null
     ) {
         if (! $requestFactory instanceof RequestFactoryInterface && $requestFactory instanceof ServerRequestFactoryInterface) {
             @trigger_error(

--- a/src/Redmine/Exception/UnexpectedResponseException.php
+++ b/src/Redmine/Exception/UnexpectedResponseException.php
@@ -21,7 +21,7 @@ final class UnexpectedResponseException extends RuntimeException implements Redm
      */
     private $response = null;
 
-    public static function create(Response $response, Throwable $prev = null): self
+    public static function create(Response $response, ?Throwable $prev = null): self
     {
         $e = new self(
             'The Redmine server replied with an unexpected response.',


### PR DESCRIPTION
This PR fixes the PHP 8.4 deprecation warnings for implicitly nullable parameter declarations, see https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated

> PHP 8.4 deprecates implicitly nullable types. PHP applications are recommended to explicitly declare the type as nullable. All type declarations that have a default value of null, but without declaring null in the type declaration emit a deprecation notice