### PR TITLE
Release v2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Nothing yet.
 
-## [v2.9.0](https://github.com/kbsali/php-redmine-api/compare/v2.8.0...v2.9.0) - 2026-03-07
+## [v2.9.0](https://github.com/kbsali/php-redmine-api/compare/v2.8.0...v2.9.0) - 2026-03-08
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/kbsali/php-redmine-api/compare/v2.8.0...v2.x)
+## [Unreleased](https://github.com/kbsali/php-redmine-api/compare/v2.9.0...v2.x)
+
+Nothing yet.
+
+## [v2.9.0](https://github.com/kbsali/php-redmine-api/compare/v2.8.0...v2.9.0) - 2026-03-07
 
 ### Added
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "kbsali/redmine-api",
-    "version": "v2.8.0",
+    "version": "v2.9.0",
     "type": "library",
     "description": "Redmine API client",
     "homepage": "https://github.com/kbsali/php-redmine-api",


### PR DESCRIPTION
After merge of #461 and this PR we can tag and release `v2.9.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Version bumped to v2.9.0.
  * Changelog updated to reflect the new version release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->