### PR TITLE
Fix tests for 8.6

### DIFF
--- a/src/Redmine/Serializer/XmlSerializer.php
+++ b/src/Redmine/Serializer/XmlSerializer.php
@@ -77,16 +77,18 @@ final class XmlSerializer implements Stringable
             $this->deserialized = new SimpleXMLElement($encoded);
         } catch (Throwable $e) {
             $errors = [];
+            $code = $e->getCode();
 
             foreach (libxml_get_errors() as $error) {
                 $errors[] = $error->message;
+                $code = max($code, $error->level);
             }
 
             libxml_clear_errors();
 
             throw new SerializerException(
                 'Catched errors: "' . implode('", "', $errors) . '" while decoding XML: ' . $encoded,
-                $e->getCode(),
+                $code,
                 $e,
             );
         } finally {

--- a/tests/Unit/Api/AbstractApi/GetTest.php
+++ b/tests/Unit/Api/AbstractApi/GetTest.php
@@ -49,7 +49,7 @@ class GetTest extends TestCase
      * @dataProvider getJsonDecodingFromGetMethodData
      */
     #[DataProvider('getJsonDecodingFromGetMethodData')]
-    public function testJsonDecodingFromGetMethod(string $response, ?bool $decode, $expected): void
+    public function testJsonDecodingFromGetMethod(string $response, ?bool $shouldDecode, $expected): void
     {
         $client = $this->createStub(Client::class);
         $client->method('getLastResponseBody')->willReturn($response);
@@ -63,8 +63,8 @@ class GetTest extends TestCase
         }
 
         // Perform the tests
-        if (is_bool($decode)) {
-            $this->assertSame($expected, $method->invoke($api, 'path', $decode));
+        if (is_bool($shouldDecode)) {
+            $this->assertSame($expected, $method->invoke($api, 'path', $shouldDecode));
         } else {
             $this->assertSame($expected, $method->invoke($api, 'path'));
         }
@@ -73,12 +73,36 @@ class GetTest extends TestCase
     public static function getJsonDecodingFromGetMethodData(): array
     {
         return [
-            'test decode by default' => ['{"foo_bar": 12345}', null, ['foo_bar' => 12345]],
-            'test decode by default, JSON decode: false' => ['{"foo_bar": 12345}', false, '{"foo_bar": 12345}'],
-            'test decode by default, JSON decode: true' => ['{"foo_bar": 12345}', true, ['foo_bar' => 12345]],
-            'Empty body, JSON decode: false' => ['', false, false],
-            'Empty body, JSON decode: true' => ['', true, false],
-            'test invalid JSON' => ['{"foo_bar":', true, 'Error decoding body as JSON: Syntax error'],
+            'test decode by default' => [
+                '{"foo_bar": 12345}',
+                null,
+                ['foo_bar' => 12345],
+            ],
+            'test decode by default, JSON decode: false' => [
+                '{"foo_bar": 12345}',
+                false,
+                '{"foo_bar": 12345}',
+            ],
+            'test decode by default, JSON decode: true' => [
+                '{"foo_bar": 12345}',
+                true,
+                ['foo_bar' => 12345],
+            ],
+            'Empty body, JSON decode: false' => [
+                '',
+                false,
+                false,
+            ],
+            'Empty body, JSON decode: true' => [
+                '',
+                true,
+                false,
+            ],
+            'test invalid JSON' => [
+                '{"foo_bar":',
+                true,
+                (PHP_VERSION_ID < 80600) ? 'Error decoding body as JSON: Syntax error' : 'Error decoding body as JSON: Syntax error near location 1:12',
+            ],
         ];
     }
 

--- a/tests/Unit/Api/AbstractApi/GetTest.php
+++ b/tests/Unit/Api/AbstractApi/GetTest.php
@@ -101,6 +101,7 @@ class GetTest extends TestCase
             'test invalid JSON' => [
                 '{"foo_bar":',
                 true,
+                /** @phpstan-ignore smaller.alwaysTrue Remove this line after release of PHP 8.6 */
                 (PHP_VERSION_ID < 80600) ? 'Error decoding body as JSON: Syntax error' : 'Error decoding body as JSON: Syntax error near location 1:12',
             ],
         ];

--- a/tests/Unit/Api/AbstractApi/GetTest.php
+++ b/tests/Unit/Api/AbstractApi/GetTest.php
@@ -101,7 +101,7 @@ class GetTest extends TestCase
             'test invalid JSON' => [
                 '{"foo_bar":',
                 true,
-                /** @phpstan-ignore smaller.alwaysTrue Remove this line after release of PHP 8.6 */
+                /** @phpstan-ignore smaller.alwaysTrue(Remove this line after release of PHP 8.6) */
                 (PHP_VERSION_ID < 80600) ? 'Error decoding body as JSON: Syntax error' : 'Error decoding body as JSON: Syntax error near location 1:12',
             ],
         ];

