### PR TITLE
Deprecate `getLastResponse...()` and `request...()` in Clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/kbsali/php-redmine-api/compare/v2.7.0...v2.x)
 
+### Deprecated
+
+- `Redmine\Client\Client::getLastResponseStatusCode()` is deprecated, use `\Redmine\Api\AbstractApi::getLastResponse()->getStatusCode()` instead.
+- `Redmine\Client\Client::getLastResponseContentType()` is deprecated, use `\Redmine\Api\AbstractApi::getLastResponse()->getContentType()` instead.
+- `Redmine\Client\Client::getLastResponseBody()` is deprecated, use `\Redmine\Api\AbstractApi::getLastResponse()->getContent()` instead.
+
 ## [v2.7.0](https://github.com/kbsali/php-redmine-api/compare/v2.6.0...v2.7.0) - 2024-07-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
-- `Redmine\Client\Client::getLastResponseStatusCode()` is deprecated, use `\Redmine\Api\AbstractApi::getLastResponse()->getStatusCode()` instead.
-- `Redmine\Client\Client::getLastResponseContentType()` is deprecated, use `\Redmine\Api\AbstractApi::getLastResponse()->getContentType()` instead.
-- `Redmine\Client\Client::getLastResponseBody()` is deprecated, use `\Redmine\Api\AbstractApi::getLastResponse()->getContent()` instead.
+- `Redmine\Client\Client::requestGet()` is deprecated, use `\Redmine\Client\Client::request()` instead.
+- `Redmine\Client\Client::requestPost()` is deprecated, use `\Redmine\Client\Client::request()` instead.
+- `Redmine\Client\Client::requestPut()` is deprecated, use `\Redmine\Client\Client::request()` instead.
+- `Redmine\Client\Client::requestDelete()` is deprecated, use `\Redmine\Client\Client::request()` instead.
+- `Redmine\Client\Client::getLastResponseStatusCode()` is deprecated, use `\Redmine\Client\Client::request()` or `\Redmine\Api\AbstractApi::getLastResponse()->getStatusCode()` instead.
+- `Redmine\Client\Client::getLastResponseContentType()` is deprecated, use `\Redmine\Client\Client::request()` or `\Redmine\Api\AbstractApi::getLastResponse()->getContentType()` instead.
+- `Redmine\Client\Client::getLastResponseBody()` is deprecated, use `\Redmine\Client\Client::request()` or `\Redmine\Api\AbstractApi::getLastResponse()->getContent()` instead.
 
 ## [v2.7.0](https://github.com/kbsali/php-redmine-api/compare/v2.6.0...v2.7.0) - 2024-07-10
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ like [Guzzle](https://github.com/guzzle/guzzle) for handling http connections
 * [mid-level API](docs/usage.md#mid-level-api) e.g.
     ```php
     $client->getApi('issue')->create(['project_id' => 1, 'subject' => 'issue title']);
+
+    $response = $client->getApi('issue')->getLastResponse();
     ```
 * [low-level API](docs/usage.md#low-level-api) e.g.
     ```php

--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,7 @@
     },
     "scripts": {
         "bdt": [
+            "Composer\\Config::disableProcessTimeout",
             "@behat --format=progress --suite=redmine_50103",
             "@behat --format=progress --suite=redmine_50009",
             "@behat --format=progress --suite=redmine_40210"

--- a/src/Redmine/Client/Client.php
+++ b/src/Redmine/Client/Client.php
@@ -48,16 +48,25 @@ interface Client
 
     /**
      * Returns status code of the last response.
+     *
+     * @deprecated v2.8.0 Use `\Redmine\Api\AbstractApi::getLastResponse()` instead
+     * @see \Redmine\Api\AbstractApi::getLastResponse()
      */
     public function getLastResponseStatusCode(): int;
 
     /**
      * Returns content type of the last response.
+     *
+     * @deprecated v2.8.0 Use `\Redmine\Api\AbstractApi::getLastResponse()` instead
+     * @see \Redmine\Api\AbstractApi::getLastResponse()
      */
     public function getLastResponseContentType(): string;
 
     /**
      * Returns the body of the last response.
+     *
+     * @deprecated v2.8.0 Use `\Redmine\Api\AbstractApi::getLastResponse()` instead
+     * @see \Redmine\Api\AbstractApi::getLastResponse()
      */
     public function getLastResponseBody(): string;
 }

--- a/src/Redmine/Client/Client.php
+++ b/src/Redmine/Client/Client.php
@@ -28,28 +28,41 @@ interface Client
 
     /**
      * Create and send a GET request.
+     *
+     * @deprecated v2.8.0 Use `\Redmine\Http\HttpClient::request()` instead
+     * @see \Redmine\Http\HttpClient::request()
      */
     public function requestGet(string $path): bool;
 
     /**
      * Create and send a POST request.
+     *
+     * @deprecated v2.8.0 Use `\Redmine\Http\HttpClient::request()` instead
+     * @see \Redmine\Http\HttpClient::request()
      */
     public function requestPost(string $path, string $body): bool;
 
     /**
      * Create and send a PUT request.
+     *
+     * @deprecated v2.8.0 Use `\Redmine\Http\HttpClient::request()` instead
+     * @see \Redmine\Http\HttpClient::request()
      */
     public function requestPut(string $path, string $body): bool;
 
     /**
      * Create and send a DELETE request.
+     *
+     * @deprecated v2.8.0 Use `\Redmine\Http\HttpClient::request()` instead
+     * @see \Redmine\Http\HttpClient::request()
      */
     public function requestDelete(string $path): bool;
 
     /**
      * Returns status code of the last response.
      *
-     * @deprecated v2.8.0 Use `\Redmine\Api\AbstractApi::getLastResponse()` instead
+     * @deprecated v2.8.0 Use `\Redmine\Http\HttpClient::request()` or `\Redmine\Api\AbstractApi::getLastResponse()` instead
+     * @see \Redmine\Http\HttpClient::request()
      * @see \Redmine\Api\AbstractApi::getLastResponse()
      */
     public function getLastResponseStatusCode(): int;
@@ -57,7 +70,8 @@ interface Client
     /**
      * Returns content type of the last response.
      *
-     * @deprecated v2.8.0 Use `\Redmine\Api\AbstractApi::getLastResponse()` instead
+     * @deprecated v2.8.0 Use `\Redmine\Http\HttpClient::request()` or `\Redmine\Api\AbstractApi::getLastResponse()` instead
+     * @see \Redmine\Http\HttpClient::request()
      * @see \Redmine\Api\AbstractApi::getLastResponse()
      */
     public function getLastResponseContentType(): string;
@@ -65,7 +79,8 @@ interface Client
     /**
      * Returns the body of the last response.
      *
-     * @deprecated v2.8.0 Use `\Redmine\Api\AbstractApi::getLastResponse()` instead
+     * @deprecated v2.8.0 Use `\Redmine\Http\HttpClient::request()` or `\Redmine\Api\AbstractApi::getLastResponse()` instead
+     * @see \Redmine\Http\HttpClient::request()
      * @see \Redmine\Api\AbstractApi::getLastResponse()
      */
     public function getLastResponseBody(): string;

--- a/src/Redmine/Client/NativeCurlClient.php
+++ b/src/Redmine/Client/NativeCurlClient.php
@@ -143,25 +143,40 @@ final class NativeCurlClient implements Client, HttpClient
 
     /**
      * Returns status code of the last response.
+     *
+     * @deprecated v2.8.0 Use `\Redmine\Api\AbstractApi::getLastResponse()` instead
+     * @see \Redmine\Api\AbstractApi::getLastResponse()
      */
     public function getLastResponseStatusCode(): int
     {
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.8.0, use `\Redmine\Api\AbstractApi::getLastResponse()` instead.', E_USER_DEPRECATED);
+
         return $this->lastResponseStatusCode;
     }
 
     /**
      * Returns content type of the last response.
+     *
+     * @deprecated v2.8.0 Use `\Redmine\Api\AbstractApi::getLastResponse()` instead
+     * @see \Redmine\Api\AbstractApi::getLastResponse()
      */
     public function getLastResponseContentType(): string
     {
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.8.0, use `\Redmine\Api\AbstractApi::getLastResponse()` instead.', E_USER_DEPRECATED);
+
         return $this->lastResponseContentType;
     }
 
     /**
      * Returns the body of the last response.
+     *
+     * @deprecated v2.8.0 Use `\Redmine\Api\AbstractApi::getLastResponse()` instead
+     * @see \Redmine\Api\AbstractApi::getLastResponse()
      */
     public function getLastResponseBody(): string
     {
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.8.0, use `\Redmine\Api\AbstractApi::getLastResponse()` instead.', E_USER_DEPRECATED);
+
         return $this->lastResponseBody;
     }
 

--- a/src/Redmine/Client/NativeCurlClient.php
+++ b/src/Redmine/Client/NativeCurlClient.php
@@ -111,45 +111,66 @@ final class NativeCurlClient implements Client, HttpClient
 
     /**
      * Create and send a GET request.
+     *
+     * @deprecated v2.8.0 Use `\Redmine\Http\HttpClient::request()` instead
+     * @see \Redmine\Http\HttpClient::request()
      */
     public function requestGet(string $path): bool
     {
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.8.0, use `\Redmine\Client\NativeCurlClient::request()` instead.', E_USER_DEPRECATED);
+
         return $this->runRequest('GET', $path);
     }
 
     /**
      * Create and send a POST request.
+     *
+     * @deprecated v2.8.0 Use `\Redmine\Http\HttpClient::request()` instead
+     * @see \Redmine\Http\HttpClient::request()
      */
     public function requestPost(string $path, string $body): bool
     {
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.8.0, use `\Redmine\Client\NativeCurlClient::request()` instead.', E_USER_DEPRECATED);
+
         return $this->runRequest('POST', $path, $body);
     }
 
     /**
      * Create and send a PUT request.
+     *
+     * @deprecated v2.8.0 Use `\Redmine\Http\HttpClient::request()` instead
+     * @see \Redmine\Http\HttpClient::request()
      */
     public function requestPut(string $path, string $body): bool
     {
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.8.0, use `\Redmine\Client\NativeCurlClient::request()` instead.', E_USER_DEPRECATED);
+
         return $this->runRequest('PUT', $path, $body);
     }
 
     /**
      * Create and send a DELETE request.
+     *
+     * @deprecated v2.8.0 Use `\Redmine\Http\HttpClient::request()` instead
+     * @see \Redmine\Http\HttpClient::request()
      */
     public function requestDelete(string $path): bool
     {
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.8.0, use `\Redmine\Client\NativeCurlClient::request()` instead.', E_USER_DEPRECATED);
+
         return $this->runRequest('DELETE', $path);
     }
 
     /**
      * Returns status code of the last response.
      *
-     * @deprecated v2.8.0 Use `\Redmine\Api\AbstractApi::getLastResponse()` instead
+     * @deprecated v2.8.0 Use `\Redmine\Http\HttpClient::request()` or `\Redmine\Api\AbstractApi::getLastResponse()` instead
+     * @see \Redmine\Http\HttpClient::request()
      * @see \Redmine\Api\AbstractApi::getLastResponse()
      */
     public function getLastResponseStatusCode(): int
     {
-        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.8.0, use `\Redmine\Api\AbstractApi::getLastResponse()` instead.', E_USER_DEPRECATED);
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.8.0, use `\Redmine\Client\NativeCurlClient::request()` or `\Redmine\Api\AbstractApi::getLastResponse()` instead.', E_USER_DEPRECATED);
 
         return $this->lastResponseStatusCode;
     }
@@ -157,12 +178,13 @@ final class NativeCurlClient implements Client, HttpClient
     /**
      * Returns content type of the last response.
      *
-     * @deprecated v2.8.0 Use `\Redmine\Api\AbstractApi::getLastResponse()` instead
+     * @deprecated v2.8.0 Use `\Redmine\Http\HttpClient::request()` or `\Redmine\Api\AbstractApi::getLastResponse()` instead
+     * @see \Redmine\Http\HttpClient::request()
      * @see \Redmine\Api\AbstractApi::getLastResponse()
      */
     public function getLastResponseContentType(): string
     {
-        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.8.0, use `\Redmine\Api\AbstractApi::getLastResponse()` instead.', E_USER_DEPRECATED);
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.8.0, use `\Redmine\Client\NativeCurlClient::request()` or `\Redmine\Api\AbstractApi::getLastResponse()` instead.', E_USER_DEPRECATED);
 
         return $this->lastResponseContentType;
     }
@@ -170,12 +192,13 @@ final class NativeCurlClient implements Client, HttpClient
     /**
      * Returns the body of the last response.
      *
-     * @deprecated v2.8.0 Use `\Redmine\Api\AbstractApi::getLastResponse()` instead
+     * @deprecated v2.8.0 Use `\Redmine\Http\HttpClient::request()` or `\Redmine\Api\AbstractApi::getLastResponse()` instead
+     * @see \Redmine\Http\HttpClient::request()
      * @see \Redmine\Api\AbstractApi::getLastResponse()
      */
     public function getLastResponseBody(): string
     {
-        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.8.0, use `\Redmine\Api\AbstractApi::getLastResponse()` instead.', E_USER_DEPRECATED);
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.8.0, use `\Redmine\Client\NativeCurlClient::request()` or `\Redmine\Api\AbstractApi::getLastResponse()` instead.', E_USER_DEPRECATED);
 
         return $this->lastResponseBody;
     }

--- a/src/Redmine/Client/Psr18Client.php
+++ b/src/Redmine/Client/Psr18Client.php
@@ -118,12 +118,17 @@ final class Psr18Client implements Client, HttpClient
     /**
      * Create and send a GET request.
      *
+     * @deprecated v2.8.0 Use `\Redmine\Http\HttpClient::request()` instead
+     * @see \Redmine\Http\HttpClient::request()
+     *
      * @throws ClientException If anything goes wrong on the request
      *
      * @return bool true if status code of the response is not 4xx oder 5xx
      */
     public function requestGet(string $path): bool
     {
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.8.0, use `\Redmine\Client\Psr18Client::request()` instead.', E_USER_DEPRECATED);
+
         $response = $this->runRequest('GET', $path);
 
         return $response->getStatusCode() < 400;
@@ -132,12 +137,17 @@ final class Psr18Client implements Client, HttpClient
     /**
      * Create and send a POST request.
      *
+     * @deprecated v2.8.0 Use `\Redmine\Http\HttpClient::request()` instead
+     * @see \Redmine\Http\HttpClient::request()
+     *
      * @throws ClientException If anything goes wrong on the request
      *
      * @return bool true if status code of the response is not 4xx oder 5xx
      */
     public function requestPost(string $path, string $body): bool
     {
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.8.0, use `\Redmine\Client\Psr18Client::request()` instead.', E_USER_DEPRECATED);
+
         $response = $this->runRequest('POST', $path, $body);
 
         return $response->getStatusCode() < 400;
@@ -146,12 +156,17 @@ final class Psr18Client implements Client, HttpClient
     /**
      * Create and send a PUT request.
      *
+     * @deprecated v2.8.0 Use `\Redmine\Http\HttpClient::request()` instead
+     * @see \Redmine\Http\HttpClient::request()
+     *
      * @throws ClientException If anything goes wrong on the request
      *
      * @return bool true if status code of the response is not 4xx oder 5xx
      */
     public function requestPut(string $path, string $body): bool
     {
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.8.0, use `\Redmine\Client\Psr18Client::request()` instead.', E_USER_DEPRECATED);
+
         $response = $this->runRequest('PUT', $path, $body);
 
         return $response->getStatusCode() < 400;
@@ -160,12 +175,17 @@ final class Psr18Client implements Client, HttpClient
     /**
      * Create and send a DELETE request.
      *
+     * @deprecated v2.8.0 Use `\Redmine\Http\HttpClient::request()` instead
+     * @see \Redmine\Http\HttpClient::request()
+     *
      * @throws ClientException If anything goes wrong on the request
      *
      * @return bool true if status code of the response is not 4xx oder 5xx
      */
     public function requestDelete(string $path): bool
     {
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.8.0, use `\Redmine\Client\Psr18Client::request()` instead.', E_USER_DEPRECATED);
+
         $response = $this->runRequest('DELETE', $path);
 
         return $response->getStatusCode() < 400;

--- a/src/Redmine/Client/Psr18Client.php
+++ b/src/Redmine/Client/Psr18Client.php
@@ -173,9 +173,14 @@ final class Psr18Client implements Client, HttpClient
 
     /**
      * Returns status code of the last response.
+     *
+     * @deprecated v2.8.0 Use `\Redmine\Api\AbstractApi::getLastResponse()` instead
+     * @see \Redmine\Api\AbstractApi::getLastResponse()
      */
     public function getLastResponseStatusCode(): int
     {
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.8.0, use `\Redmine\Api\AbstractApi::getLastResponse()` instead.', E_USER_DEPRECATED);
+
         if (null === $this->lastResponse) {
             return 0;
         }
@@ -185,9 +190,14 @@ final class Psr18Client implements Client, HttpClient
 
     /**
      * Returns content type of the last response.
+     *
+     * @deprecated v2.8.0 Use `\Redmine\Api\AbstractApi::getLastResponse()` instead
+     * @see \Redmine\Api\AbstractApi::getLastResponse()
      */
     public function getLastResponseContentType(): string
     {
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.8.0, use `\Redmine\Api\AbstractApi::getLastResponse()` instead.', E_USER_DEPRECATED);
+
         if (null === $this->lastResponse) {
             return '';
         }
@@ -197,9 +207,14 @@ final class Psr18Client implements Client, HttpClient
 
     /**
      * Returns the body of the last response.
+     *
+     * @deprecated v2.8.0 Use `\Redmine\Api\AbstractApi::getLastResponse()` instead
+     * @see \Redmine\Api\AbstractApi::getLastResponse()
      */
     public function getLastResponseBody(): string
     {
+        @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.8.0, use `\Redmine\Api\AbstractApi::getLastResponse()` instead.', E_USER_DEPRECATED);
+
         if (null === $this->lastResponse) {
             return '';
         }

--- a/tests/Unit/Client/NativeCurlClientTest.php
+++ b/tests/Unit/Client/NativeCurlClientTest.php
@@ -765,7 +765,8 @@ class NativeCurlClientTest extends TestCase
 
         try {
             $client->requestGet('/path');
-        } catch (ClientException $th) {}
+        } catch (ClientException $th) {
+        }
     }
 
     public function testRequestPostTriggersDeprecationWarning(): void
@@ -809,7 +810,8 @@ class NativeCurlClientTest extends TestCase
 
         try {
             $client->requestPost('/path', '');
-        } catch (ClientException $th) {}
+        } catch (ClientException $th) {
+        }
     }
 
     public function testRequestPutTriggersDeprecationWarning(): void
@@ -853,7 +855,8 @@ class NativeCurlClientTest extends TestCase
 
         try {
             $client->requestPut('/path', '');
-        } catch (ClientException $th) {}
+        } catch (ClientException $th) {
+        }
     }
 
     public function testRequestDeleteTriggersDeprecationWarning(): void
@@ -897,7 +900,8 @@ class NativeCurlClientTest extends TestCase
 
         try {
             $client->requestDelete('/path');
-        } catch (ClientException $th) {}
+        } catch (ClientException $th) {
+        }
     }
 
     public function testHandlingOfResponseWithoutContent(): void

--- a/tests/Unit/Client/NativeCurlClientTest.php
+++ b/tests/Unit/Client/NativeCurlClientTest.php
@@ -12,6 +12,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Client\Client;
 use Redmine\Client\NativeCurlClient;
+use Redmine\Exception\ClientException;
 use Redmine\Http\HttpClient;
 use stdClass;
 
@@ -80,7 +81,7 @@ class NativeCurlClientTest extends TestCase
         set_error_handler(
             function ($errno, $errstr): bool {
                 $this->assertSame(
-                    '`Redmine\Client\NativeCurlClient::getLastResponseStatusCode()` is deprecated since v2.8.0, use `\Redmine\Api\AbstractApi::getLastResponse()` instead.',
+                    '`Redmine\Client\NativeCurlClient::getLastResponseStatusCode()` is deprecated since v2.8.0, use `\Redmine\Client\NativeCurlClient::request()` or `\Redmine\Api\AbstractApi::getLastResponse()` instead.',
                     $errstr,
                 );
 
@@ -114,7 +115,7 @@ class NativeCurlClientTest extends TestCase
         set_error_handler(
             function ($errno, $errstr): bool {
                 $this->assertSame(
-                    '`Redmine\Client\NativeCurlClient::getLastResponseContentType()` is deprecated since v2.8.0, use `\Redmine\Api\AbstractApi::getLastResponse()` instead.',
+                    '`Redmine\Client\NativeCurlClient::getLastResponseContentType()` is deprecated since v2.8.0, use `\Redmine\Client\NativeCurlClient::request()` or `\Redmine\Api\AbstractApi::getLastResponse()` instead.',
                     $errstr,
                 );
 
@@ -148,7 +149,7 @@ class NativeCurlClientTest extends TestCase
         set_error_handler(
             function ($errno, $errstr): bool {
                 $this->assertSame(
-                    '`Redmine\Client\NativeCurlClient::getLastResponseBody()` is deprecated since v2.8.0, use `\Redmine\Api\AbstractApi::getLastResponse()` instead.',
+                    '`Redmine\Client\NativeCurlClient::getLastResponseBody()` is deprecated since v2.8.0, use `\Redmine\Client\NativeCurlClient::request()` or `\Redmine\Api\AbstractApi::getLastResponse()` instead.',
                     $errstr,
                 );
 
@@ -721,6 +722,182 @@ class NativeCurlClientTest extends TestCase
             ['requestDelete', '', false, 404, 'application/json', '{"title": "404 Not Found"}'],
             ['requestDelete', '', false, 500, 'text/plain', 'Internal Server Error'],
         ];
+    }
+
+    public function testRequestGetTriggersDeprecationWarning(): void
+    {
+        $curl = $this->createMock(stdClass::class);
+
+        $curlInit = $this->getFunctionMock(self::__NAMESPACE__, 'curl_init');
+
+        $curlExec = $this->getFunctionMock(self::__NAMESPACE__, 'curl_exec');
+
+        $curlSetoptArray = $this->getFunctionMock(self::__NAMESPACE__, 'curl_setopt_array');
+
+        $curlGetinfo = $this->getFunctionMock(self::__NAMESPACE__, 'curl_getinfo');
+
+        $curlErrno = $this->getFunctionMock(self::__NAMESPACE__, 'curl_errno');
+        $curlErrno->expects($this->exactly(1))->willReturn(CURLE_COULDNT_CONNECT);
+
+        $curlError = $this->getFunctionMock(self::__NAMESPACE__, 'curl_error');
+        $curlError->expects($this->exactly(1))->willReturn('');
+
+        $curlClose = $this->getFunctionMock(self::__NAMESPACE__, 'curl_close');
+
+        $client = new NativeCurlClient(
+            'http://test.local',
+            'access_token',
+        );
+
+        // PHPUnit 10 compatible way to test trigger_error().
+        set_error_handler(
+            function ($errno, $errstr): bool {
+                $this->assertSame(
+                    '`Redmine\Client\NativeCurlClient::requestGet()` is deprecated since v2.8.0, use `\Redmine\Client\NativeCurlClient::request()` instead.',
+                    $errstr,
+                );
+
+                restore_error_handler();
+                return true;
+            },
+            E_USER_DEPRECATED,
+        );
+
+        try {
+            $client->requestGet('/path');
+        } catch (ClientException $th) {}
+    }
+
+    public function testRequestPostTriggersDeprecationWarning(): void
+    {
+        $curl = $this->createMock(stdClass::class);
+
+        $curlInit = $this->getFunctionMock(self::__NAMESPACE__, 'curl_init');
+
+        $curlExec = $this->getFunctionMock(self::__NAMESPACE__, 'curl_exec');
+
+        $curlSetoptArray = $this->getFunctionMock(self::__NAMESPACE__, 'curl_setopt_array');
+
+        $curlGetinfo = $this->getFunctionMock(self::__NAMESPACE__, 'curl_getinfo');
+
+        $curlErrno = $this->getFunctionMock(self::__NAMESPACE__, 'curl_errno');
+        $curlErrno->expects($this->exactly(1))->willReturn(CURLE_COULDNT_CONNECT);
+
+        $curlError = $this->getFunctionMock(self::__NAMESPACE__, 'curl_error');
+        $curlError->expects($this->exactly(1))->willReturn('');
+
+        $curlClose = $this->getFunctionMock(self::__NAMESPACE__, 'curl_close');
+
+        $client = new NativeCurlClient(
+            'http://test.local',
+            'access_token',
+        );
+
+        // PHPUnit 10 compatible way to test trigger_error().
+        set_error_handler(
+            function ($errno, $errstr): bool {
+                $this->assertSame(
+                    '`Redmine\Client\NativeCurlClient::requestPost()` is deprecated since v2.8.0, use `\Redmine\Client\NativeCurlClient::request()` instead.',
+                    $errstr,
+                );
+
+                restore_error_handler();
+                return true;
+            },
+            E_USER_DEPRECATED,
+        );
+
+        try {
+            $client->requestPost('/path', '');
+        } catch (ClientException $th) {}
+    }
+
+    public function testRequestPutTriggersDeprecationWarning(): void
+    {
+        $curl = $this->createMock(stdClass::class);
+
+        $curlInit = $this->getFunctionMock(self::__NAMESPACE__, 'curl_init');
+
+        $curlExec = $this->getFunctionMock(self::__NAMESPACE__, 'curl_exec');
+
+        $curlSetoptArray = $this->getFunctionMock(self::__NAMESPACE__, 'curl_setopt_array');
+
+        $curlGetinfo = $this->getFunctionMock(self::__NAMESPACE__, 'curl_getinfo');
+
+        $curlErrno = $this->getFunctionMock(self::__NAMESPACE__, 'curl_errno');
+        $curlErrno->expects($this->exactly(1))->willReturn(CURLE_COULDNT_CONNECT);
+
+        $curlError = $this->getFunctionMock(self::__NAMESPACE__, 'curl_error');
+        $curlError->expects($this->exactly(1))->willReturn('');
+
+        $curlClose = $this->getFunctionMock(self::__NAMESPACE__, 'curl_close');
+
+        $client = new NativeCurlClient(
+            'http://test.local',
+            'access_token',
+        );
+
+        // PHPUnit 10 compatible way to test trigger_error().
+        set_error_handler(
+            function ($errno, $errstr): bool {
+                $this->assertSame(
+                    '`Redmine\Client\NativeCurlClient::requestPut()` is deprecated since v2.8.0, use `\Redmine\Client\NativeCurlClient::request()` instead.',
+                    $errstr,
+                );
+
+                restore_error_handler();
+                return true;
+            },
+            E_USER_DEPRECATED,
+        );
+
+        try {
+            $client->requestPut('/path', '');
+        } catch (ClientException $th) {}
+    }
+
+    public function testRequestDeleteTriggersDeprecationWarning(): void
+    {
+        $curl = $this->createMock(stdClass::class);
+
+        $curlInit = $this->getFunctionMock(self::__NAMESPACE__, 'curl_init');
+
+        $curlExec = $this->getFunctionMock(self::__NAMESPACE__, 'curl_exec');
+
+        $curlSetoptArray = $this->getFunctionMock(self::__NAMESPACE__, 'curl_setopt_array');
+
+        $curlGetinfo = $this->getFunctionMock(self::__NAMESPACE__, 'curl_getinfo');
+
+        $curlErrno = $this->getFunctionMock(self::__NAMESPACE__, 'curl_errno');
+        $curlErrno->expects($this->exactly(1))->willReturn(CURLE_COULDNT_CONNECT);
+
+        $curlError = $this->getFunctionMock(self::__NAMESPACE__, 'curl_error');
+        $curlError->expects($this->exactly(1))->willReturn('');
+
+        $curlClose = $this->getFunctionMock(self::__NAMESPACE__, 'curl_close');
+
+        $client = new NativeCurlClient(
+            'http://test.local',
+            'access_token',
+        );
+
+        // PHPUnit 10 compatible way to test trigger_error().
+        set_error_handler(
+            function ($errno, $errstr): bool {
+                $this->assertSame(
+                    '`Redmine\Client\NativeCurlClient::requestDelete()` is deprecated since v2.8.0, use `\Redmine\Client\NativeCurlClient::request()` instead.',
+                    $errstr,
+                );
+
+                restore_error_handler();
+                return true;
+            },
+            E_USER_DEPRECATED,
+        );
+
+        try {
+            $client->requestDelete('/path');
+        } catch (ClientException $th) {}
     }
 
     public function testHandlingOfResponseWithoutContent(): void

--- a/tests/Unit/Client/NativeCurlClientTest.php
+++ b/tests/Unit/Client/NativeCurlClientTest.php
@@ -69,6 +69,30 @@ class NativeCurlClientTest extends TestCase
         $this->assertSame(0, $client->getLastResponseStatusCode());
     }
 
+    public function testGetLastResponseStatusCodeTriggersDeprecationWarning(): void
+    {
+        $client = new NativeCurlClient(
+            'http://test.local',
+            'access_token',
+        );
+
+        // PHPUnit 10 compatible way to test trigger_error().
+        set_error_handler(
+            function ($errno, $errstr): bool {
+                $this->assertSame(
+                    '`Redmine\Client\NativeCurlClient::getLastResponseStatusCode()` is deprecated since v2.8.0, use `\Redmine\Api\AbstractApi::getLastResponse()` instead.',
+                    $errstr,
+                );
+
+                restore_error_handler();
+                return true;
+            },
+            E_USER_DEPRECATED,
+        );
+
+        $client->getLastResponseStatusCode();
+    }
+
     public function testGetLastResponseContentTypeIsInitialEmpty(): void
     {
         $client = new NativeCurlClient(
@@ -79,6 +103,30 @@ class NativeCurlClientTest extends TestCase
         $this->assertSame('', $client->getLastResponseContentType());
     }
 
+    public function testGetLastResponseContentTypeTriggersDeprecationWarning(): void
+    {
+        $client = new NativeCurlClient(
+            'http://test.local',
+            'access_token',
+        );
+
+        // PHPUnit 10 compatible way to test trigger_error().
+        set_error_handler(
+            function ($errno, $errstr): bool {
+                $this->assertSame(
+                    '`Redmine\Client\NativeCurlClient::getLastResponseContentType()` is deprecated since v2.8.0, use `\Redmine\Api\AbstractApi::getLastResponse()` instead.',
+                    $errstr,
+                );
+
+                restore_error_handler();
+                return true;
+            },
+            E_USER_DEPRECATED,
+        );
+
+        $client->getLastResponseContentType();
+    }
+
     public function testGetLastResponseBodyIsInitialEmpty(): void
     {
         $client = new NativeCurlClient(
@@ -87,6 +135,30 @@ class NativeCurlClientTest extends TestCase
         );
 
         $this->assertSame('', $client->getLastResponseBody());
+    }
+
+    public function testGetLastResponseBodyTriggersDeprecationWarning(): void
+    {
+        $client = new NativeCurlClient(
+            'http://test.local',
+            'access_token',
+        );
+
+        // PHPUnit 10 compatible way to test trigger_error().
+        set_error_handler(
+            function ($errno, $errstr): bool {
+                $this->assertSame(
+                    '`Redmine\Client\NativeCurlClient::getLastResponseBody()` is deprecated since v2.8.0, use `\Redmine\Api\AbstractApi::getLastResponse()` instead.',
+                    $errstr,
+                );
+
+                restore_error_handler();
+                return true;
+            },
+            E_USER_DEPRECATED,
+        );
+
+        $client->getLastResponseBody();
     }
 
     public function testStartAndStopImpersonateUser(): void

--- a/tests/Unit/Client/Psr18ClientTest.php
+++ b/tests/Unit/Client/Psr18ClientTest.php
@@ -17,6 +17,7 @@ use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Redmine\Client\Client;
 use Redmine\Client\Psr18Client;
+use Redmine\Exception\ClientException;
 use Redmine\Http\HttpClient;
 use stdClass;
 
@@ -314,6 +315,142 @@ class Psr18ClientTest extends TestCase
             ['requestDelete', '', false, 404, 'application/json', '{"title": "404 Not Found"}'],
             ['requestDelete', '', false, 500, 'text/plain', 'Internal Server Error'],
         ];
+    }
+
+    public function testRequestGetTriggersDeprecationWarning(): void
+    {
+        $requestFactory = $this->createMock(RequestFactoryInterface::class);
+        $requestFactory->method('createRequest')->willThrowException(
+            $this->createMock(ClientException::class),
+        );
+
+        $client = new Psr18Client(
+            $this->createMock(ClientInterface::class),
+            $requestFactory,
+            $this->createMock(StreamFactoryInterface::class),
+            'http://test.local',
+            'access_token',
+        );
+
+        // PHPUnit 10 compatible way to test trigger_error().
+        set_error_handler(
+            function ($errno, $errstr): bool {
+                $this->assertSame(
+                    '`Redmine\Client\Psr18Client::requestGet()` is deprecated since v2.8.0, use `\Redmine\Client\Psr18Client::request()` instead.',
+                    $errstr,
+                );
+
+                restore_error_handler();
+                return true;
+            },
+            E_USER_DEPRECATED,
+        );
+
+        try {
+            $client->requestGet('/path');
+        } catch (ClientException $th) {}
+    }
+
+    public function testRequestPostTriggersDeprecationWarning(): void
+    {
+        $requestFactory = $this->createMock(RequestFactoryInterface::class);
+        $requestFactory->method('createRequest')->willThrowException(
+            $this->createMock(ClientException::class),
+        );
+
+        $client = new Psr18Client(
+            $this->createMock(ClientInterface::class),
+            $requestFactory,
+            $this->createMock(StreamFactoryInterface::class),
+            'http://test.local',
+            'access_token',
+        );
+
+        // PHPUnit 10 compatible way to test trigger_error().
+        set_error_handler(
+            function ($errno, $errstr): bool {
+                $this->assertSame(
+                    '`Redmine\Client\Psr18Client::requestPost()` is deprecated since v2.8.0, use `\Redmine\Client\Psr18Client::request()` instead.',
+                    $errstr,
+                );
+
+                restore_error_handler();
+                return true;
+            },
+            E_USER_DEPRECATED,
+        );
+
+        try {
+            $client->requestPost('/path', '');
+        } catch (ClientException $th) {}
+    }
+
+    public function testRequestPutTriggersDeprecationWarning(): void
+    {
+        $requestFactory = $this->createMock(RequestFactoryInterface::class);
+        $requestFactory->method('createRequest')->willThrowException(
+            $this->createMock(ClientException::class),
+        );
+
+        $client = new Psr18Client(
+            $this->createMock(ClientInterface::class),
+            $requestFactory,
+            $this->createMock(StreamFactoryInterface::class),
+            'http://test.local',
+            'access_token',
+        );
+
+        // PHPUnit 10 compatible way to test trigger_error().
+        set_error_handler(
+            function ($errno, $errstr): bool {
+                $this->assertSame(
+                    '`Redmine\Client\Psr18Client::requestPut()` is deprecated since v2.8.0, use `\Redmine\Client\Psr18Client::request()` instead.',
+                    $errstr,
+                );
+
+                restore_error_handler();
+                return true;
+            },
+            E_USER_DEPRECATED,
+        );
+
+        try {
+            $client->requestPut('/path', '');
+        } catch (ClientException $th) {}
+    }
+
+    public function testRequestDeleteTriggersDeprecationWarning(): void
+    {
+        $requestFactory = $this->createMock(RequestFactoryInterface::class);
+        $requestFactory->method('createRequest')->willThrowException(
+            $this->createMock(ClientException::class),
+        );
+
+        $client = new Psr18Client(
+            $this->createMock(ClientInterface::class),
+            $requestFactory,
+            $this->createMock(StreamFactoryInterface::class),
+            'http://test.local',
+            'access_token',
+        );
+
+        // PHPUnit 10 compatible way to test trigger_error().
+        set_error_handler(
+            function ($errno, $errstr): bool {
+                $this->assertSame(
+                    '`Redmine\Client\Psr18Client::requestDelete()` is deprecated since v2.8.0, use `\Redmine\Client\Psr18Client::request()` instead.',
+                    $errstr,
+                );
+
+                restore_error_handler();
+                return true;
+            },
+            E_USER_DEPRECATED,
+        );
+
+        try {
+            $client->requestDelete('/path');
+        } catch (ClientException $th) {}
     }
 
     /**

--- a/tests/Unit/Client/Psr18ClientTest.php
+++ b/tests/Unit/Client/Psr18ClientTest.php
@@ -348,7 +348,8 @@ class Psr18ClientTest extends TestCase
 
         try {
             $client->requestGet('/path');
-        } catch (ClientException $th) {}
+        } catch (ClientException $th) {
+        }
     }
 
     public function testRequestPostTriggersDeprecationWarning(): void
@@ -382,7 +383,8 @@ class Psr18ClientTest extends TestCase
 
         try {
             $client->requestPost('/path', '');
-        } catch (ClientException $th) {}
+        } catch (ClientException $th) {
+        }
     }
 
     public function testRequestPutTriggersDeprecationWarning(): void
@@ -416,7 +418,8 @@ class Psr18ClientTest extends TestCase
 
         try {
             $client->requestPut('/path', '');
-        } catch (ClientException $th) {}
+        } catch (ClientException $th) {
+        }
     }
 
     public function testRequestDeleteTriggersDeprecationWarning(): void
@@ -450,7 +453,8 @@ class Psr18ClientTest extends TestCase
 
         try {
             $client->requestDelete('/path');
-        } catch (ClientException $th) {}
+        } catch (ClientException $th) {
+        }
     }
 
     /**

--- a/tests/Unit/Client/Psr18ClientTest.php
+++ b/tests/Unit/Client/Psr18ClientTest.php
@@ -90,6 +90,33 @@ class Psr18ClientTest extends TestCase
         $this->assertSame(0, $client->getLastResponseStatusCode());
     }
 
+    public function testGetLastResponseStatusCodeTriggersDeprecationWarning(): void
+    {
+        $client = new Psr18Client(
+            $this->createMock(ClientInterface::class),
+            $this->createMock(RequestFactoryInterface::class),
+            $this->createMock(StreamFactoryInterface::class),
+            'http://test.local',
+            'access_token',
+        );
+
+        // PHPUnit 10 compatible way to test trigger_error().
+        set_error_handler(
+            function ($errno, $errstr): bool {
+                $this->assertSame(
+                    '`Redmine\Client\Psr18Client::getLastResponseStatusCode()` is deprecated since v2.8.0, use `\Redmine\Api\AbstractApi::getLastResponse()` instead.',
+                    $errstr,
+                );
+
+                restore_error_handler();
+                return true;
+            },
+            E_USER_DEPRECATED,
+        );
+
+        $client->getLastResponseStatusCode();
+    }
+
     public function testGetLastResponseContentTypeIsInitialEmpty(): void
     {
         $client = new Psr18Client(
@@ -103,6 +130,33 @@ class Psr18ClientTest extends TestCase
         $this->assertSame('', $client->getLastResponseContentType());
     }
 
+    public function testGetLastResponseContentTypeTriggersDeprecationWarning(): void
+    {
+        $client = new Psr18Client(
+            $this->createMock(ClientInterface::class),
+            $this->createMock(RequestFactoryInterface::class),
+            $this->createMock(StreamFactoryInterface::class),
+            'http://test.local',
+            'access_token',
+        );
+
+        // PHPUnit 10 compatible way to test trigger_error().
+        set_error_handler(
+            function ($errno, $errstr): bool {
+                $this->assertSame(
+                    '`Redmine\Client\Psr18Client::getLastResponseContentType()` is deprecated since v2.8.0, use `\Redmine\Api\AbstractApi::getLastResponse()` instead.',
+                    $errstr,
+                );
+
+                restore_error_handler();
+                return true;
+            },
+            E_USER_DEPRECATED,
+        );
+
+        $client->getLastResponseContentType();
+    }
+
     public function testGetLastResponseBodyIsInitialEmpty(): void
     {
         $client = new Psr18Client(
@@ -114,6 +168,33 @@ class Psr18ClientTest extends TestCase
         );
 
         $this->assertSame('', $client->getLastResponseBody());
+    }
+
+    public function testGetLastResponseBodyTriggersDeprecationWarning(): void
+    {
+        $client = new Psr18Client(
+            $this->createMock(ClientInterface::class),
+            $this->createMock(RequestFactoryInterface::class),
+            $this->createMock(StreamFactoryInterface::class),
+            'http://test.local',
+            'access_token',
+        );
+
+        // PHPUnit 10 compatible way to test trigger_error().
+        set_error_handler(
+            function ($errno, $errstr): bool {
+                $this->assertSame(
+                    '`Redmine\Client\Psr18Client::getLastResponseBody()` is deprecated since v2.8.0, use `\Redmine\Api\AbstractApi::getLastResponse()` instead.',
+                    $errstr,
+                );
+
+                restore_error_handler();
+                return true;
+            },
+            E_USER_DEPRECATED,
+        );
+
+        $client->getLastResponseBody();
     }
 
     public function testStartAndStopImpersonateUser(): void


### PR DESCRIPTION
Closes #391.