### PR TITLE
Improve BDD with new testing command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,12 @@
         "sort-packages": true
     },
     "scripts": {
-        "behat": "behat --config tests/Behat/behat.yml --format progress",
+        "bdt": [
+            "@behat --format=progress --suite=redmine_50103",
+            "@behat --format=progress --suite=redmine_50009",
+            "@behat --format=progress --suite=redmine_40210"
+        ],
+        "behat": "behat --config tests/Behat/behat.yml",
         "codestyle": "php-cs-fixer fix",
         "coverage": "phpunit --coverage-html=\".phpunit.cache/code-coverage\"",
         "phpstan": "phpstan analyze --memory-limit 512M --configuration .phpstan.neon",

--- a/tests/Behat/README.md
+++ b/tests/Behat/README.md
@@ -10,27 +10,35 @@ Pull the Redmine docker images and start them by running:
 docker compose up -d
 ```
 
-Now you can run the tests:
+Now you can run all behaviour-driven tests grouped by Redmine version using the `bdt` command:
 
 ```bash
 # all tests
-docker compose exec php composer behat
-# only a specific redmine version
-docker compose exec php composer behat -- --suite=redmine_50103
-# only specific endpoints
-docker compose exec php composer behat -- --tags=issue,group
-# only specific endpoints on a specific redmine version
-docker compose exec php composer behat -- --suite=redmine_50103 --tags=issue,group
+docker compose exec php composer bdt
 ```
 
-## Redmine specific features
+If you need more control about the behat tests or want to change the output format,
+you can use the `behat` command directly:
 
-Some Redmine features are specific for a Redmine version. There are two ways to handle this situations.
+```bash
+# test only a specific redmine version
+docker compose exec php composer behat -- --suite=redmine_50103
+# test only specific endpoints
+docker compose exec php composer behat -- --tags=issue,group
+# test only specific endpoints on a specific redmine version
+docker compose exec php composer behat -- --suite=redmine_50103 --tags=issue,group
+# test only a specific redmine version and format the output as `progress` (default is `pretty`)
+docker compose exec php composer behat -- --suite=redmine_50103 --format=progress
+```
+
+## Redmine version specific features
+
+Some Redmine features are specific for a Redmine version. Theses situations are handled in different ways.
 
 ### Modified Rest-API Responses
 
 It is possible that a new Redmine version returns new or changed elements in a response.
-This can be handled on the `step` layer:
+This can be handled on the `step` layer (note the missing `homepage` property in `< 5.1.0`):
 
 ```
         And the returned data "projects.0" property has only the following properties with Redmine version ">= 5.1.0"
@@ -40,11 +48,6 @@ This can be handled on the `step` layer:
             identifier
             description
             homepage
-            status
-            is_public
-            inherit_members
-            created_on
-            updated_on
             """
         But the returned data "projects.0" property has only the following properties with Redmine version "< 5.1.0"
             """
@@ -52,17 +55,13 @@ This can be handled on the `step` layer:
             name
             identifier
             description
-            status
-            is_public
-            inherit_members
-            created_on
-            updated_on
             """
 ```
 
 ### New Rest-API Endpoints
 
-A new Redmine version could be introduce new REST-API endpoints that are missing in the older version.
+A new Redmine version could introduce new REST-API endpoints.
+Tests for this endpoint should not be run on older Redmine versions.
 This can be handled on the `scenario` or `feature` layer.
 
 1. Tag features or scenarios e.g. with `@since50000`.
@@ -98,7 +97,8 @@ default:
 
 ### Removed Rest-API Endpoints
 
-A new Redmine version could remove REST-API endpoints that are missing in the newer versions.
+A new Redmine version could remove REST-API endpoints.
+Tests for this endpoint should not be run on newer Redmine versions.
 This can be handled on the `scenario` or `feature` layer.
 
 1. Tag features or scenarios e.g. with `@until60000`.


### PR DESCRIPTION
Using Behat for BDD and BDT is really impressive and useful. For new features I create a temporary tag `@wip` and run `docker compose exec php composer behat -- --tags=wip`. To test the feature on a specific redmine version I run `docker compose exec php composer behat -- --tags=issue,group --suite=redmine=50103`. If the feature is ready I run all behat tests on all redmine versions using `docker compose exec php composer behat`.

However the tests are becoming bigger and that leads to 1.) higher usage of time and memory to execute all tests at once. And 2.) it is not possible to change the format of the output using CLI (because the `--output=progress` is already declared in `composer.json`).

This PR solves these problems by creating a new `bdt` composer command for tests grouped by Redmine versions (aka behat suites). The output there is always formatted as `progress`. If one test fails it is now easier to find the Redmine version, where the test has failed thanks to the separation by behat suite.

<details><summary>Test-run: docker compose exec php composer bdt </summary>

```bash
$ docker compose exec php composer bdt
> behat --config tests/Behat/behat.yml '--format=progress' '--suite=redmine_50103'
...................................................................... 70
...................................................................... 140
...................................................................... 210
...................................................................... 280
...................................................................... 350
...................................................................... 420
...................................................................... 490
...................................................................... 560
...................................................................... 630
...................................................................... 700
...................................................................... 770
...................................................................... 840
..............................................

89 scenarios (89 passed)
886 steps (886 passed)
1m56.30s (15.69Mb)
> behat --config tests/Behat/behat.yml '--format=progress' '--suite=redmine_50009'
...................................................................... 70
...................................................................... 140
...................................................................... 210
...................................................................... 280
...................................................................... 350
...................................................................... 420
...................................................................... 490
...................................................................... 560
...................................................................... 630
...................................................................... 700
...................................................................... 770
...................................................................... 840
..............................................

89 scenarios (89 passed)
886 steps (886 passed)
2m9.03s (15.66Mb)
> behat --config tests/Behat/behat.yml '--format=progress' '--suite=redmine_40210'
...................................................................... 70
...................................................................... 140
...................................................................... 210
...................................................................... 280
...................................................................... 350
...................................................................... 420
...................................................................... 490
...................................................................... 560
...................................................................... 630
...................................................................... 700
...................................................................... 770
...................................................................... 840
..


84 scenarios (84 passed)
842 steps (842 passed)
1m59.39s (15.57Mb)
```

</details> 

The `behat` command will be changed to have no output format (defaults to `--format=pretty`). So if I run `docker compose exec php composer behat -- --tags=wip` I will get the pretty format that helps me with debugging. If I want to have the `progress` output I can declare it with `docker compose exec php composer behat -- --tags=wip --format=progress`.

This PR also improves the test docs explaining the different commands. I've tested theses new commands while working on #419.