--- a/tests/Unit/Api/Attachment/ShowTest.php
+++ b/tests/Unit/Api/Attachment/ShowTest.php
@@ -40,10 +40,32 @@ class ShowTest extends TestCase
     public static function getShowData(): array
     {
         return [
-            'array response with integer id' => [5, '/attachments/5.json', '["API Response"]', ['API Response']],
-            'array response with string id' => ['5', '/attachments/5.json', '["API Response"]', ['API Response']],
-            'string response' => [5, '/attachments/5.json', 'string', 'Error decoding body as JSON: Syntax error'],
-            'false response' => [5, '/attachments/5.json', '', false],
+            'array response with integer id' => [
+                5,
+                '/attachments/5.json',
+                '["API Response"]',
+                ['API Response'],
+            ],
+            'array response with string id' =>
+            [
+                '5',
+                '/attachments/5.json',
+                '["API Response"]',
+                ['API Response'],
+            ],
+            'string response' => [
+                5,
+                '/attachments/5.json',
+                'string',
+                /** @phpstan-ignore smaller.alwaysTrue(Remove this line after release of PHP 8.6) */
+                (PHP_VERSION_ID < 80600) ? 'Error decoding body as JSON: Syntax error' : 'Error decoding body as JSON: Syntax error near location 1:1',
+            ],
+            'false response' => [
+                5,
+                '/attachments/5.json',
+                '',
+                false,
+            ],
         ];
     }
 }

--- a/tests/Unit/Api/Group/ShowTest.php
+++ b/tests/Unit/Api/Group/ShowTest.php
@@ -40,11 +40,42 @@ class ShowTest extends TestCase
     public static function getShowData(): array
     {
         return [
-            'array response with integer id' => [5, [], '/groups/5.json', '["API Response"]', ['API Response']],
-            'array response with string id' => ['5', [], '/groups/5.json', '["API Response"]', ['API Response']],
-            'array response with parameters' => [5, ['include' => ['parameter1', 'parameter2'], 'not-used'], '/groups/5.json?include%5B%5D=parameter1&include%5B%5D=parameter2&0=not-used', '["API Response"]', ['API Response']],
-            'string response' => [5, [], '/groups/5.json', 'string', 'Error decoding body as JSON: Syntax error'],
-            'false response' => [5, [], '/groups/5.json', '', false],
+            'array response with integer id' => [
+                5,
+                [],
+                '/groups/5.json',
+                '["API Response"]',
+                ['API Response'],
+            ],
+            'array response with string id' => [
+                '5',
+                [],
+                '/groups/5.json',
+                '["API Response"]',
+                ['API Response'],
+            ],
+            'array response with parameters' => [
+                5,
+                ['include' => ['parameter1', 'parameter2'], 'not-used'],
+                '/groups/5.json?include%5B%5D=parameter1&include%5B%5D=parameter2&0=not-used',
+                '["API Response"]',
+                ['API Response'],
+            ],
+            'string response' => [
+                5,
+                [],
+                '/groups/5.json',
+                'string',
+                /** @phpstan-ignore smaller.alwaysTrue(Remove this line after release of PHP 8.6) */
+                (PHP_VERSION_ID < 80600) ? 'Error decoding body as JSON: Syntax error' : 'Error decoding body as JSON: Syntax error near location 1:1',
+            ],
+            'false response' => [
+                5,
+                [],
+                '/groups/5.json',
+                '',
+                false,
+            ],
         ];
     }
 }

