### PR TITLE
Run tests with Redmine 6.1.1, 6.0.8 and 5.1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Behaviour-driven tests are run against Redmine 6.1.0, 6.0.7, 5.1.10.
+- Behaviour-driven tests are run against Redmine 6.1.1, 6.0.8, 5.1.11.
 
 ### Deprecated
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
             - ./:/var/www/project/ # Location of the project for php-fpm. Note this should be the same for NGINX.*
 
     redmine-dev:
-        image: redmine:6.1.0
+        image: redmine:6.1.1
         user: "33:33"
         ports:
             - "3000:3000"
@@ -31,7 +31,7 @@ services:
     # - /tests/Behat/behat.yml
 
     redmine-6-1:
-        image: redmine:6.1.0
+        image: redmine:6.1.1
         user: "33:33"
         ports:
             - "5061:3000"
@@ -41,11 +41,11 @@ services:
             # REDMINE_SECRET_KEY_BASE: supersecretkey
             REDMINE_PLUGINS_MIGRATE: true
         volumes:
-            - ./.docker/redmine-60100_data/files:/usr/src/redmine/files
-            - ./.docker/redmine-60100_data/sqlite:/usr/src/redmine/sqlite
+            - ./.docker/redmine-60101_data/files:/usr/src/redmine/files
+            - ./.docker/redmine-60101_data/sqlite:/usr/src/redmine/sqlite
 
     redmine-6-0:
-        image: redmine:6.0.7
+        image: redmine:6.0.8
         user: "33:33"
         ports:
             - "5060:3000"
@@ -55,11 +55,11 @@ services:
             # REDMINE_SECRET_KEY_BASE: supersecretkey
             REDMINE_PLUGINS_MIGRATE: true
         volumes:
-            - ./.docker/redmine-60007_data/files:/usr/src/redmine/files
-            - ./.docker/redmine-60007_data/sqlite:/usr/src/redmine/sqlite
+            - ./.docker/redmine-60008_data/files:/usr/src/redmine/files
+            - ./.docker/redmine-60008_data/sqlite:/usr/src/redmine/sqlite
 
     redmine-5-1:
-        image: redmine:5.1.10
+        image: redmine:5.1.11
         user: "33:33"
         ports:
             - "5051:3000"
@@ -67,5 +67,5 @@ services:
             REDMINE_SECRET_KEY_BASE: supersecretkey
             REDMINE_PLUGINS_MIGRATE: true
         volumes:
-            - ./.docker/redmine-50110_data/files:/usr/src/redmine/files
-            - ./.docker/redmine-50110_data/sqlite:/usr/src/redmine/sqlite
+            - ./.docker/redmine-50111_data/files:/usr/src/redmine/files
+            - ./.docker/redmine-50111_data/sqlite:/usr/src/redmine/sqlite

--- a/tests/Behat/behat.yml
+++ b/tests/Behat/behat.yml
@@ -6,17 +6,17 @@ default:
         redmine_6_1:
             contexts:
                 - Redmine\Tests\Behat\Bootstrap\FeatureContext:
-                    redmineVersion: '6.1.0'
+                    redmineVersion: '6.1.1'
                     rootPath: '%paths.base%/../../.docker'
         redmine_6_0:
             contexts:
                 - Redmine\Tests\Behat\Bootstrap\FeatureContext:
-                    redmineVersion: '6.0.7'
+                    redmineVersion: '6.0.8'
                     rootPath: '%paths.base%/../../.docker'
         redmine_5_1:
             contexts:
                 - Redmine\Tests\Behat\Bootstrap\FeatureContext:
-                    redmineVersion: '5.1.10'
+                    redmineVersion: '5.1.11'
                     rootPath: '%paths.base%/../../.docker'
 
 github-actions:
@@ -24,15 +24,15 @@ github-actions:
         redmine_6_1:
             contexts:
                 - Redmine\Tests\Behat\Bootstrap\FeatureContext:
-                    redmineVersion: '6.1.0'
+                    redmineVersion: '6.1.1'
                     rootPath: '/home/runner/work/_temp'
         redmine_6_0:
             contexts:
                 - Redmine\Tests\Behat\Bootstrap\FeatureContext:
-                    redmineVersion: '6.0.7'
+                    redmineVersion: '6.0.8'
                     rootPath: '/home/runner/work/_temp'
         redmine_5_1:
             contexts:
                 - Redmine\Tests\Behat\Bootstrap\FeatureContext:
-                    redmineVersion: '5.1.10'
+                    redmineVersion: '5.1.11'
                     rootPath: '/home/runner/work/_temp'

--- a/tests/RedmineExtension/RedmineVersion.php
+++ b/tests/RedmineExtension/RedmineVersion.php
@@ -12,12 +12,28 @@ namespace Redmine\Tests\RedmineExtension;
 final class RedmineVersion
 {
     /**
+     * Redmine 6.1.1
+     *
+     * @link https://www.redmine.org/versions/218
+     * @link https://www.redmine.org/projects/redmine/wiki/Changelog_6_1#611-2026-01-05
+     */
+    public const V6_1_1 = '6.1.1';
+
+    /**
      * Redmine 6.1.0
      *
      * @link https://www.redmine.org/versions/198
      * @link https://www.redmine.org/projects/redmine/wiki/Changelog_6_1#610-2025-09-21
      */
     public const V6_1_0 = '6.1.0';
+
+    /**
+     * Redmine 6.0.8
+     *
+     * @link https://www.redmine.org/versions/217
+     * @link https://www.redmine.org/projects/redmine/wiki/Changelog_6_0#608-2026-01-05
+     */
+    public const V6_0_8 = '6.0.8';
 
     /**
      * Redmine 6.0.7
@@ -82,6 +98,14 @@ final class RedmineVersion
      * @link https://www.redmine.org/projects/redmine/wiki/Changelog_6_0#600-2024-11-10
      */
     public const V6_0_0 = '6.0.0';
+
+    /**
+     * Redmine 5.1.11
+     *
+     * @link https://www.redmine.org/versions/219
+     * @link https://www.redmine.org/projects/redmine/wiki/Changelog_5_1#5111-2026-01-05
+     */
+    public const V5_1_11 = '5.1.11';
 
     /**
      * Redmine 5.1.10


### PR DESCRIPTION
Fixes #459

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version references for Redmine compatibility from 6.1.0/6.0.7/5.1.10 to 6.1.1/6.0.8/5.1.11 across configuration and test settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->