### PR TITLE
Deprecate all `Redmine\Api\*::getIdBy...()` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Redmine\Api\CustomField::getIdByName()` is deprecated, use `\Redmine\Api\CustomField::listNames()` instead.
 - `Redmine\Api\Group::listing()` is deprecated, use `\Redmine\Api\Group::listNames()` instead.
 - `Redmine\Api\IssueCategory::listing()` is deprecated, use `\Redmine\Api\IssueCategory::listNamesByProject()` instead.
+- `Redmine\Api\IssueCategory::getIdByName()` is deprecated, use `\Redmine\Api\IssueCategory::listNamesByProject()` instead.
 - `Redmine\Api\IssueStatus::listing()` is deprecated, use `\Redmine\Api\IssueStatus::listNames()` instead.
 - `Redmine\Api\Project::listing()` is deprecated, use `\Redmine\Api\Project::listNames()` instead.
 - `Redmine\Api\Role::listing()` is deprecated, use `\Redmine\Api\Role::listNames()` instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Redmine\Api\Project::getIdByName()` is deprecated, use `\Redmine\Api\Project::listNames()` instead.
 - `Redmine\Api\Role::listing()` is deprecated, use `\Redmine\Api\Role::listNames()` instead.
 - `Redmine\Api\TimeEntryActivity::listing()` is deprecated, use `\Redmine\Api\TimeEntryActivity::listNames()` instead.
+- `Redmine\Api\TimeEntryActivity::getIdByName()` is deprecated, use `\Redmine\Api\TimeEntryActivity::listNames()` instead.
 - `Redmine\Api\Tracker::listing()` is deprecated, use `\Redmine\Api\Tracker::listNames()` instead.
 - `Redmine\Api\User::listing()` is deprecated, use `\Redmine\Api\User::listLogins()` instead.
 - `Redmine\Api\Version::listing()` is deprecated, use `\Redmine\Api\Version::listNamesByProject()` instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 - `Redmine\Api\CustomField::listing()` is deprecated, use `\Redmine\Api\CustomField::listNames()` instead.
+- `Redmine\Api\CustomField::getIdByName()` is deprecated, use `\Redmine\Api\CustomField::listNames()` instead.
 - `Redmine\Api\Group::listing()` is deprecated, use `\Redmine\Api\Group::listNames()` instead.
 - `Redmine\Api\IssueCategory::listing()` is deprecated, use `\Redmine\Api\IssueCategory::listNamesByProject()` instead.
 - `Redmine\Api\IssueStatus::listing()` is deprecated, use `\Redmine\Api\IssueStatus::listNames()` instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Redmine\Api\Tracker::listing()` is deprecated, use `\Redmine\Api\Tracker::listNames()` instead.
 - `Redmine\Api\Tracker::getIdByName()` is deprecated, use `\Redmine\Api\Tracker::listNames()` instead.
 - `Redmine\Api\User::listing()` is deprecated, use `\Redmine\Api\User::listLogins()` instead.
+- `Redmine\Api\User::getIdByUsername()` is deprecated, use `\Redmine\Api\User::listLogins()` instead.
 - `Redmine\Api\Version::listing()` is deprecated, use `\Redmine\Api\Version::listNamesByProject()` instead.
 
 ## [v2.6.0](https://github.com/kbsali/php-redmine-api/compare/v2.5.0...v2.6.0) - 2024-03-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Redmine\Api\IssueCategory::listing()` is deprecated, use `\Redmine\Api\IssueCategory::listNamesByProject()` instead.
 - `Redmine\Api\IssueCategory::getIdByName()` is deprecated, use `\Redmine\Api\IssueCategory::listNamesByProject()` instead.
 - `Redmine\Api\IssueStatus::listing()` is deprecated, use `\Redmine\Api\IssueStatus::listNames()` instead.
+- `Redmine\Api\IssueStatus::getIdByName()` is deprecated, use `\Redmine\Api\IssueStatus::listNames()` instead.
 - `Redmine\Api\Project::listing()` is deprecated, use `\Redmine\Api\Project::listNames()` instead.
 - `Redmine\Api\Role::listing()` is deprecated, use `\Redmine\Api\Role::listNames()` instead.
 - `Redmine\Api\TimeEntryActivity::listing()` is deprecated, use `\Redmine\Api\TimeEntryActivity::listNames()` instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Redmine\Api\User::listing()` is deprecated, use `\Redmine\Api\User::listLogins()` instead.
 - `Redmine\Api\User::getIdByUsername()` is deprecated, use `\Redmine\Api\User::listLogins()` instead.
 - `Redmine\Api\Version::listing()` is deprecated, use `\Redmine\Api\Version::listNamesByProject()` instead.
+- `Redmine\Api\Version::getIdByName()` is deprecated, use `\Redmine\Api\Version::listNamesByProject()` instead.
 
 ## [v2.6.0](https://github.com/kbsali/php-redmine-api/compare/v2.5.0...v2.6.0) - 2024-03-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Redmine\Api\IssueStatus::listing()` is deprecated, use `\Redmine\Api\IssueStatus::listNames()` instead.
 - `Redmine\Api\IssueStatus::getIdByName()` is deprecated, use `\Redmine\Api\IssueStatus::listNames()` instead.
 - `Redmine\Api\Project::listing()` is deprecated, use `\Redmine\Api\Project::listNames()` instead.