--- a/tests/Unit/Api/Issue/ShowTest.php
+++ b/tests/Unit/Api/Issue/ShowTest.php
@@ -40,11 +40,42 @@ class ShowTest extends TestCase
     public static function getShowData(): array
     {
         return [
-            'array response with integer id' => [5, [], '/issues/5.json', '["API Response"]', ['API Response']],
-            'array response with string id' => ['5', [], '/issues/5.json', '["API Response"]', ['API Response']],
-            'array response with parameters' => [5, ['include' => ['parameter1', 'parameter2'], 'not-used'], '/issues/5.json?include=parameter1%2Cparameter2&0=not-used', '["API Response"]', ['API Response']],
-            'string response' => [5, [], '/issues/5.json', 'string', 'Error decoding body as JSON: Syntax error'],
-            'false response' => [5, [], '/issues/5.json', '', false],
+            'array response with integer id' => [
+                5,
+                [],
+                '/issues/5.json',
+                '["API Response"]',
+                ['API Response'],
+            ],
+            'array response with string id' => [
+                '5',
+                [],
+                '/issues/5.json',
+                '["API Response"]',
+                ['API Response'],
+            ],
+            'array response with parameters' => [
+                5,
+                ['include' => ['parameter1', 'parameter2'], 'not-used'],
+                '/issues/5.json?include=parameter1%2Cparameter2&0=not-used',
+                '["API Response"]',
+                ['API Response'],
+            ],
+            'string response' => [
+                5,
+                [],
+                '/issues/5.json',
+                'string',
+                /** @phpstan-ignore smaller.alwaysTrue(Remove this line after release of PHP 8.6) */
+                (PHP_VERSION_ID < 80600) ? 'Error decoding body as JSON: Syntax error' : 'Error decoding body as JSON: Syntax error near location 1:1',
+            ],
+            'false response' => [
+                5,
+                [],
+                '/issues/5.json',
+                '',
+                false,
+            ],
         ];
     }
 }

--- a/tests/Unit/Api/IssueCategory/ShowTest.php
+++ b/tests/Unit/Api/IssueCategory/ShowTest.php
@@ -40,10 +40,31 @@ class ShowTest extends TestCase
     public static function getShowData(): array
     {
         return [
-            'array response with integer id' => [5, '/issue_categories/5.json', '["API Response"]', ['API Response']],
-            'array response with string id' => ['5', '/issue_categories/5.json', '["API Response"]', ['API Response']],
-            'string response' => [5, '/issue_categories/5.json', 'string', 'Error decoding body as JSON: Syntax error'],
-            'false response' => [5, '/issue_categories/5.json', '', false],
+            'array response with integer id' => [
+                5,
+                '/issue_categories/5.json',
+                '["API Response"]',
+                ['API Response'],
+            ],
+            'array response with string id' => [
+                '5',
+                '/issue_categories/5.json',
+                '["API Response"]',
+                ['API Response'],
+            ],
+            'string response' => [
+                5,
+                '/issue_categories/5.json',
+                'string',
+                /** @phpstan-ignore smaller.alwaysTrue(Remove this line after release of PHP 8.6) */
+                (PHP_VERSION_ID < 80600) ? 'Error decoding body as JSON: Syntax error' : 'Error decoding body as JSON: Syntax error near location 1:1',
+            ],
+            'false response' => [
+                5,
+                '/issue_categories/5.json',
+                '',
+                false,
+            ],
         ];
     }
 }

--- a/tests/Unit/Api/IssueRelation/ShowTest.php
+++ b/tests/Unit/Api/IssueRelation/ShowTest.php
@@ -40,11 +40,36 @@ class ShowTest extends TestCase
     public static function getShowData(): array
     {
         return [
-            'array response with integer id' => [5, '/relations/5.json', '{"relation":{"child":[5,2,3]}}', ['child' => [5, 2, 3]]],
-            'array response with string id' => ['5', '/relations/5.json', '{"relation":{"child":[5,2,3]}}', ['child' => [5, 2, 3]]],
-            'array response on object without relation key error' => [5, '/relations/5.json', '{}', []],
-            'array response on string error' => [5, '/relations/5.json', 'string', []],
-            'array response on empty error' => [5, '/relations/5.json', '', []],
+            'array response with integer id' => [
+                5,
+                '/relations/5.json',
+                '{"relation":{"child":[5,2,3]}}',
+                ['child' => [5, 2, 3]],
+            ],
+            'array response with string id' => [
+                '5',
+                '/relations/5.json',
+                '{"relation":{"child":[5,2,3]}}',
+                ['child' => [5, 2, 3]],
+            ],
+            'array response on object without relation key error' => [
+                5,
+                '/relations/5.json',
+                '{}',
+                [],
+            ],
+            'array response on string error' => [
+                5,
+                '/relations/5.json',
+                'string',
+                [],
+            ],
+            'array response on empty error' => [
+                5,
+                '/relations/5.json',
+                '',
+                [],
+            ],
         ];
     }
 }

--- a/tests/Unit/Api/Project/ShowTest.php
+++ b/tests/Unit/Api/Project/ShowTest.php
@@ -88,7 +88,8 @@ class ShowTest extends TestCase
                 [],
                 '/projects/5.json?include=trackers%2Cissue_categories%2Cattachments%2Crelations',
                 'string',
-                'Error decoding body as JSON: Syntax error',
+                /** @phpstan-ignore smaller.alwaysTrue(Remove this line after release of PHP 8.6) */
+                (PHP_VERSION_ID < 80600) ? 'Error decoding body as JSON: Syntax error' : 'Error decoding body as JSON: Syntax error near location 1:1',
             ],
             'false response' => [
                 5,

--- a/tests/Unit/Api/Role/ShowTest.php
+++ b/tests/Unit/Api/Role/ShowTest.php
@@ -40,10 +40,31 @@ class ShowTest extends TestCase
     public static function getShowData(): array
     {
         return [
-            'array response with integer id' => [5, '/roles/5.json', '["API Response"]', ['API Response']],
-            'array response with string id' => ['5', '/roles/5.json', '["API Response"]', ['API Response']],
-            'string response' => [5, '/roles/5.json', 'string', 'Error decoding body as JSON: Syntax error'],
-            'false response' => [5, '/roles/5.json', '', false],
+            'array response with integer id' => [
+                5,
+                '/roles/5.json',
+                '["API Response"]',
+                ['API Response'],
+            ],
+            'array response with string id' => [
+                '5',
+                '/roles/5.json',
+                '["API Response"]',
+                ['API Response'],
+            ],
+            'string response' => [
+                5,
+                '/roles/5.json',
+                'string',
+                /** @phpstan-ignore smaller.alwaysTrue(Remove this line after release of PHP 8.6) */
+                (PHP_VERSION_ID < 80600) ? 'Error decoding body as JSON: Syntax error' : 'Error decoding body as JSON: Syntax error near location 1:1',
+            ],
+            'false response' => [
+                5,
+                '/roles/5.json',
+                '',
+                false,
+            ],
         ];
     }
 }

--- a/tests/Unit/Api/TimeEntry/ShowTest.php
+++ b/tests/Unit/Api/TimeEntry/ShowTest.php
@@ -40,10 +40,31 @@ class ShowTest extends TestCase
     public static function getShowData(): array
     {
         return [
-            'array response with integer id' => [5, '/time_entries/5.json', '["API Response"]', ['API Response']],
-            'array response with string id' => ['5', '/time_entries/5.json', '["API Response"]', ['API Response']],
-            'string response' => [5, '/time_entries/5.json', 'string', 'Error decoding body as JSON: Syntax error'],
-            'false response' => [5, '/time_entries/5.json', '', false],
+            'array response with integer id' => [
+                5,
+                '/time_entries/5.json',
+                '["API Response"]',
+                ['API Response'],
+            ],
+            'array response with string id' => [
+                '5',
+                '/time_entries/5.json',
+                '["API Response"]',
+                ['API Response'],
+            ],
+            'string response' => [
+                5,
+                '/time_entries/5.json',
+                'string',
+                /** @phpstan-ignore smaller.alwaysTrue(Remove this line after release of PHP 8.6) */
+                (PHP_VERSION_ID < 80600) ? 'Error decoding body as JSON: Syntax error' : 'Error decoding body as JSON: Syntax error near location 1:1',
+            ],
+            'false response' => [
+                5,
+                '/time_entries/5.json',
+                '',
+                false,
+            ],
         ];
     }
 }