+- `Redmine\Api\Project::getIdByName()` is deprecated, use `\Redmine\Api\Project::listNames()` instead.
 - `Redmine\Api\Role::listing()` is deprecated, use `\Redmine\Api\Role::listNames()` instead.
 - `Redmine\Api\TimeEntryActivity::listing()` is deprecated, use `\Redmine\Api\TimeEntryActivity::listNames()` instead.
 - `Redmine\Api\Tracker::listing()` is deprecated, use `\Redmine\Api\Tracker::listNames()` instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Redmine\Api\TimeEntryActivity::listing()` is deprecated, use `\Redmine\Api\TimeEntryActivity::listNames()` instead.
 - `Redmine\Api\TimeEntryActivity::getIdByName()` is deprecated, use `\Redmine\Api\TimeEntryActivity::listNames()` instead.
 - `Redmine\Api\Tracker::listing()` is deprecated, use `\Redmine\Api\Tracker::listNames()` instead.
+- `Redmine\Api\Tracker::getIdByName()` is deprecated, use `\Redmine\Api\Tracker::listNames()` instead.
 - `Redmine\Api\User::listing()` is deprecated, use `\Redmine\Api\User::listLogins()` instead.
 - `Redmine\Api\Version::listing()` is deprecated, use `\Redmine\Api\Version::listNamesByProject()` instead.
 

--- a/src/Redmine/Api/CustomField.php
+++ b/src/Redmine/Api/CustomField.php
@@ -111,19 +111,11 @@ class CustomField extends AbstractApi
     {
         @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.7.0, use `' . __CLASS__ . '::listNames()` instead.', E_USER_DEPRECATED);
 
-        if (empty($this->customFields) || $forceUpdate) {
-            $this->customFields = $this->list($params);
-        }
-        $ret = [];
-        foreach ($this->customFields['custom_fields'] as $e) {
-            $ret[$e['name']] = (int) $e['id'];
-        }
-
-        return $ret;
+        return $this->doListing($forceUpdate, $params);
     }
 
     /**
-     * Get a tracket id given its name.
+     * Get a custom field id given its name.
      *
      * @param string|int $name   customer field name
      * @param array      $params optional parameters to be passed to the api (offset, limit, ...)
@@ -132,11 +124,27 @@ class CustomField extends AbstractApi
      */
     public function getIdByName($name, array $params = [])
     {
-        $arr = $this->listing(false, $params);
+        $arr = $this->doListing(false, $params);
+
         if (!isset($arr[$name])) {
             return false;
         }
 
         return $arr[(string) $name];
+    }
+
+    private function doListing($forceUpdate = false, array $params = [])
+    {
+        if (empty($this->customFields) || $forceUpdate) {
+            $this->customFields = $this->list($params);
+        }
+
+        $ret = [];
+
+        foreach ($this->customFields['custom_fields'] as $e) {
+            $ret[$e['name']] = (int) $e['id'];
+        }
+
+        return $ret;
     }
 }

--- a/src/Redmine/Api/CustomField.php
+++ b/src/Redmine/Api/CustomField.php
@@ -117,6 +117,9 @@ class CustomField extends AbstractApi
     /**
      * Get a custom field id given its name.
      *
+     * @deprecated v2.7.0 Use listNames() instead.
+     * @see CustomField::listNames()
+     *
      * @param string|int $name   customer field name
      * @param array      $params optional parameters to be passed to the api (offset, limit, ...)
      *
@@ -124,6 +127,8 @@ class CustomField extends AbstractApi
      */
     public function getIdByName($name, array $params = [])
     {
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.7.0, use `' . __CLASS__ . '::listNames()` instead.', E_USER_DEPRECATED);
+
         $arr = $this->doListing(false, $params);
 
         if (!isset($arr[$name])) {

--- a/src/Redmine/Api/CustomField.php
+++ b/src/Redmine/Api/CustomField.php
@@ -138,7 +138,7 @@ class CustomField extends AbstractApi
         return $arr[(string) $name];
     }
 
-    private function doListing($forceUpdate = false, array $params = [])
+    private function doListing(bool $forceUpdate, array $params)
     {
         if (empty($this->customFields) || $forceUpdate) {
             $this->customFields = $this->list($params);

--- a/src/Redmine/Api/Issue.php
+++ b/src/Redmine/Api/Issue.php
@@ -348,7 +348,12 @@ class Issue extends AbstractApi
         if (isset($params['project'])) {
             $projectApi = $this->getProjectApi();
 
-            $params['project_id'] = $projectApi->getIdByName($params['project']);
+            // TODO: project names are not unique; there could be collisions
+            $params['project_id'] = array_search(
+                $params['project'],
+                $projectApi->listNames(),
+                true,
+            );
             unset($params['project']);
         }
 

--- a/src/Redmine/Api/Issue.php
+++ b/src/Redmine/Api/Issue.php
@@ -319,7 +319,7 @@ class Issue extends AbstractApi
         $issueStatusApi = $this->getIssueStatusApi();
 
         return $this->update($id, [
-            'status_id' => $issueStatusApi->getIdByName($status),
+            'status_id' => array_search($status, $issueStatusApi->listNames(), true),
         ]);
     }
 
@@ -366,7 +366,11 @@ class Issue extends AbstractApi
         if (isset($params['status'])) {
             $issueStatusApi = $this->getIssueStatusApi();
 
-            $params['status_id'] = $issueStatusApi->getIdByName($params['status']);
+            $params['status_id'] = array_search(
+                $params['status'],
+                $issueStatusApi->listNames(),
+                true,
+            );
             unset($params['status']);
         }
 

--- a/src/Redmine/Api/Issue.php
+++ b/src/Redmine/Api/Issue.php
@@ -393,14 +393,22 @@ class Issue extends AbstractApi
         if (isset($params['assigned_to'])) {
             $userApi = $this->getUserApi();
 
-            $params['assigned_to_id'] = $userApi->getIdByUsername($params['assigned_to']);
+            $params['assigned_to_id'] = array_search(
+                $params['assigned_to'],
+                $userApi->listLogins(),
+                true,
+            );
             unset($params['assigned_to']);
         }
 
         if (isset($params['author'])) {
             $userApi = $this->getUserApi();
 
-            $params['author_id'] = $userApi->getIdByUsername($params['author']);
+            $params['author_id'] = array_search(
+                $params['author'],
+                $userApi->listLogins(),
+                true,
+            );
             unset($params['author']);
         }
 

--- a/src/Redmine/Api/Issue.php
+++ b/src/Redmine/Api/Issue.php
@@ -355,7 +355,11 @@ class Issue extends AbstractApi
         if (isset($params['category']) && isset($params['project_id'])) {
             $issueCategoryApi = $this->getIssueCategoryApi();
 
-            $params['category_id'] = $issueCategoryApi->getIdByName($params['project_id'], $params['category']);
+            $params['category_id'] = array_search(
+                $params['category'],
+                $issueCategoryApi->listNamesByProject($params['project_id']),
+                true,
+            );
             unset($params['category']);
         }
 

--- a/src/Redmine/Api/Issue.php
+++ b/src/Redmine/Api/Issue.php
@@ -382,7 +382,11 @@ class Issue extends AbstractApi
         if (isset($params['tracker'])) {
             $trackerApi = $this->getTrackerApi();
 
-            $params['tracker_id'] = $trackerApi->getIdByName($params['tracker']);
+            $params['tracker_id'] = array_search(
+                $params['tracker'],
+                $trackerApi->listNames(),
+                true,
+            );
             unset($params['tracker']);
         }
 

--- a/src/Redmine/Api/IssueCategory.php
+++ b/src/Redmine/Api/IssueCategory.php
@@ -155,7 +155,7 @@ class IssueCategory extends AbstractApi
     {
         @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.7.0, use `' . __CLASS__ . '::listNamesByProject()` instead.', E_USER_DEPRECATED);
 
-        $arr = $this->doListing($project);
+        $arr = $this->doListing($project, false);
 
         if (!isset($arr[$name])) {
             return false;
@@ -282,7 +282,7 @@ class IssueCategory extends AbstractApi
         return $this->lastResponse->getContent();
     }
 
-    private function doListing($project, $forceUpdate = false)
+    private function doListing($project, bool $forceUpdate)
     {
         if (true === $forceUpdate || empty($this->issueCategories)) {
             $this->issueCategories = $this->listByProject($project);

--- a/src/Redmine/Api/IssueCategory.php
+++ b/src/Redmine/Api/IssueCategory.php
@@ -137,15 +137,7 @@ class IssueCategory extends AbstractApi
     {
         @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.7.0, use `' . __CLASS__ . '::listNamesByProject()` instead.', E_USER_DEPRECATED);
 
-        if (true === $forceUpdate || empty($this->issueCategories)) {
-            $this->issueCategories = $this->listByProject($project);
-        }
-        $ret = [];
-        foreach ($this->issueCategories['issue_categories'] as $e) {
-            $ret[$e['name']] = (int) $e['id'];
-        }
-
-        return $ret;
+        return $this->doListing($project, $forceUpdate);
     }
 
     /**
@@ -158,7 +150,7 @@ class IssueCategory extends AbstractApi
      */
     public function getIdByName($project, $name)
     {
-        $arr = $this->listing($project);
+        $arr = $this->doListing($project);
         if (!isset($arr[$name])) {
             return false;
         }
@@ -282,5 +274,20 @@ class IssueCategory extends AbstractApi
         ));
 
         return $this->lastResponse->getContent();
+    }
+
+    private function doListing($project, $forceUpdate = false)
+    {
+        if (true === $forceUpdate || empty($this->issueCategories)) {
+            $this->issueCategories = $this->listByProject($project);
+        }
+
+        $ret = [];
+
+        foreach ($this->issueCategories['issue_categories'] as $e) {
+            $ret[$e['name']] = (int) $e['id'];
+        }
+
+        return $ret;
     }
 }

--- a/src/Redmine/Api/IssueCategory.php
+++ b/src/Redmine/Api/IssueCategory.php
@@ -143,6 +143,9 @@ class IssueCategory extends AbstractApi
     /**
      * Get a category id given its name and related project.
      *
+     * @deprecated v2.7.0 Use listNamesByProject() instead.
+     * @see IssueCategory::listNamesByProject()
+     *
      * @param string|int $project project id or literal identifier
      * @param string     $name
      *
@@ -150,7 +153,10 @@ class IssueCategory extends AbstractApi
      */
     public function getIdByName($project, $name)
     {
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.7.0, use `' . __CLASS__ . '::listNamesByProject()` instead.', E_USER_DEPRECATED);
+
         $arr = $this->doListing($project);
+
         if (!isset($arr[$name])) {
             return false;
         }

--- a/src/Redmine/Api/IssueStatus.php
+++ b/src/Redmine/Api/IssueStatus.php
@@ -110,15 +110,7 @@ class IssueStatus extends AbstractApi
     {
         @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.7.0, use `' . __CLASS__ . '::listNames()` instead.', E_USER_DEPRECATED);
 
-        if (empty($this->issueStatuses) || $forceUpdate) {
-            $this->issueStatuses = $this->list();
-        }
-        $ret = [];
-        foreach ($this->issueStatuses['issue_statuses'] as $e) {
-            $ret[$e['name']] = (int) $e['id'];
-        }
-
-        return $ret;
+        return $this->doListing($forceUpdate);
     }
 
     /**
@@ -130,11 +122,27 @@ class IssueStatus extends AbstractApi
      */
     public function getIdByName($name)
     {
-        $arr = $this->listing();
+        $arr = $this->doListing(false);
+
         if (!isset($arr[$name])) {
             return false;
         }
 
         return $arr[(string) $name];
+    }
+
+    private function doListing(bool $forceUpdate)
+    {
+        if (empty($this->issueStatuses) || $forceUpdate) {
+            $this->issueStatuses = $this->list();
+        }
+
+        $ret = [];
+
+        foreach ($this->issueStatuses['issue_statuses'] as $e) {
+            $ret[$e['name']] = (int) $e['id'];
+        }
+
+        return $ret;
     }
 }

--- a/src/Redmine/Api/IssueStatus.php
+++ b/src/Redmine/Api/IssueStatus.php
@@ -116,12 +116,17 @@ class IssueStatus extends AbstractApi
     /**
      * Get a status id given its name.
      *
+     * @deprecated v2.7.0 Use listNames() instead.
+     * @see IssueStatus::listNames()
+     *
      * @param string $name
      *
      * @return int|false
      */
     public function getIdByName($name)
     {
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.7.0, use `' . __CLASS__ . '::listNames()` instead.', E_USER_DEPRECATED);
+
         $arr = $this->doListing(false);
 
         if (!isset($arr[$name])) {

--- a/src/Redmine/Api/Project.php
+++ b/src/Redmine/Api/Project.php
@@ -138,6 +138,9 @@ class Project extends AbstractApi
     /**
      * Get a project id given its name.
      *
+     * @deprecated v2.7.0 Use listNames() instead.
+     * @see Project::listNames()
+     *
      * @param string $name
      * @param array  $params to allow offset/limit (and more) to be passed
      *
@@ -145,6 +148,8 @@ class Project extends AbstractApi
      */
     public function getIdByName($name, array $params = [])
     {
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.7.0, use `' . __CLASS__ . '::listNames()` instead.', E_USER_DEPRECATED);
+
         $arr = $this->doListing(false, true, $params);
 
         if (!isset($arr[$name])) {

--- a/src/Redmine/Api/Project.php
+++ b/src/Redmine/Api/Project.php
@@ -132,15 +132,7 @@ class Project extends AbstractApi
     {
         @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.7.0, use `' . __CLASS__ . '::listNames()` instead.', E_USER_DEPRECATED);
 
-        if (true === $forceUpdate || empty($this->projects)) {
-            $this->projects = $this->list($params);
-        }
-        $ret = [];
-        foreach ($this->projects['projects'] as $e) {
-            $ret[(int) $e['id']] = $e['name'];
-        }
-
-        return $reverse ? array_flip($ret) : $ret;
+        return $this->doListing($forceUpdate, $reverse, $params);
     }
 
     /**
@@ -153,7 +145,8 @@ class Project extends AbstractApi
      */
     public function getIdByName($name, array $params = [])
     {
-        $arr = $this->listing(false, true, $params);
+        $arr = $this->doListing(false, true, $params);
+
         if (!isset($arr[$name])) {
             return false;
         }
@@ -446,5 +439,20 @@ class Project extends AbstractApi
         ));
 
         return $this->lastResponse->getContent();
+    }
+
+    private function doListing(bool $forceUpdate, bool $reverse, array $params)
+    {
+        if (true === $forceUpdate || empty($this->projects)) {
+            $this->projects = $this->list($params);
+        }
+
+        $ret = [];
+
+        foreach ($this->projects['projects'] as $e) {
+            $ret[(int) $e['id']] = $e['name'];
+        }
+
+        return $reverse ? array_flip($ret) : $ret;
     }
 }

--- a/src/Redmine/Api/TimeEntryActivity.php
+++ b/src/Redmine/Api/TimeEntryActivity.php
@@ -111,12 +111,17 @@ class TimeEntryActivity extends AbstractApi
     /**
      * Get a activities id given its name.
      *
+     * @deprecated v2.7.0 Use listNames() instead.
+     * @see Project::listNames()
+     *
      * @param string $name
      *
      * @return int|false
      */
     public function getIdByName($name)
     {
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.7.0, use `' . __CLASS__ . '::listNames()` instead.', E_USER_DEPRECATED);
+
         $arr = $this->doListing(false);
 
         if (!isset($arr[$name])) {

--- a/src/Redmine/Api/TimeEntryActivity.php
+++ b/src/Redmine/Api/TimeEntryActivity.php
@@ -105,15 +105,7 @@ class TimeEntryActivity extends AbstractApi
     {
         @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.7.0, use `' . __CLASS__ . '::listNames()` instead.', E_USER_DEPRECATED);
 
-        if (empty($this->timeEntryActivities) || $forceUpdate) {
-            $this->timeEntryActivities = $this->list();
-        }
-        $ret = [];
-        foreach ($this->timeEntryActivities['time_entry_activities'] as $e) {
-            $ret[$e['name']] = (int) $e['id'];
-        }
-
-        return $ret;
+        return $this->doListing((bool) $forceUpdate);
     }
 
     /**
@@ -125,11 +117,27 @@ class TimeEntryActivity extends AbstractApi
      */
     public function getIdByName($name)
     {
-        $arr = $this->listing();
+        $arr = $this->doListing(false);
+
         if (!isset($arr[$name])) {
             return false;
         }
 
         return $arr[(string) $name];
+    }
+
+    private function doListing(bool $forceUpdate)
+    {
+        if (empty($this->timeEntryActivities) || $forceUpdate) {
+            $this->timeEntryActivities = $this->list();
+        }
+
+        $ret = [];
+
+        foreach ($this->timeEntryActivities['time_entry_activities'] as $e) {
+            $ret[$e['name']] = (int) $e['id'];
+        }
+
+        return $ret;
     }
 }

--- a/src/Redmine/Api/Tracker.php
+++ b/src/Redmine/Api/Tracker.php
@@ -113,7 +113,10 @@ class Tracker extends AbstractApi
     }
 
     /**
-     * Get a tracket id given its name.
+     * Get a tracker id given its name.
+     *
+     * @deprecated v2.7.0 Use listNames() instead.
+     * @see Tracker::listNames()
      *
      * @param string|int $name tracker name
      *
@@ -121,6 +124,8 @@ class Tracker extends AbstractApi
      */
     public function getIdByName($name)
     {
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.7.0, use `' . __CLASS__ . '::listNames()` instead.', E_USER_DEPRECATED);
+
         $arr = $this->doListing(false);
 
         if (!isset($arr[$name])) {

--- a/src/Redmine/Api/Tracker.php
+++ b/src/Redmine/Api/Tracker.php
@@ -109,15 +109,7 @@ class Tracker extends AbstractApi
     {
         @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.7.0, use `' . __CLASS__ . '::listNames()` instead.', E_USER_DEPRECATED);
 
-        if (empty($this->trackers) || $forceUpdate) {
-            $this->trackers = $this->list();
-        }
-        $ret = [];
-        foreach ($this->trackers['trackers'] as $e) {
-            $ret[$e['name']] = (int) $e['id'];
-        }
-
-        return $ret;
+        return $this->doListing($forceUpdate);
     }
 
     /**
@@ -129,11 +121,27 @@ class Tracker extends AbstractApi
      */
     public function getIdByName($name)
     {
-        $arr = $this->listing();
+        $arr = $this->doListing(false);
+
         if (!isset($arr[$name])) {
             return false;
         }
 
         return $arr[(string) $name];
+    }
+
+    private function doListing(bool $forceUpdate)
+    {
+        if (empty($this->trackers) || $forceUpdate) {
+            $this->trackers = $this->list();
+        }
+
+        $ret = [];
+
+        foreach ($this->trackers['trackers'] as $e) {
+            $ret[$e['name']] = (int) $e['id'];
+        }
+
+        return $ret;
     }
 }

--- a/src/Redmine/Api/User.php
+++ b/src/Redmine/Api/User.php
@@ -150,6 +150,9 @@ class User extends AbstractApi
     /**
      * Get a user id given its username.
      *
+     * @deprecated v2.7.0 Use listLogins() instead.
+     * @see User::listLogins()
+     *
      * @param string $username
      * @param array  $params   to allow offset/limit (and more) to be passed
      *
@@ -157,6 +160,8 @@ class User extends AbstractApi
      */
     public function getIdByUsername($username, array $params = [])
     {
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.7.0, use `' . __CLASS__ . '::listLogins()` instead.', E_USER_DEPRECATED);
+
         $arr = $this->doListing(false, $params);
 
         if (!isset($arr[$username])) {

--- a/src/Redmine/Api/User.php
+++ b/src/Redmine/Api/User.php
@@ -130,17 +130,7 @@ class User extends AbstractApi
     {
         @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.7.0, use `' . __CLASS__ . '::listLogins()` instead.', E_USER_DEPRECATED);
 
-        if (empty($this->users) || $forceUpdate) {
-            $this->users = $this->list($params);
-        }
-        $ret = [];
-        if (is_array($this->users) && isset($this->users['users'])) {
-            foreach ($this->users['users'] as $e) {
-                $ret[$e['login']] = (int) $e['id'];
-            }
-        }
-
-        return $ret;
+        return $this->doListing($forceUpdate, $params);
     }
 
     /**
@@ -167,7 +157,8 @@ class User extends AbstractApi
      */
     public function getIdByUsername($username, array $params = [])
     {
-        $arr = $this->listing(false, $params);
+        $arr = $this->doListing(false, $params);
+
         if (!isset($arr[$username])) {
             return false;
         }
@@ -317,5 +308,22 @@ class User extends AbstractApi
         ));
 
         return $this->lastResponse->getContent();
+    }
+
+    private function doListing(bool $forceUpdate, array $params)
+    {
+        if (empty($this->users) || $forceUpdate) {
+            $this->users = $this->list($params);
+        }
+
+        $ret = [];
+
+        if (is_array($this->users) && isset($this->users['users'])) {
+            foreach ($this->users['users'] as $e) {
+                $ret[$e['login']] = (int) $e['id'];
+            }
+        }
+
+        return $ret;
     }
 }

--- a/src/Redmine/Api/Version.php
+++ b/src/Redmine/Api/Version.php
@@ -139,15 +139,7 @@ class Version extends AbstractApi
     {
         @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.7.0, use `' . __CLASS__ . '::listNamesByProject()` instead.', E_USER_DEPRECATED);
 
-        if (true === $forceUpdate || empty($this->versions)) {
-            $this->versions = $this->listByProject($project, $params);
-        }
-        $ret = [];
-        foreach ($this->versions['versions'] as $e) {
-            $ret[(int) $e['id']] = $e['name'];
-        }
-
-        return $reverse ? array_flip($ret) : $ret;
+        return $this->doListing($project, $forceUpdate, $reverse, $params);
     }
 
     /**
@@ -161,7 +153,8 @@ class Version extends AbstractApi
      */
     public function getIdByName($project, $name, array $params = [])
     {
-        $arr = $this->listing($project, false, true, $params);
+        $arr = $this->doListing($project, false, true, $params);
+
         if (!isset($arr[$name])) {
             return false;
         }
@@ -318,5 +311,20 @@ class Version extends AbstractApi
         ));
 
         return $this->lastResponse->getContent();
+    }
+
+    private function doListing($project, bool $forceUpdate, bool $reverse, array $params)
+    {
+        if (true === $forceUpdate || empty($this->versions)) {
+            $this->versions = $this->listByProject($project, $params);
+        }
+
+        $ret = [];
+
+        foreach ($this->versions['versions'] as $e) {
+            $ret[(int) $e['id']] = $e['name'];
+        }
+
+        return $reverse ? array_flip($ret) : $ret;
     }
 }

--- a/src/Redmine/Api/Version.php
+++ b/src/Redmine/Api/Version.php
@@ -145,6 +145,9 @@ class Version extends AbstractApi
     /**
      * Get an version id given its name and related project.
      *
+     * @deprecated v2.7.0 Use listNamesByProject() instead.
+     * @see Version::listNamesByProject()
+     *
      * @param string|int $project project id or literal identifier
      * @param string     $name The version name
      * @param array      $params  optional parameters to be passed to the api (offset, limit, ...)
@@ -153,6 +156,8 @@ class Version extends AbstractApi
      */
     public function getIdByName($project, $name, array $params = [])
     {
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.7.0, use `' . __CLASS__ . '::listNamesByProject()` instead.', E_USER_DEPRECATED);
+
         $arr = $this->doListing($project, false, true, $params);
 
         if (!isset($arr[$name])) {

--- a/tests/Unit/Api/Issue/CreateTest.php
+++ b/tests/Unit/Api/Issue/CreateTest.php
@@ -410,12 +410,12 @@ class CreateTest extends TestCase
             $this,
             [
                 'GET',
-                '/users.json',
+                '/users.json?limit=100&offset=0',
                 'application/json',
                 '',
                 200,
                 'application/json',
-                '{"users":[{"login":"Author Name","id":5},{"login":"Assigned to User Name","id":6}]}',
+                '{"users":[{"login":"user_5","id":5},{"login":"user_6","id":6}]}',
             ],
             [
                 'POST',
@@ -432,7 +432,7 @@ class CreateTest extends TestCase
         $api = new Issue($client);
 
         // Perform the tests
-        $xmlElement = $api->create(['assigned_to' => 'Assigned to User Name', 'author' => 'Author Name']);
+        $xmlElement = $api->create(['assigned_to' => 'user_6', 'author' => 'user_5']);
 
         $this->assertInstanceOf(SimpleXMLElement::class, $xmlElement);
         $this->assertXmlStringEqualsXmlString(
@@ -486,12 +486,12 @@ class CreateTest extends TestCase
             ],
             [
                 'GET',
-                '/users.json',
+                '/users.json?limit=100&offset=0',
                 'application/json',
                 '',
                 200,
                 'application/json',
-                '{"users":[{"login":"Author Name","id":5},{"login":"Assigned to User Name","id":6}]}',
+                '{"users":[{"login":"user_5","id":5},{"login":"user_6","id":6}]}',
             ],
             [
                 'POST',
@@ -519,8 +519,8 @@ class CreateTest extends TestCase
             'category' => 'Category Name',
             'status' => 'Status Name',
             'tracker' => 'Tracker Name',
-            'assigned_to' => 'Assigned to User Name',
-            'author' => 'Author Name',
+            'assigned_to' => 'user_6',
+            'author' => 'user_5',
         ];
 
         // Create the object under test

--- a/tests/Unit/Api/Issue/CreateTest.php
+++ b/tests/Unit/Api/Issue/CreateTest.php
@@ -299,7 +299,7 @@ class CreateTest extends TestCase
             $this,
             [
                 'GET',
-                '/projects.json',
+                '/projects.json?limit=100&offset=0',
                 'application/json',
                 '',
                 200,
@@ -450,7 +450,7 @@ class CreateTest extends TestCase
             $this,
             [
                 'GET',
-                '/projects.json',
+                '/projects.json?limit=100&offset=0',
                 'application/json',
                 '',
                 200,

--- a/tests/Unit/Api/Issue/UpdateTest.php
+++ b/tests/Unit/Api/Issue/UpdateTest.php
@@ -119,7 +119,7 @@ class UpdateTest extends TestCase
             $this,
             [
                 'GET',
-                '/projects.json',
+                '/projects.json?limit=100&offset=0',
                 'application/json',
                 '',
                 200,

--- a/tests/Unit/Api/Issue/UpdateTest.php
+++ b/tests/Unit/Api/Issue/UpdateTest.php
@@ -155,7 +155,7 @@ class UpdateTest extends TestCase
             ],
             [
                 'GET',
-                '/users.json',
+                '/users.json?limit=100&offset=0',
                 'application/json',
                 '',
                 200,

--- a/tests/Unit/Api/IssueTest.php
+++ b/tests/Unit/Api/IssueTest.php
@@ -10,6 +10,7 @@ use Redmine\Api\IssueCategory;
 use Redmine\Api\IssueStatus;
 use Redmine\Api\Project;
 use Redmine\Api\Tracker;
+use Redmine\Api\User;
 use Redmine\Client\Client;
 use Redmine\Http\HttpClient;
 use Redmine\Http\Response;
@@ -152,16 +153,11 @@ class IssueTest extends TestCase
             'category' => 'Category 5 Name',
             'status' => 'Status 6 Name',
             'tracker' => 'Tracker 2 Name',
-            'assigned_to' => 'Assigned to User Name',
-            'author' => 'Author Name',
+            'assigned_to' => 'user_3',
+            'author' => 'user_4',
         ];
 
         // Create the used mock objects
-        $getIdByUsernameApi = $this->createMock('Redmine\Api\User');
-        $getIdByUsernameApi->expects($this->exactly(2))
-            ->method('getIdByUsername')
-            ->willReturn('cleanedValue');
-
         $httpClient = AssertingHttpClient::create(
             $this,
             [
@@ -200,6 +196,15 @@ class IssueTest extends TestCase
                 'application/json',
                 '{"trackers":[{"id":2,"name":"Tracker 2 Name"}]}',
             ],
+            [
+                'GET',
+                '/users.json?limit=100&offset=0',
+                'application/json',
+                '',
+                200,
+                'application/json',
+                '{"users":[{"id":3,"login":"user_3"},{"id":4,"login":"user_4"}]}',
+            ],
         );
 
         $client = $this->createMock(Client::class);
@@ -211,7 +216,7 @@ class IssueTest extends TestCase
                     ['issue_category', new IssueCategory($httpClient)],
                     ['issue_status', new IssueStatus($httpClient)],
                     ['tracker', new Tracker($httpClient)],
-                    ['user', $getIdByUsernameApi],
+                    ['user', new User($httpClient)],
                 ],
             )
         ;
@@ -222,7 +227,7 @@ class IssueTest extends TestCase
                 '/issues.xml',
                 <<< XML
                 <?xml version="1.0"?>
-                <issue><project_id>1</project_id><category_id>5</category_id><status_id>6</status_id><tracker_id>2</tracker_id><assigned_to_id>cleanedValue</assigned_to_id><author_id>cleanedValue</author_id></issue>
+                <issue><project_id>1</project_id><category_id>5</category_id><status_id>6</status_id><tracker_id>2</tracker_id><assigned_to_id>3</assigned_to_id><author_id>4</author_id></issue>
 
                 XML,
             )

--- a/tests/Unit/Api/IssueTest.php
+++ b/tests/Unit/Api/IssueTest.php
@@ -199,13 +199,11 @@ class IssueTest extends TestCase
             ->method('requestPost')
             ->with(
                 '/issues.xml',
-                $this->stringEqualsStringIgnoringLineEndings(
-                    <<< XML
-                    <?xml version="1.0"?>
-                    <issue><project_id>1</project_id><category_id>5</category_id><status_id>cleanedValue</status_id><tracker_id>cleanedValue</tracker_id><assigned_to_id>cleanedValue</assigned_to_id><author_id>cleanedValue</author_id></issue>
+                <<< XML
+                <?xml version="1.0"?>
+                <issue><project_id>1</project_id><category_id>5</category_id><status_id>cleanedValue</status_id><tracker_id>cleanedValue</tracker_id><assigned_to_id>cleanedValue</assigned_to_id><author_id>cleanedValue</author_id></issue>
 
-                    XML,
-                ),
+                XML,
             )
             ->willReturn(true);
         $client->expects($this->exactly(1))

--- a/tests/Unit/Api/IssueTest.php
+++ b/tests/Unit/Api/IssueTest.php
@@ -9,6 +9,7 @@ use Redmine\Api\Issue;
 use Redmine\Api\IssueCategory;
 use Redmine\Api\IssueStatus;
 use Redmine\Api\Project;
+use Redmine\Api\Tracker;
 use Redmine\Client\Client;
 use Redmine\Http\HttpClient;
 use Redmine\Http\Response;
@@ -150,16 +151,12 @@ class IssueTest extends TestCase
             'project' => 'Project 1 Name',
             'category' => 'Category 5 Name',
             'status' => 'Status 6 Name',
-            'tracker' => 'Tracker Name',
+            'tracker' => 'Tracker 2 Name',
             'assigned_to' => 'Assigned to User Name',
             'author' => 'Author Name',
         ];
 
         // Create the used mock objects
-        $getIdByNameApi = $this->createMock('Redmine\Api\Tracker');
-        $getIdByNameApi->expects($this->exactly(1))
-            ->method('getIdByName')
-            ->willReturn('cleanedValue');
         $getIdByUsernameApi = $this->createMock('Redmine\Api\User');
         $getIdByUsernameApi->expects($this->exactly(2))
             ->method('getIdByUsername')
@@ -194,6 +191,15 @@ class IssueTest extends TestCase
                 'application/json',
                 '{"issue_statuses":[{"id":6,"name":"Status 6 Name"}]}',
             ],
+            [
+                'GET',
+                '/trackers.json',
+                'application/json',
+                '',
+                200,
+                'application/json',
+                '{"trackers":[{"id":2,"name":"Tracker 2 Name"}]}',
+            ],
         );
 
         $client = $this->createMock(Client::class);
@@ -204,7 +210,7 @@ class IssueTest extends TestCase
                     ['project', new Project($httpClient)],
                     ['issue_category', new IssueCategory($httpClient)],
                     ['issue_status', new IssueStatus($httpClient)],
-                    ['tracker', $getIdByNameApi],
+                    ['tracker', new Tracker($httpClient)],
                     ['user', $getIdByUsernameApi],
                 ],
             )
@@ -216,7 +222,7 @@ class IssueTest extends TestCase
                 '/issues.xml',
                 <<< XML
                 <?xml version="1.0"?>
-                <issue><project_id>1</project_id><category_id>5</category_id><status_id>6</status_id><tracker_id>cleanedValue</tracker_id><assigned_to_id>cleanedValue</assigned_to_id><author_id>cleanedValue</author_id></issue>
+                <issue><project_id>1</project_id><category_id>5</category_id><status_id>6</status_id><tracker_id>2</tracker_id><assigned_to_id>cleanedValue</assigned_to_id><author_id>cleanedValue</author_id></issue>
 
                 XML,
             )

--- a/tests/Unit/Api/IssueTest.php
+++ b/tests/Unit/Api/IssueTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Redmine\Api\Issue;
 use Redmine\Api\IssueCategory;
 use Redmine\Api\IssueStatus;
+use Redmine\Api\Project;
 use Redmine\Client\Client;
 use Redmine\Http\HttpClient;
 use Redmine\Http\Response;
@@ -146,7 +147,7 @@ class IssueTest extends TestCase
         // Test values
         $response = '<?xml version="1.0"?><issue></issue>';
         $parameters = [
-            'project' => 'Project Name',
+            'project' => 'Project 1 Name',
             'category' => 'Category 5 Name',
             'status' => 'Status 6 Name',
             'tracker' => 'Tracker Name',
@@ -155,10 +156,6 @@ class IssueTest extends TestCase
         ];
 
         // Create the used mock objects
-        $projectApi = $this->createMock('Redmine\Api\Project');
-        $projectApi->expects($this->exactly(1))
-            ->method('getIdByName')
-            ->willReturn(1);
         $getIdByNameApi = $this->createMock('Redmine\Api\Tracker');
         $getIdByNameApi->expects($this->exactly(1))
             ->method('getIdByName')
@@ -170,6 +167,15 @@ class IssueTest extends TestCase
 
         $httpClient = AssertingHttpClient::create(
             $this,
+            [
+                'GET',
+                '/projects.json?limit=100&offset=0',
+                'application/json',
+                '',
+                200,
+                'application/json',
+                '{"projects":[{"id":1,"name":"Project 1 Name"},{"id":2,"name":"Project 1 Name"}]}',
+            ],
             [
                 'GET',
                 '/projects/1/issue_categories.json',
@@ -195,7 +201,7 @@ class IssueTest extends TestCase
             ->method('getApi')
             ->willReturnMap(
                 [
-                    ['project', $projectApi],
+                    ['project', new Project($httpClient)],
                     ['issue_category', new IssueCategory($httpClient)],
                     ['issue_status', new IssueStatus($httpClient)],
                     ['tracker', $getIdByNameApi],

--- a/tests/Unit/Api/ProjectTest.php
+++ b/tests/Unit/Api/ProjectTest.php
@@ -280,6 +280,35 @@ class ProjectTest extends TestCase
         $this->assertSame(5, $api->getIdByName('Project 5'));
     }
 
+    public function testGetIdByNameTriggersDeprecationWarning()
+    {
+        $client = $this->createMock(Client::class);
+        $client->method('requestGet')
+            ->willReturn(true);
+        $client->method('getLastResponseBody')
+            ->willReturn('{"projects":[{"id":1,"name":"Project 1"},{"id":5,"name":"Project 5"}]}');
+        $client->method('getLastResponseContentType')
+            ->willReturn('application/json');
+
+        $api = new Project($client);
+
+        // PHPUnit 10 compatible way to test trigger_error().
+        set_error_handler(
+            function ($errno, $errstr): bool {
+                $this->assertSame(
+                    '`Redmine\Api\Project::getIdByName()` is deprecated since v2.7.0, use `Redmine\Api\Project::listNames()` instead.',
+                    $errstr,
+                );
+
+                restore_error_handler();
+                return true;
+            },
+            E_USER_DEPRECATED,
+        );
+
+        $api->getIdByName('Project 1');
+    }
+
     public function testDeprecatedPrepareParamsXml()
     {
         $client = $this->createMock(Client::class);

--- a/tests/Unit/Api/TimeEntryActivityTest.php
+++ b/tests/Unit/Api/TimeEntryActivityTest.php
@@ -221,4 +221,33 @@ class TimeEntryActivityTest extends TestCase
         $this->assertFalse($api->getIdByName('TimeEntryActivities 1'));
         $this->assertSame(2, $api->getIdByName('TimeEntryActivities 2'));
     }
+
+    public function testGetIdByNameTriggersDeprecationWarning()
+    {
+        $client = $this->createMock(Client::class);
+        $client->method('requestGet')
+            ->willReturn(true);
+        $client->method('getLastResponseBody')
+            ->willReturn('{"time_entry_activities":[{"id":1,"name":"TimeEntryActivity 1"},{"id":5,"name":"TimeEntryActivity 5"}]}');
+        $client->method('getLastResponseContentType')
+            ->willReturn('application/json');
+
+        $api = new TimeEntryActivity($client);
+
+        // PHPUnit 10 compatible way to test trigger_error().
+        set_error_handler(
+            function ($errno, $errstr): bool {
+                $this->assertSame(
+                    '`Redmine\Api\TimeEntryActivity::getIdByName()` is deprecated since v2.7.0, use `Redmine\Api\TimeEntryActivity::listNames()` instead.',
+                    $errstr,
+                );
+
+                restore_error_handler();
+                return true;
+            },
+            E_USER_DEPRECATED,
+        );
+
+        $api->getIdByName('TimeEntryActivities 2');
+    }
 }

--- a/tests/Unit/Api/TrackerTest.php
+++ b/tests/Unit/Api/TrackerTest.php
@@ -277,4 +277,33 @@ class TrackerTest extends TestCase
         $this->assertFalse($api->getIdByName('Tracker 1'));
         $this->assertSame(5, $api->getIdByName('Tracker 5'));
     }
+
+    public function testGgetIdByNameTriggersDeprecationWarning()
+    {
+        $client = $this->createMock(Client::class);
+        $client->method('requestGet')
+            ->willReturn(true);
+        $client->method('getLastResponseBody')
+            ->willReturn('{"trackers":[{"id":1,"name":"Tracker 1"},{"id":5,"name":"Tracker 5"}]}');
+        $client->method('getLastResponseContentType')
+            ->willReturn('application/json');
+
+        $api = new Tracker($client);
+
+        // PHPUnit 10 compatible way to test trigger_error().
+        set_error_handler(
+            function ($errno, $errstr): bool {
+                $this->assertSame(
+                    '`Redmine\Api\Tracker::getIdByName()` is deprecated since v2.7.0, use `Redmine\Api\Tracker::listNames()` instead.',
+                    $errstr,
+                );
+
+                restore_error_handler();
+                return true;
+            },
+            E_USER_DEPRECATED,
+        );
+
+        $api->getIdByName('Tracker 5');
+    }
 }

--- a/tests/Unit/Api/UserTest.php
+++ b/tests/Unit/Api/UserTest.php
@@ -55,7 +55,7 @@ class UserTest extends TestCase
     public function testGetIdByUsernameMakesGetRequest()
     {
         // Test values
-        $response = '{"users":[{"id":5,"login":"User 5"}]}';
+        $response = '{"users":[{"id":5,"login":"user_5"}]}';
 
         // Create the used mock objects
         $client = $this->createMock(Client::class);
@@ -79,8 +79,37 @@ class UserTest extends TestCase
         $api = new User($client);
 
         // Perform the tests
-        $this->assertFalse($api->getIdByUsername('User 1'));
-        $this->assertSame(5, $api->getIdByUsername('User 5'));
+        $this->assertFalse($api->getIdByUsername('user_1'));
+        $this->assertSame(5, $api->getIdByUsername('user_5'));
+    }
+
+    public function testGetIdByUsernameTriggersDeprecationWarning()
+    {
+        $client = $this->createMock(Client::class);
+        $client->method('requestGet')
+            ->willReturn(true);
+        $client->method('getLastResponseBody')
+            ->willReturn('{"users":[{"id":1,"login":"user_1"},{"id":5,"login":"user_5"}]}');
+        $client->method('getLastResponseContentType')
+            ->willReturn('application/json');
+
+        $api = new User($client);
+
+        // PHPUnit 10 compatible way to test trigger_error().
+        set_error_handler(
+            function ($errno, $errstr): bool {
+                $this->assertSame(
+                    '`Redmine\Api\User::getIdByUsername()` is deprecated since v2.7.0, use `Redmine\Api\User::listLogins()` instead.',
+                    $errstr,
+                );
+
+                restore_error_handler();
+                return true;
+            },
+            E_USER_DEPRECATED,
+        );
+
+        $api->getIdByUsername('user_5');
     }
 
     /**
@@ -189,10 +218,10 @@ class UserTest extends TestCase
     public function testListingReturnsNameIdArray()
     {
         // Test values
-        $response = '{"users":[{"id":1,"login":"User 1"},{"id":5,"login":"User 5"}]}';
+        $response = '{"users":[{"id":1,"login":"user_1"},{"id":5,"login":"user_5"}]}';
         $expectedReturn = [
-            'User 1' => 1,
-            'User 5' => 5,
+            'user_1' => 1,
+            'user_5' => 5,
         ];
 
         // Create the used mock objects
@@ -223,10 +252,10 @@ class UserTest extends TestCase
     public function testListingCallsGetOnlyTheFirstTime()
     {
         // Test values
-        $response = '{"users":[{"id":1,"login":"User 1"},{"id":5,"login":"User 5"}]}';
+        $response = '{"users":[{"id":1,"login":"user_1"},{"id":5,"login":"user_5"}]}';
         $expectedReturn = [
-            'User 1' => 1,
-            'User 5' => 5,
+            'user_1' => 1,
+            'user_5' => 5,
         ];
 
         // Create the used mock objects
@@ -258,10 +287,10 @@ class UserTest extends TestCase
     public function testListingCallsGetEveryTimeWithForceUpdate()
     {
         // Test values
-        $response = '{"users":[{"id":1,"login":"User 1"},{"id":5,"login":"User 5"}]}';
+        $response = '{"users":[{"id":1,"login":"user_1"},{"id":5,"login":"user_5"}]}';
         $expectedReturn = [
-            'User 1' => 1,
-            'User 5' => 5,
+            'user_1' => 1,
+            'user_5' => 5,
         ];
 
         // Create the used mock objects

--- a/tests/Unit/Api/VersionTest.php
+++ b/tests/Unit/Api/VersionTest.php
@@ -309,6 +309,35 @@ class VersionTest extends TestCase
         $this->assertSame(5, $api->getIdByName(5, 'Version 5'));
     }
 
+    public function testGetIdByNameTriggersDeprecationWarning()
+    {
+        $client = $this->createMock(Client::class);
+        $client->method('requestGet')
+            ->willReturn(true);
+        $client->method('getLastResponseBody')
+            ->willReturn('{"versions":[{"id":1,"name":"Version 1"},{"id":5,"name":"Version 5"}]}');
+        $client->method('getLastResponseContentType')
+            ->willReturn('application/json');
+
+        $api = new Version($client);
+
+        // PHPUnit 10 compatible way to test trigger_error().
+        set_error_handler(
+            function ($errno, $errstr): bool {
+                $this->assertSame(
+                    '`Redmine\Api\Version::getIdByName()` is deprecated since v2.7.0, use `Redmine\Api\Version::listNamesByProject()` instead.',
+                    $errstr,
+                );
+
+                restore_error_handler();
+                return true;
+            },
+            E_USER_DEPRECATED,
+        );
+
+        $api->getIdByName(5, 'Version 5');
+    }
+
     /**
      * Test validateSharing().
      *


### PR DESCRIPTION
Closes #417.

### Todo

- [x] Deprecate `CustomField::getIdByName()`
- [x] Deprecate `IssueCategory::getIdByName()`
- [x] Deprecate `IssueStatus::getIdByName()`
- [x] Deprecate `Project::getIdByName()`
- [x] Deprecate `TimeEntryActivity::getIdByName()`
- [x] Deprecate `Tracker::getIdByName()`
- [x] Deprecate `User::getIdByUsername()`
- [x] Deprecate `Version::getIdByName()`