--- a/tests/Unit/Api/User/ShowTest.php
+++ b/tests/Unit/Api/User/ShowTest.php
@@ -40,11 +40,44 @@ class ShowTest extends TestCase
     public static function getShowData(): array
     {
         return [
-            'array response with integer id' => [5, [], '/users/5.json?include=memberships%2Cgroups', '["API Response"]', ['API Response']],
-            'array response with string id' => ['5', [], '/users/5.json?include=memberships%2Cgroups', '["API Response"]', ['API Response']],
-            'array response with parameters' => [5, ['parameter1', 'parameter2', 'memberships'], '/users/5.json?0=parameter1&1=parameter2&2=memberships&include=memberships%2Cgroups', '["API Response"]', ['API Response']],
-            'string response' => [5, [], '/users/5.json?include=memberships%2Cgroups', 'string', 'Error decoding body as JSON: Syntax error'],
-            'false response' => [5, [], '/users/5.json?include=memberships%2Cgroups', '', false],
+            'array response with integer id' => [
+                5,
+                [],
+                '/users/5.json?include=memberships%2Cgroups',
+                '["API Response"]',
+                ['API Response'],
+            ],
+            'array response with string id' => [
+                '5',
+                [],
+                '/users/5.json?include=memberships%2Cgroups',
+                '["API Response"]',
+                ['API Response'],
+            ],
+            'array response with parameters' => [
+                5,
+                ['parameter1',
+                'parameter2',
+                'memberships'],
+                '/users/5.json?0=parameter1&1=parameter2&2=memberships&include=memberships%2Cgroups',
+                '["API Response"]',
+                ['API Response'],
+            ],
+            'string response' => [
+                5,
+                [],
+                '/users/5.json?include=memberships%2Cgroups',
+                'string',
+                /** @phpstan-ignore smaller.alwaysTrue(Remove this line after release of PHP 8.6) */
+                (PHP_VERSION_ID < 80600) ? 'Error decoding body as JSON: Syntax error' : 'Error decoding body as JSON: Syntax error near location 1:1',
+            ],
+            'false response' => [
+                5,
+                [],
+                '/users/5.json?include=memberships%2Cgroups',
+                '',
+                false,
+            ],
         ];
     }
 }

--- a/tests/Unit/Api/User/ShowTest.php
+++ b/tests/Unit/Api/User/ShowTest.php
@@ -56,9 +56,7 @@ class ShowTest extends TestCase
             ],
             'array response with parameters' => [
                 5,
-                ['parameter1',
-                'parameter2',
-                'memberships'],
+                ['parameter1', 'parameter2', 'memberships'],
                 '/users/5.json?0=parameter1&1=parameter2&2=memberships&include=memberships%2Cgroups',
                 '["API Response"]',
                 ['API Response'],

--- a/tests/Unit/Api/Version/ShowTest.php
+++ b/tests/Unit/Api/Version/ShowTest.php
@@ -40,10 +40,31 @@ class ShowTest extends TestCase
     public static function getShowData(): array
     {
         return [
-            'array response with integer id' => [5, '/versions/5.json', '["API Response"]', ['API Response']],
-            'array response with string id' => ['5', '/versions/5.json', '["API Response"]', ['API Response']],
-            'string response' => [5, '/versions/5.json', 'string', 'Error decoding body as JSON: Syntax error'],
-            'false response' => [5, '/versions/5.json', '', false],
+            'array response with integer id' => [
+                5,
+                '/versions/5.json',
+                '["API Response"]',
+                ['API Response'],
+            ],
+            'array response with string id' => [
+                '5',
+                '/versions/5.json',
+                '["API Response"]',
+                ['API Response'],
+            ],
+            'string response' => [
+                5,
+                '/versions/5.json',
+                'string',
+                /** @phpstan-ignore smaller.alwaysTrue(Remove this line after release of PHP 8.6) */
+                (PHP_VERSION_ID < 80600) ? 'Error decoding body as JSON: Syntax error' : 'Error decoding body as JSON: Syntax error near location 1:1',
+            ],
+            'false response' => [
+                5,
+                '/versions/5.json',
+                '',
+                false,
+            ],
         ];
     }
 }

--- a/tests/Unit/Api/Wiki/ShowTest.php
+++ b/tests/Unit/Api/Wiki/ShowTest.php
@@ -40,12 +40,55 @@ class ShowTest extends TestCase
     public static function getShowData(): array
     {
         return [
-            'array response with integer identifier' => [5, 'page', null, '/projects/5/wiki/page.json?include=attachments', '["API Response"]', ['API Response']],
-            'array response with string identifier' => ['project', 'page', null, '/projects/project/wiki/page.json?include=attachments', '["API Response"]', ['API Response']],
-            'array response with integer identifier and version' => [5, 'page', 22, '/projects/5/wiki/page/22.json?include=attachments', '["API Response"]', ['API Response']],
-            'array response with string identifier and version' => ['project', 'page', 22, '/projects/project/wiki/page/22.json?include=attachments', '["API Response"]', ['API Response']],
-            'string response' => [5, 'page', null, '/projects/5/wiki/page.json?include=attachments', 'string', 'Error decoding body as JSON: Syntax error'],
-            'false response' => [5, 'page', null, '/projects/5/wiki/page.json?include=attachments', '', false],
+            'array response with integer identifier' => [
+                5,
+                'page',
+                null,
+                '/projects/5/wiki/page.json?include=attachments',
+                '["API Response"]',
+                ['API Response'],
+            ],
+            'array response with string identifier' => [
+                'project',
+                'page',
+                null,
+                '/projects/project/wiki/page.json?include=attachments',
+                '["API Response"]',
+                ['API Response'],
+            ],
+            'array response with integer identifier and version' => [
+                5,
+                'page',
+                22,
+                '/projects/5/wiki/page/22.json?include=attachments',
+                '["API Response"]',
+                ['API Response'],
+            ],
+            'array response with string identifier and version' => [
+                'project',
+                'page',
+                22,
+                '/projects/project/wiki/page/22.json?include=attachments',
+                '["API Response"]',
+                ['API Response'],
+            ],
+            'string response' => [
+                5,
+                'page',
+                null,
+                '/projects/5/wiki/page.json?include=attachments',
+                'string',
+                /** @phpstan-ignore smaller.alwaysTrue(Remove this line after release of PHP 8.6) */
+                (PHP_VERSION_ID < 80600) ? 'Error decoding body as JSON: Syntax error' : 'Error decoding body as JSON: Syntax error near location 1:1',
+            ],
+            'false response' => [
+                5,
+                'page',
+                null,
+                '/projects/5/wiki/page.json?include=attachments',
+                '',
+                false,
+            ],
         ];
     }
 }

--- a/tests/Unit/Serializer/JsonSerializerTest.php
+++ b/tests/Unit/Serializer/JsonSerializerTest.php
@@ -74,12 +74,13 @@ class JsonSerializerTest extends TestCase
     {
         return [
             [
-                'Catched error "Syntax error" while decoding JSON: ',
                 '',
+                'Catched error "Syntax error" while decoding JSON: ',
             ],
             [
-                'Catched error "Syntax error" while decoding JSON: ["foo":"bar"]',
                 '["foo":"bar"]',
+                /** @phpstan-ignore smaller.alwaysTrue(Remove this line after release of PHP 8.6) */
+                (PHP_VERSION_ID < 80600) ? 'Catched error "Syntax error" while decoding JSON: ["foo":"bar"]' : 'Catched error "Syntax error near location 1:7" while decoding JSON: ["foo":"bar"]',
             ],
         ];
     }
@@ -88,7 +89,7 @@ class JsonSerializerTest extends TestCase
      * @dataProvider getInvalidEncodedData
      */
     #[DataProvider('getInvalidEncodedData')]
-    public function testCreateFromStringWithInvalidStringThrowsException(string $message, string $data): void
+    public function testCreateFromStringWithInvalidStringThrowsException(string $data, string $message): void
     {
         $this->expectException(SerializerException::class);
         $this->expectExceptionMessage($message);

--- a/tests/Unit/Serializer/XmlSerializerTest.php
+++ b/tests/Unit/Serializer/XmlSerializerTest.php
@@ -77,36 +77,54 @@ class XmlSerializerTest extends TestCase
      * @dataProvider getInvalidEncodedData
      */
     #[DataProvider('getInvalidEncodedData')]
-    public function testCreateFromStringWithInvalidStringThrowsException(string $message, string $data): void
+    public function testCreateFromStringWithInvalidStringThrowsException(string $data, int $expectedCode, array $expectedMessages): void
     {
-        $this->expectException(SerializerException::class);
-        $this->expectExceptionMessage($message);
-
-        XmlSerializer::createFromString($data);
+        try {
+            XmlSerializer::createFromString($data);
+        } catch (SerializerException $th) {
+            $this->assertSame($expectedCode, $th->getCode());
+            $this->assertContains($th->getMessage(), $expectedMessages);
+        }
     }
 
     public static function getInvalidEncodedData(): array
     {
         return [
             'empty string' => [
-                'Catched errors: "" while decoding XML: ',
                 '',
+                \LIBXML_ERR_NONE,
+                [
+                    'Catched errors: "" while decoding XML: ',
+                ],
             ],
             'wrong start tag' => [
-                'Catched errors: "Start tag expected, \'<\' not found' . "\n" . '" while decoding XML: <?xml version="1.0" encoding="UTF-8"?>',
                 '<?xml version="1.0" encoding="UTF-8"?>',
+                \LIBXML_ERR_FATAL,
+                [
+                    'Catched errors: "Start tag expected, \'<\' not found' . "\n" . '" while decoding XML: <?xml version="1.0" encoding="UTF-8"?>',
+                ],
             ],
             'invalid element name as start tag' => [
-                'Catched errors: "StartTag: invalid element name' . "\n" . '", "Extra content at the end of the document' . "\n" . '" while decoding XML: <?xml version="1.0" encoding="UTF-8"?><>',
                 '<?xml version="1.0" encoding="UTF-8"?><>',
+                \LIBXML_ERR_FATAL,
+                [
+                    'Catched errors: "StartTag: invalid element name' . "\n" . '", "Extra content at the end of the document' . "\n" . '" while decoding XML: <?xml version="1.0" encoding="UTF-8"?><>',
+                ],
             ],
             'Premature end of data' => [
-                'Catched errors: "Premature end of data in tag a line 1' . "\n" . '" while decoding XML: <?xml version="1.0" encoding="UTF-8"?><a>',
                 '<?xml version="1.0" encoding="UTF-8"?><a>',
+                \LIBXML_ERR_FATAL,
+                [
+                    'Catched errors: "Premature end of data in tag a line 1' . "\n" . '" while decoding XML: <?xml version="1.0" encoding="UTF-8"?><a>',
+                    'Catched errors: "EndTag: \'</\' not found' . "\n" . '" while decoding XML: <?xml version="1.0" encoding="UTF-8"?><a>',
+                ],
             ],
             'invalid element name as start tag 2' => [
-                'Catched errors: "StartTag: invalid element name' . "\n" . '", "Extra content at the end of the document' . "\n" . '" while decoding XML: <?xml version="1.0" encoding="UTF-8"?></>',
                 '<?xml version="1.0" encoding="UTF-8"?></>',
+                \LIBXML_ERR_FATAL,
+                [
+                    'Catched errors: "StartTag: invalid element name' . "\n" . '", "Extra content at the end of the document' . "\n" . '" while decoding XML: <?xml version="1.0" encoding="UTF-8"?></>',
+                ],
             ],
         ];
     }


### PR DESCRIPTION
PHP 8.6 will start to output more error details on decoding JSON. e.g. `Syntax error` will become `Syntax error near location 1:12`, so the tests for PHP 8.6 fails at the moment.

This PR will fix this.

See https://php.watch/versions/8.6/json_decode-error-position