### PR TITLE
Check response status codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add support for Redmine 7.0.
+- `\Redmine\Client\NativeCurlClient::enableFutureMode()` to opt-in to throwing `UnexpectedResponseException` on unexpected status codes.
+- `\Redmine\Client\Psr18Client::enableFutureMode()` to opt-in to throwing `UnexpectedResponseException` on unexpected status codes.
+- API methods that create, update, or delete resources now verify the HTTP response status code. The return value only changes if `enableFutureMode()` was called – unexpected status codes then throw `UnexpectedResponseException` instead of returning the response body.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -69,8 +69,6 @@ you are welcome to [create an issue](https://github.com/kbsali/php-redmine-api/i
 ## Todo
 
 * Tracking of Redmine API feature support in [#305](https://github.com/kbsali/php-redmine-api/issues/305)
-* Check header's response code (especially for POST/PUT/DELETE requests)
-    * See https://stackoverflow.com/questions/9183178/php-curl-retrieving-response-headers-and-body-in-a-single-request/9183272#9183272
 
 ## Limitations / Missing Redmine-API
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -215,6 +215,34 @@ try {
 }
 ```
 
+### Forward compatibility mode
+
+By default, API methods that create, update, or delete resources return the raw response body even if the HTTP status code indicates an error. This preserves backwards compatibility with existing code.
+
+You can opt-in to stricter behavior by enabling the forward compatibility mode on the client:
+
+```php
+$client->enableFutureMode();
+```
+
+After calling `enableFutureMode()`, any unexpected status code (e.g. a 422 validation error) throws `\Redmine\Exception\UnexpectedResponseException` instead of returning the response body. This allows you to catch and handle errors more reliably.
+
+```php
+$client->enableFutureMode();
+
+try {
+    $client->getApi('issue')->create([
+        'project_id' => 1,
+        'subject' => 'test',
+    ]);
+} catch (\Redmine\Exception\UnexpectedResponseException $e) {
+    // Handle unexpected response (wrong status code)
+    $response = $e->getResponse();
+    $statusCode = $response->getStatusCode();
+    $body = $response->getContent();
+}
+```
+
 ## API
 
 ### Mid-level API

--- a/src/Redmine/Api/Attachment.php
+++ b/src/Redmine/Api/Attachment.php
@@ -186,6 +186,17 @@ class Attachment extends AbstractApi
             '/attachments/' . urlencode(strval($id)) . '.xml',
         ));
 
-        return $this->lastResponse->getContent();
+        $body = $this->lastResponse->getContent();
+        $statusCode = $this->lastResponse->getStatusCode();
+
+        if ($statusCode !== 200 && $statusCode !== 204) {
+            if (!Future::isForwardCompatibilityEnabled()) {
+                return $body;
+            }
+
+            throw UnexpectedResponseException::create($this->lastResponse);
+        }
+
+        return $body;
     }
 }

--- a/src/Redmine/Api/Attachment.php
+++ b/src/Redmine/Api/Attachment.php
@@ -7,6 +7,7 @@ namespace Redmine\Api;
 use Redmine\Client\Client;
 use Redmine\Exception\SerializerException;
 use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Http\HttpClient;
 use Redmine\Http\HttpFactory;
 use Redmine\Serializer\JsonSerializer;
@@ -156,7 +157,17 @@ class Attachment extends AbstractApi
             $attachment,
         ));
 
-        return $this->lastResponse->getContent();
+        $body = $this->lastResponse->getContent();
+
+        if ($this->lastResponse->getStatusCode() !== 201) {
+            if (!Future::isForwardCompatibilityEnabled()) {
+                return $body;
+            }
+
+            throw UnexpectedResponseException::create($this->lastResponse);
+        }
+
+        return $body;
     }
 
     /**

--- a/src/Redmine/Api/Group.php
+++ b/src/Redmine/Api/Group.php
@@ -334,6 +334,15 @@ class Group extends AbstractApi
         ));
 
         $body = $this->lastResponse->getContent();
+        $statusCode = $this->lastResponse->getStatusCode();
+
+        if ($statusCode !== 201) {
+            if (!Future::isForwardCompatibilityEnabled()) {
+                return $body;
+            }
+
+            throw UnexpectedResponseException::create($this->lastResponse);
+        }
 
         if ($body === '') {
             return $body;

--- a/src/Redmine/Api/Group.php
+++ b/src/Redmine/Api/Group.php
@@ -200,7 +200,11 @@ class Group extends AbstractApi
 
         if ($statusCode !== 201) {
             if (!Future::isForwardCompatibilityEnabled()) {
-                return $body;
+                if ($body === '') {
+                    return $body;
+                }
+
+                return new SimpleXMLElement($body);
             }
 
             throw UnexpectedResponseException::create($this->lastResponse);
@@ -338,7 +342,11 @@ class Group extends AbstractApi
 
         if ($statusCode !== 201) {
             if (!Future::isForwardCompatibilityEnabled()) {
-                return $body;
+                if ($body === '') {
+                    return $body;
+                }
+
+                return new SimpleXMLElement($body);
             }
 
             throw UnexpectedResponseException::create($this->lastResponse);

--- a/src/Redmine/Api/Group.php
+++ b/src/Redmine/Api/Group.php
@@ -368,6 +368,17 @@ class Group extends AbstractApi
             '/groups/' . strval($id) . '/users/' . strval($userId) . '.xml',
         ));
 
-        return $this->lastResponse->getContent();
+        $body = $this->lastResponse->getContent();
+        $statusCode = $this->lastResponse->getStatusCode();
+
+        if ($statusCode !== 200 && $statusCode !== 204) {
+            if (!Future::isForwardCompatibilityEnabled()) {
+                return $body;
+            }
+
+            throw UnexpectedResponseException::create($this->lastResponse);
+        }
+
+        return $body;
     }
 }

--- a/src/Redmine/Api/Group.php
+++ b/src/Redmine/Api/Group.php
@@ -239,7 +239,18 @@ class Group extends AbstractApi
             XmlSerializer::createFromArray(['group' => $params])->getEncoded(),
         ));
 
-        return $this->lastResponse->getContent();
+        $body = $this->lastResponse->getContent();
+        $statusCode = $this->lastResponse->getStatusCode();
+
+        if ($statusCode !== 200 && $statusCode !== 204) {
+            if (!Future::isForwardCompatibilityEnabled()) {
+                return $body;
+            }
+
+            throw UnexpectedResponseException::create($this->lastResponse);
+        }
+
+        return $body;
     }
 
     /**

--- a/src/Redmine/Api/Group.php
+++ b/src/Redmine/Api/Group.php
@@ -301,7 +301,18 @@ class Group extends AbstractApi
             '/groups/' . strval($id) . '.xml',
         ));
 
-        return $this->lastResponse->getContent();
+        $body = $this->lastResponse->getContent();
+        $statusCode = $this->lastResponse->getStatusCode();
+
+        if ($statusCode !== 200 && $statusCode !== 204) {
+            if (!Future::isForwardCompatibilityEnabled()) {
+                return $body;
+            }
+
+            throw UnexpectedResponseException::create($this->lastResponse);
+        }
+
+        return $body;
     }
 
     /**

--- a/src/Redmine/Api/Group.php
+++ b/src/Redmine/Api/Group.php
@@ -9,6 +9,7 @@ use Redmine\Exception;
 use Redmine\Exception\MissingParameterException;
 use Redmine\Exception\SerializerException;
 use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Http\HttpClient;
 use Redmine\Http\HttpFactory;
 use Redmine\Serializer\JsonSerializer;
@@ -195,6 +196,15 @@ class Group extends AbstractApi
         ));
 
         $body = $this->lastResponse->getContent();
+        $statusCode = $this->lastResponse->getStatusCode();
+
+        if ($statusCode !== 201) {
+            if (!Future::isForwardCompatibilityEnabled()) {
+                return $body;
+            }
+
+            throw UnexpectedResponseException::create($this->lastResponse);
+        }
 
         if ($body === '') {
             return $body;

--- a/src/Redmine/Api/Issue.php
+++ b/src/Redmine/Api/Issue.php
@@ -370,7 +370,18 @@ class Issue extends AbstractApi
             '/issues/' . urlencode(strval($id)) . '/watchers/' . urlencode(strval($watcherUserId)) . '.xml',
         ));
 
-        return $this->lastResponse->getContent();
+        $body = $this->lastResponse->getContent();
+        $statusCode = $this->lastResponse->getStatusCode();
+
+        if ($statusCode !== 200 && $statusCode !== 204) {
+            if (!Future::isForwardCompatibilityEnabled()) {
+                return $body;
+            }
+
+            throw UnexpectedResponseException::create($this->lastResponse);
+        }
+
+        return $body;
     }
 
     /**

--- a/src/Redmine/Api/Issue.php
+++ b/src/Redmine/Api/Issue.php
@@ -10,6 +10,7 @@ use Redmine\Client\Psr18Client;
 use Redmine\Exception;
 use Redmine\Exception\SerializerException;
 use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Http\HttpClient;
 use Redmine\Http\HttpFactory;
 use Redmine\Serializer\JsonSerializer;
@@ -256,8 +257,12 @@ class Issue extends AbstractApi
 
         $body = $this->lastResponse->getContent();
 
-        if ($body === '') {
-            return $body;
+        if ($this->lastResponse->getStatusCode() !== 201) {
+            if (!Future::isForwardCompatibilityEnabled() && $body === '') {
+                return $body;
+            }
+
+            throw UnexpectedResponseException::create($this->lastResponse);
         }
 
         return new SimpleXMLElement($body);

--- a/src/Redmine/Api/Issue.php
+++ b/src/Redmine/Api/Issue.php
@@ -340,6 +340,15 @@ class Issue extends AbstractApi
         ));
 
         $body = $this->lastResponse->getContent();
+        $statusCode = $this->lastResponse->getStatusCode();
+
+        if ($statusCode !== 201) {
+            if (!Future::isForwardCompatibilityEnabled()) {
+                return $body;
+            }
+
+            throw UnexpectedResponseException::create($this->lastResponse);
+        }
 
         if ($body === '') {
             return $body;

--- a/src/Redmine/Api/Issue.php
+++ b/src/Redmine/Api/Issue.php
@@ -311,7 +311,18 @@ class Issue extends AbstractApi
             XmlSerializer::createFromArray(['issue' => $sanitizedParams])->getEncoded(),
         ));
 
-        return $this->lastResponse->getContent();
+        $body = $this->lastResponse->getContent();
+        $statusCode = $this->lastResponse->getStatusCode();
+
+        if ($statusCode !== 200 && $statusCode !== 204) {
+            if (!Future::isForwardCompatibilityEnabled()) {
+                return $body;
+            }
+
+            throw UnexpectedResponseException::create($this->lastResponse);
+        }
+
+        return $body;
     }
 
     /**

--- a/src/Redmine/Api/Issue.php
+++ b/src/Redmine/Api/Issue.php
@@ -531,7 +531,18 @@ class Issue extends AbstractApi
             '/issues/' . urlencode(strval($id)) . '.xml',
         ));
 
-        return $this->lastResponse->getContent();
+        $body = $this->lastResponse->getContent();
+        $statusCode = $this->lastResponse->getStatusCode();
+
+        if ($statusCode !== 200 && $statusCode !== 204) {
+            if (!Future::isForwardCompatibilityEnabled()) {
+                return $body;
+            }
+
+            throw UnexpectedResponseException::create($this->lastResponse);
+        }
+
+        return $body;
     }
 
     /**

--- a/src/Redmine/Api/Issue.php
+++ b/src/Redmine/Api/Issue.php
@@ -258,8 +258,12 @@ class Issue extends AbstractApi
         $body = $this->lastResponse->getContent();
 
         if ($this->lastResponse->getStatusCode() !== 201) {
-            if (!Future::isForwardCompatibilityEnabled() && $body === '') {
-                return $body;
+            if (!Future::isForwardCompatibilityEnabled()) {
+                if ($body === '') {
+                    return $body;
+                }
+
+                return new SimpleXMLElement($body);
             }
 
             throw UnexpectedResponseException::create($this->lastResponse);

--- a/src/Redmine/Api/Issue.php
+++ b/src/Redmine/Api/Issue.php
@@ -534,7 +534,18 @@ class Issue extends AbstractApi
             JsonSerializer::createFromArray(['issue' => $params])->getEncoded(),
         ));
 
-        return $this->lastResponse->getContent();
+        $body = $this->lastResponse->getContent();
+        $statusCode = $this->lastResponse->getStatusCode();
+
+        if ($statusCode !== 200 && $statusCode !== 201 && $statusCode !== 204) {
+            if (!Future::isForwardCompatibilityEnabled()) {
+                return $body;
+            }
+
+            throw UnexpectedResponseException::create($this->lastResponse);
+        }
+
+        return $body;
     }
 
     /**

--- a/src/Redmine/Api/Issue.php
+++ b/src/Redmine/Api/Issue.php
@@ -348,7 +348,11 @@ class Issue extends AbstractApi
 
         if ($statusCode !== 201) {
             if (!Future::isForwardCompatibilityEnabled()) {
-                return $body;
+                if ($body === '') {
+                    return $body;
+                }
+
+                return new SimpleXMLElement($body);
             }
 
             throw UnexpectedResponseException::create($this->lastResponse);

--- a/src/Redmine/Api/IssueCategory.php
+++ b/src/Redmine/Api/IssueCategory.php
@@ -10,6 +10,7 @@ use Redmine\Exception\InvalidParameterException;
 use Redmine\Exception\MissingParameterException;
 use Redmine\Exception\SerializerException;
 use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Http\HttpClient;
 use Redmine\Http\HttpFactory;
 use Redmine\Serializer\JsonSerializer;
@@ -266,6 +267,14 @@ class IssueCategory extends AbstractApi
         ));
 
         $body = $this->lastResponse->getContent();
+
+        if ($this->lastResponse->getStatusCode() !== 201) {
+            if (!Future::isForwardCompatibilityEnabled() && $body === '') {
+                return $body;
+            }
+
+            throw UnexpectedResponseException::create($this->lastResponse);
+        }
 
         if ($body === '') {
             return $body;

--- a/src/Redmine/Api/IssueCategory.php
+++ b/src/Redmine/Api/IssueCategory.php
@@ -340,7 +340,18 @@ class IssueCategory extends AbstractApi
             PathSerializer::create('/issue_categories/' . urlencode(strval($id)) . '.xml', $params)->getPath(),
         ));
 
-        return $this->lastResponse->getContent();
+        $body = $this->lastResponse->getContent();
+        $statusCode = $this->lastResponse->getStatusCode();
+
+        if ($statusCode !== 200 && $statusCode !== 204) {
+            if (!Future::isForwardCompatibilityEnabled()) {
+                return $body;
+            }
+
+            throw UnexpectedResponseException::create($this->lastResponse);
+        }
+
+        return $body;
     }
 
     /**

--- a/src/Redmine/Api/IssueCategory.php
+++ b/src/Redmine/Api/IssueCategory.php
@@ -269,8 +269,12 @@ class IssueCategory extends AbstractApi
         $body = $this->lastResponse->getContent();
 
         if ($this->lastResponse->getStatusCode() !== 201) {
-            if (!Future::isForwardCompatibilityEnabled() && $body === '') {
-                return $body;
+            if (!Future::isForwardCompatibilityEnabled()) {
+                if ($body === '') {
+                    return $body;
+                }
+
+                return new SimpleXMLElement($body);
             }
 
             throw UnexpectedResponseException::create($this->lastResponse);

--- a/src/Redmine/Api/IssueCategory.php
+++ b/src/Redmine/Api/IssueCategory.php
@@ -307,7 +307,18 @@ class IssueCategory extends AbstractApi
             XmlSerializer::createFromArray(['issue_category' => $params])->getEncoded(),
         ));
 
-        return $this->lastResponse->getContent();
+        $body = $this->lastResponse->getContent();
+        $statusCode = $this->lastResponse->getStatusCode();
+
+        if ($statusCode !== 200 && $statusCode !== 204) {
+            if (!Future::isForwardCompatibilityEnabled()) {
+                return $body;
+            }
+
+            throw UnexpectedResponseException::create($this->lastResponse);
+        }
+
+        return $body;
     }
 
     /**

--- a/src/Redmine/Api/IssueRelation.php
+++ b/src/Redmine/Api/IssueRelation.php
@@ -160,7 +160,18 @@ class IssueRelation extends AbstractApi
             '/relations/' . $id . '.xml',
         ));
 
-        return $this->lastResponse->getContent();
+        $body = $this->lastResponse->getContent();
+        $statusCode = $this->lastResponse->getStatusCode();
+
+        if ($statusCode !== 200 && $statusCode !== 204) {
+            if (!Future::isForwardCompatibilityEnabled()) {
+                return $body;
+            }
+
+            throw UnexpectedResponseException::create($this->lastResponse);
+        }
+
+        return $body;
     }
 
     /**

--- a/src/Redmine/Api/IssueRelation.php
+++ b/src/Redmine/Api/IssueRelation.php
@@ -9,6 +9,7 @@ use Redmine\Exception;
 use Redmine\Exception\MissingParameterException;
 use Redmine\Exception\SerializerException;
 use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Http\HttpClient;
 use Redmine\Http\HttpFactory;
 use Redmine\Serializer\JsonSerializer;
@@ -200,6 +201,15 @@ class IssueRelation extends AbstractApi
         ));
 
         $body = $this->lastResponse->getContent();
+        $statusCode = $this->lastResponse->getStatusCode();
+
+        if ($statusCode !== 201) {
+            if (!Future::isForwardCompatibilityEnabled()) {
+                return JsonSerializer::createFromString($body)->getNormalized();
+            }
+
+            throw UnexpectedResponseException::create($this->lastResponse);
+        }
 
         return JsonSerializer::createFromString($body)->getNormalized();
     }

--- a/src/Redmine/Api/Membership.php
+++ b/src/Redmine/Api/Membership.php
@@ -194,7 +194,18 @@ class Membership extends AbstractApi
             XmlSerializer::createFromArray(['membership' => $params])->getEncoded(),
         ));
 
-        return $this->lastResponse->getContent();
+        $body = $this->lastResponse->getContent();
+        $statusCode = $this->lastResponse->getStatusCode();
+
+        if ($statusCode !== 200 && $statusCode !== 204) {
+            if (!Future::isForwardCompatibilityEnabled()) {
+                return $body;
+            }
+
+            throw UnexpectedResponseException::create($this->lastResponse);
+        }
+
+        return $body;
     }
 
     /**

--- a/src/Redmine/Api/Membership.php
+++ b/src/Redmine/Api/Membership.php
@@ -10,6 +10,7 @@ use Redmine\Exception\InvalidParameterException;
 use Redmine\Exception\MissingParameterException;
 use Redmine\Exception\SerializerException;
 use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Http\HttpClient;
 use Redmine\Http\HttpFactory;
 use Redmine\Serializer\XmlSerializer;
@@ -148,6 +149,14 @@ class Membership extends AbstractApi
         ));
 
         $body = $this->lastResponse->getContent();
+
+        if ($this->lastResponse->getStatusCode() !== 201) {
+            if (!Future::isForwardCompatibilityEnabled() && $body === '') {
+                return $body;
+            }
+
+            throw UnexpectedResponseException::create($this->lastResponse);
+        }
 
         if ('' !== $body) {
             return new SimpleXMLElement($body);

--- a/src/Redmine/Api/Membership.php
+++ b/src/Redmine/Api/Membership.php
@@ -151,8 +151,12 @@ class Membership extends AbstractApi
         $body = $this->lastResponse->getContent();
 
         if ($this->lastResponse->getStatusCode() !== 201) {
-            if (!Future::isForwardCompatibilityEnabled() && $body === '') {
-                return $body;
+            if (!Future::isForwardCompatibilityEnabled()) {
+                if ($body === '') {
+                    return $body;
+                }
+
+                return new SimpleXMLElement($body);
             }
 
             throw UnexpectedResponseException::create($this->lastResponse);

--- a/src/Redmine/Api/Membership.php
+++ b/src/Redmine/Api/Membership.php
@@ -224,7 +224,18 @@ class Membership extends AbstractApi
             '/memberships/' . $id . '.xml',
         ));
 
-        return $this->lastResponse->getContent();
+        $body = $this->lastResponse->getContent();
+        $statusCode = $this->lastResponse->getStatusCode();
+
+        if ($statusCode !== 200 && $statusCode !== 204) {
+            if (!Future::isForwardCompatibilityEnabled()) {
+                return $body;
+            }
+
+            throw UnexpectedResponseException::create($this->lastResponse);
+        }
+
+        return $body;
     }
 
     /**

--- a/src/Redmine/Api/Project.php
+++ b/src/Redmine/Api/Project.php
@@ -275,7 +275,11 @@ class Project extends AbstractApi
 
         if ($statusCode !== 201) {
             if (!Future::isForwardCompatibilityEnabled()) {
-                return $body;
+                if ($body === '') {
+                    return $body;
+                }
+
+                return new SimpleXMLElement($body);
             }
 
             throw UnexpectedResponseException::create($this->lastResponse);

--- a/src/Redmine/Api/Project.php
+++ b/src/Redmine/Api/Project.php
@@ -314,7 +314,18 @@ class Project extends AbstractApi
             XmlSerializer::createFromArray(['project' => $params])->getEncoded(),
         ));
 
-        return $this->lastResponse->getContent();
+        $body = $this->lastResponse->getContent();
+        $statusCode = $this->lastResponse->getStatusCode();
+
+        if ($statusCode !== 200 && $statusCode !== 204) {
+            if (!Future::isForwardCompatibilityEnabled()) {
+                return $body;
+            }
+
+            throw UnexpectedResponseException::create($this->lastResponse);
+        }
+
+        return $body;
     }
 
     /**

--- a/src/Redmine/Api/Project.php
+++ b/src/Redmine/Api/Project.php
@@ -505,7 +505,18 @@ class Project extends AbstractApi
             '/projects/' . $id . '.xml',
         ));
 
-        return $this->lastResponse->getContent();
+        $body = $this->lastResponse->getContent();
+        $statusCode = $this->lastResponse->getStatusCode();
+
+        if ($statusCode !== 200 && $statusCode !== 204) {
+            if (!Future::isForwardCompatibilityEnabled()) {
+                return $body;
+            }
+
+            throw UnexpectedResponseException::create($this->lastResponse);
+        }
+
+        return $body;
     }
 
     /**

--- a/src/Redmine/Api/Project.php
+++ b/src/Redmine/Api/Project.php
@@ -10,6 +10,7 @@ use Redmine\Exception;
 use Redmine\Exception\MissingParameterException;
 use Redmine\Exception\SerializerException;
 use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Http\HttpClient;
 use Redmine\Http\HttpFactory;
 use Redmine\Serializer\JsonSerializer;
@@ -270,6 +271,15 @@ class Project extends AbstractApi
         ));
 
         $body = $this->lastResponse->getContent();
+        $statusCode = $this->lastResponse->getStatusCode();
+
+        if ($statusCode !== 201) {
+            if (!Future::isForwardCompatibilityEnabled()) {
+                return $body;
+            }
+
+            throw UnexpectedResponseException::create($this->lastResponse);
+        }
 
         if ('' !== $body) {
             return new SimpleXMLElement($body);

--- a/src/Redmine/Api/TimeEntry.php
+++ b/src/Redmine/Api/TimeEntry.php
@@ -250,6 +250,17 @@ class TimeEntry extends AbstractApi
             '/time_entries/' . $id . '.xml',
         ));
 
-        return $this->lastResponse->getContent();
+        $body = $this->lastResponse->getContent();
+        $statusCode = $this->lastResponse->getStatusCode();
+
+        if ($statusCode !== 200 && $statusCode !== 204) {
+            if (!Future::isForwardCompatibilityEnabled()) {
+                return $body;
+            }
+
+            throw UnexpectedResponseException::create($this->lastResponse);
+        }
+
+        return $body;
     }
 }

--- a/src/Redmine/Api/TimeEntry.php
+++ b/src/Redmine/Api/TimeEntry.php
@@ -9,6 +9,7 @@ use Redmine\Exception;
 use Redmine\Exception\MissingParameterException;
 use Redmine\Exception\SerializerException;
 use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Http\HttpClient;
 use Redmine\Http\HttpFactory;
 use Redmine\Serializer\JsonSerializer;
@@ -173,6 +174,15 @@ class TimeEntry extends AbstractApi
         ));
 
         $body = $this->lastResponse->getContent();
+        $statusCode = $this->lastResponse->getStatusCode();
+
+        if ($statusCode !== 201) {
+            if (!Future::isForwardCompatibilityEnabled()) {
+                return $body;
+            }
+
+            throw UnexpectedResponseException::create($this->lastResponse);
+        }
 
         if ('' !== $body) {
             return new SimpleXMLElement($body);

--- a/src/Redmine/Api/TimeEntry.php
+++ b/src/Redmine/Api/TimeEntry.php
@@ -178,7 +178,11 @@ class TimeEntry extends AbstractApi
 
         if ($statusCode !== 201) {
             if (!Future::isForwardCompatibilityEnabled()) {
-                return $body;
+                if ($body === '') {
+                    return $body;
+                }
+
+                return new SimpleXMLElement($body);
             }
 
             throw UnexpectedResponseException::create($this->lastResponse);

--- a/src/Redmine/Api/TimeEntry.php
+++ b/src/Redmine/Api/TimeEntry.php
@@ -220,7 +220,18 @@ class TimeEntry extends AbstractApi
             XmlSerializer::createFromArray(['time_entry' => $params])->getEncoded(),
         ));
 
-        return $this->lastResponse->getContent();
+        $body = $this->lastResponse->getContent();
+        $statusCode = $this->lastResponse->getStatusCode();
+
+        if ($statusCode !== 200 && $statusCode !== 204) {
+            if (!Future::isForwardCompatibilityEnabled()) {
+                return $body;
+            }
+
+            throw UnexpectedResponseException::create($this->lastResponse);
+        }
+
+        return $body;
     }
 
     /**

--- a/src/Redmine/Api/User.php
+++ b/src/Redmine/Api/User.php
@@ -303,7 +303,11 @@ class User extends AbstractApi
 
         if ($statusCode !== 201) {
             if (!Future::isForwardCompatibilityEnabled()) {
-                return $body;
+                if ($body === '') {
+                    return $body;
+                }
+
+                return new SimpleXMLElement($body);
             }
 
             throw UnexpectedResponseException::create($this->lastResponse);

--- a/src/Redmine/Api/User.php
+++ b/src/Redmine/Api/User.php
@@ -374,7 +374,18 @@ class User extends AbstractApi
             '/users/' . $id . '.xml',
         ));
 
-        return $this->lastResponse->getContent();
+        $body = $this->lastResponse->getContent();
+        $statusCode = $this->lastResponse->getStatusCode();
+
+        if ($statusCode !== 200 && $statusCode !== 204) {
+            if (!Future::isForwardCompatibilityEnabled()) {
+                return $body;
+            }
+
+            throw UnexpectedResponseException::create($this->lastResponse);
+        }
+
+        return $body;
     }
 
     /**

--- a/src/Redmine/Api/User.php
+++ b/src/Redmine/Api/User.php
@@ -344,7 +344,18 @@ class User extends AbstractApi
             XmlSerializer::createFromArray(['user' => $params])->getEncoded(),
         ));
 
-        return $this->lastResponse->getContent();
+        $body = $this->lastResponse->getContent();
+        $statusCode = $this->lastResponse->getStatusCode();
+
+        if ($statusCode !== 200 && $statusCode !== 204) {
+            if (!Future::isForwardCompatibilityEnabled()) {
+                return $body;
+            }
+
+            throw UnexpectedResponseException::create($this->lastResponse);
+        }
+
+        return $body;
     }
 
     /**

--- a/src/Redmine/Api/User.php
+++ b/src/Redmine/Api/User.php
@@ -9,6 +9,7 @@ use Redmine\Exception;
 use Redmine\Exception\MissingParameterException;
 use Redmine\Exception\SerializerException;
 use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Http\HttpClient;
 use Redmine\Http\HttpFactory;
 use Redmine\Serializer\JsonSerializer;
@@ -298,6 +299,15 @@ class User extends AbstractApi
         ));
 
         $body = $this->lastResponse->getContent();
+        $statusCode = $this->lastResponse->getStatusCode();
+
+        if ($statusCode !== 201) {
+            if (!Future::isForwardCompatibilityEnabled()) {
+                return $body;
+            }
+
+            throw UnexpectedResponseException::create($this->lastResponse);
+        }
 
         if ('' !== $body) {
             return new SimpleXMLElement($body);

--- a/src/Redmine/Api/Version.php
+++ b/src/Redmine/Api/Version.php
@@ -321,7 +321,18 @@ class Version extends AbstractApi
             XmlSerializer::createFromArray(['version' => $params])->getEncoded(),
         ));
 
-        return $this->lastResponse->getContent();
+        $body = $this->lastResponse->getContent();
+        $statusCode = $this->lastResponse->getStatusCode();
+
+        if ($statusCode !== 200 && $statusCode !== 204) {
+            if (!Future::isForwardCompatibilityEnabled()) {
+                return $body;
+            }
+
+            throw UnexpectedResponseException::create($this->lastResponse);
+        }
+
+        return $body;
     }
 
     /**

--- a/src/Redmine/Api/Version.php
+++ b/src/Redmine/Api/Version.php
@@ -389,7 +389,18 @@ class Version extends AbstractApi
             '/versions/' . $id . '.xml',
         ));
 
-        return $this->lastResponse->getContent();
+        $body = $this->lastResponse->getContent();
+        $statusCode = $this->lastResponse->getStatusCode();
+
+        if ($statusCode !== 200 && $statusCode !== 204) {
+            if (!Future::isForwardCompatibilityEnabled()) {
+                return $body;
+            }
+
+            throw UnexpectedResponseException::create($this->lastResponse);
+        }
+
+        return $body;
     }
 
     /**

--- a/src/Redmine/Api/Version.php
+++ b/src/Redmine/Api/Version.php
@@ -279,7 +279,11 @@ class Version extends AbstractApi
 
         if ($statusCode !== 201) {
             if (!Future::isForwardCompatibilityEnabled()) {
-                return $body;
+                if ($body === '') {
+                    return $body;
+                }
+
+                return new SimpleXMLElement($body);
             }
 
             throw UnexpectedResponseException::create($this->lastResponse);

--- a/src/Redmine/Api/Version.php
+++ b/src/Redmine/Api/Version.php
@@ -10,6 +10,7 @@ use Redmine\Exception\InvalidParameterException;
 use Redmine\Exception\MissingParameterException;
 use Redmine\Exception\SerializerException;
 use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Http\HttpClient;
 use Redmine\Http\HttpFactory;
 use Redmine\Serializer\JsonSerializer;
@@ -274,6 +275,15 @@ class Version extends AbstractApi
         ));
 
         $body = $this->lastResponse->getContent();
+        $statusCode = $this->lastResponse->getStatusCode();
+
+        if ($statusCode !== 201) {
+            if (!Future::isForwardCompatibilityEnabled()) {
+                return $body;
+            }
+
+            throw UnexpectedResponseException::create($this->lastResponse);
+        }
 
         if ('' !== $body) {
             return new SimpleXMLElement($body);

--- a/src/Redmine/Api/Wiki.php
+++ b/src/Redmine/Api/Wiki.php
@@ -235,6 +235,17 @@ class Wiki extends AbstractApi
             '/projects/' . $project . '/wiki/' . urlencode($page) . '.xml',
         ));
 
-        return $this->lastResponse->getContent();
+        $body = $this->lastResponse->getContent();
+        $statusCode = $this->lastResponse->getStatusCode();
+
+        if ($statusCode !== 200 && $statusCode !== 204) {
+            if (!Future::isForwardCompatibilityEnabled()) {
+                return $body;
+            }
+
+            throw UnexpectedResponseException::create($this->lastResponse);
+        }
+
+        return $body;
     }
 }

--- a/src/Redmine/Api/Wiki.php
+++ b/src/Redmine/Api/Wiki.php
@@ -189,7 +189,11 @@ class Wiki extends AbstractApi
 
         if ($statusCode !== 200 && $statusCode !== 201) {
             if (!Future::isForwardCompatibilityEnabled()) {
-                return $body;
+                if ($body === '') {
+                    return $body;
+                }
+
+                return new SimpleXMLElement($body);
             }
 
             throw UnexpectedResponseException::create($this->lastResponse);

--- a/src/Redmine/Api/Wiki.php
+++ b/src/Redmine/Api/Wiki.php
@@ -9,6 +9,7 @@ use Redmine\Exception;
 use Redmine\Exception\InvalidParameterException;
 use Redmine\Exception\SerializerException;
 use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Http\HttpClient;
 use Redmine\Http\HttpFactory;
 use Redmine\Serializer\JsonSerializer;
@@ -184,6 +185,15 @@ class Wiki extends AbstractApi
         ));
 
         $body = $this->lastResponse->getContent();
+        $statusCode = $this->lastResponse->getStatusCode();
+
+        if ($statusCode !== 200 && $statusCode !== 201) {
+            if (!Future::isForwardCompatibilityEnabled()) {
+                return $body;
+            }
+
+            throw UnexpectedResponseException::create($this->lastResponse);
+        }
 
         if ($body !== '') {
             return new SimpleXMLElement($body);

--- a/src/Redmine/Client/ClientApiTrait.php
+++ b/src/Redmine/Client/ClientApiTrait.php
@@ -6,6 +6,7 @@ namespace Redmine\Client;
 
 use Redmine\Api;
 use Redmine\Exception\InvalidApiNameException;
+use Redmine\Future;
 
 /**
  * Provide API instantiation to clients.
@@ -60,6 +61,11 @@ trait ClientApiTrait
         $this->apiInstances[$name] = $class::fromHttpClient($this);
 
         return $this->apiInstances[$name];
+    }
+
+    public function enableFutureMode(): void
+    {
+        Future::enableForwardCompatibility();
     }
 
     private function isUploadCall(string $path): bool

--- a/src/Redmine/Future.php
+++ b/src/Redmine/Future.php
@@ -16,6 +16,11 @@ final class Future
         self::$isForwardCompatibilityEnabled = true;
     }
 
+    public static function disableForwardCompatibility(): void
+    {
+        self::$isForwardCompatibilityEnabled = false;
+    }
+
     public static function isForwardCompatibilityEnabled(): bool
     {
         return self::$isForwardCompatibilityEnabled;

--- a/src/Redmine/Future.php
+++ b/src/Redmine/Future.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Redmine;
+
+/**
+ * @internal
+ */
+final class Future
+{
+    public static function isForwardCompatibilityEnabled(): bool
+    {
+        return false;
+    }
+}

--- a/src/Redmine/Future.php
+++ b/src/Redmine/Future.php
@@ -9,8 +9,15 @@ namespace Redmine;
  */
 final class Future
 {
+    private static bool $isForwardCompatibilityEnabled = false;
+
+    public static function enableForwardCompatibility(): void
+    {
+        self::$isForwardCompatibilityEnabled = true;
+    }
+
     public static function isForwardCompatibilityEnabled(): bool
     {
-        return false;
+        return self::$isForwardCompatibilityEnabled;
     }
 }

--- a/tests/Unit/Api/Attachment/RemoveTest.php
+++ b/tests/Unit/Api/Attachment/RemoveTest.php
@@ -7,6 +7,8 @@ namespace Redmine\Tests\Unit\Api\Attachment;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Attachment;
+use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
 #[CoversClass(Attachment::class)]
@@ -30,5 +32,53 @@ class RemoveTest extends TestCase
         $api = Attachment::fromHttpClient($client);
 
         $this->assertSame('', $api->remove(5));
+    }
+
+    public function testRemoveWithIncorrectStatusCodeReturnsBody(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'DELETE',
+                '/attachments/5.xml',
+                'application/xml',
+                '',
+                500,
+                '',
+                'error body',
+            ],
+        );
+
+        $api = Attachment::fromHttpClient($client);
+
+        $this->assertSame('error body', $api->remove(5));
+    }
+
+    public function testRemoveWithIncorrectStatusCodeThrowsException(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'DELETE',
+                '/attachments/5.xml',
+                'application/xml',
+                '',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = Attachment::fromHttpClient($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+
+        try {
+            Future::enableForwardCompatibility();
+
+            $api->remove(5);
+        } finally {
+            Future::disableForwardCompatibility();
+        }
     }
 }

--- a/tests/Unit/Api/Attachment/UploadTest.php
+++ b/tests/Unit/Api/Attachment/UploadTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Attachment;
+use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
 #[CoversClass(Attachment::class)]
@@ -88,5 +90,53 @@ class UploadTest extends TestCase
                 '{"upload":{}}',
             ],
         ];
+    }
+
+    public function testUploadWithIncorrectStatusCodeReturnsBody(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'POST',
+                '/uploads.json',
+                'application/octet-stream',
+                'attachment-content',
+                500,
+                'application/json',
+                '{"error":"internal error"}',
+            ],
+        );
+
+        $api = Attachment::fromHttpClient($client);
+
+        $this->assertSame('{"error":"internal error"}', $api->upload('attachment-content'));
+    }
+
+    public function testUploadWithIncorrectStatusCodeThrowsException(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'POST',
+                '/uploads.json',
+                'application/octet-stream',
+                'attachment-content',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = Attachment::fromHttpClient($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+
+        try {
+            Future::enableForwardCompatibility();
+
+            $api->upload('attachment-content');
+        } finally {
+            Future::disableForwardCompatibility();
+        }
     }
 }

--- a/tests/Unit/Api/Group/AddUserTest.php
+++ b/tests/Unit/Api/Group/AddUserTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Group;
+use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 use SimpleXMLElement;
 
@@ -85,5 +87,33 @@ class AddUserTest extends TestCase
         $return = $api->addUser(1, 2);
 
         $this->assertSame('', $return);
+    }
+
+    public function testAddUserWithIncorrectStatusCodeThrowsException(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'POST',
+                '/groups/1/users.xml',
+                'application/xml',
+                '<?xml version="1.0" encoding="UTF-8"?><user_id>2</user_id>',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = Group::fromHttpClient($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+
+        try {
+            Future::enableForwardCompatibility();
+
+            $api->addUser(1, 2);
+        } finally {
+            Future::disableForwardCompatibility();
+        }
     }
 }

--- a/tests/Unit/Api/Group/AddUserTest.php
+++ b/tests/Unit/Api/Group/AddUserTest.php
@@ -89,6 +89,28 @@ class AddUserTest extends TestCase
         $this->assertSame('', $return);
     }
 
+    public function testAddUserWithIncorrectStatusCodeReturnsBody(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'POST',
+                '/groups/1/users.xml',
+                'application/xml',
+                '<?xml version="1.0" encoding="UTF-8"?><user_id>2</user_id>',
+                500,
+                '',
+                '<?xml version="1.0" encoding="UTF-8"?><error>error</error>',
+            ],
+        );
+
+        $api = Group::fromHttpClient($client);
+
+        $return = $api->addUser(1, 2);
+
+        $this->assertXmlStringEqualsXmlString('<?xml version="1.0" encoding="UTF-8"?><error>error</error>', $return->asXML());
+    }
+
     public function testAddUserWithIncorrectStatusCodeThrowsException(): void
     {
         $client = AssertingHttpClient::create(

--- a/tests/Unit/Api/Group/CreateTest.php
+++ b/tests/Unit/Api/Group/CreateTest.php
@@ -138,6 +138,28 @@ class CreateTest extends TestCase
         $this->assertSame('', $return);
     }
 
+    public function testCreateWithIncorrectStatusCodeReturnsBody(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'POST',
+                '/groups.xml',
+                'application/xml',
+                '<?xml version="1.0" encoding="UTF-8"?><group><name>Group Name</name></group>',
+                500,
+                '',
+                'error',
+            ],
+        );
+
+        $api = Group::fromHttpClient($client);
+
+        $return = $api->create(['name' => 'Group Name']);
+
+        $this->assertSame('error', $return);
+    }
+
     public function testCreateThrowsExceptionIfNameIsMissing(): void
     {
         // Test values

--- a/tests/Unit/Api/Group/CreateTest.php
+++ b/tests/Unit/Api/Group/CreateTest.php
@@ -9,6 +9,8 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Group;
 use Redmine\Exception\MissingParameterException;
+use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Http\HttpClient;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 use SimpleXMLElement;
@@ -152,5 +154,33 @@ class CreateTest extends TestCase
 
         // Perform the tests
         $api->create($postParameter);
+    }
+
+    public function testCreateWithIncorrectStatusCodeThrowsException(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'POST',
+                '/groups.xml',
+                'application/xml',
+                '<?xml version="1.0" encoding="UTF-8"?><group><name>Group Name</name></group>',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = Group::fromHttpClient($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+
+        try {
+            Future::enableForwardCompatibility();
+
+            $api->create(['name' => 'Group Name']);
+        } finally {
+            Future::disableForwardCompatibility();
+        }
     }
 }

--- a/tests/Unit/Api/Group/CreateTest.php
+++ b/tests/Unit/Api/Group/CreateTest.php
@@ -149,7 +149,7 @@ class CreateTest extends TestCase
                 '<?xml version="1.0" encoding="UTF-8"?><group><name>Group Name</name></group>',
                 500,
                 '',
-                'error',
+                '<?xml version="1.0" encoding="UTF-8"?><error>error</error>',
             ],
         );
 
@@ -157,7 +157,7 @@ class CreateTest extends TestCase
 
         $return = $api->create(['name' => 'Group Name']);
 
-        $this->assertSame('error', $return);
+        $this->assertXmlStringEqualsXmlString('<?xml version="1.0" encoding="UTF-8"?><error>error</error>', $return->asXML());
     }
 
     public function testCreateThrowsExceptionIfNameIsMissing(): void

--- a/tests/Unit/Api/Group/RemoveTest.php
+++ b/tests/Unit/Api/Group/RemoveTest.php
@@ -7,6 +7,8 @@ namespace Redmine\Tests\Unit\Api\Group;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Group;
+use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
 #[CoversClass(Group::class)]
@@ -30,5 +32,53 @@ class RemoveTest extends TestCase
         $api = Group::fromHttpClient($client);
 
         $this->assertSame('', $api->remove(5));
+    }
+
+    public function testRemoveWithIncorrectStatusCodeReturnsBody(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'DELETE',
+                '/groups/5.xml',
+                'application/xml',
+                '',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = Group::fromHttpClient($client);
+
+        $this->assertSame('', $api->remove(5));
+    }
+
+    public function testRemoveWithIncorrectStatusCodeThrowsException(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'DELETE',
+                '/groups/5.xml',
+                'application/xml',
+                '',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = Group::fromHttpClient($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+
+        try {
+            Future::enableForwardCompatibility();
+
+            $api->remove(5);
+        } finally {
+            Future::disableForwardCompatibility();
+        }
     }
 }

--- a/tests/Unit/Api/Group/RemoveUserTest.php
+++ b/tests/Unit/Api/Group/RemoveUserTest.php
@@ -7,6 +7,8 @@ namespace Redmine\Tests\Unit\Api\Group;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Group;
+use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
 #[CoversClass(Group::class)]
@@ -30,5 +32,53 @@ class RemoveUserTest extends TestCase
         $api = Group::fromHttpClient($client);
 
         $this->assertSame('', $api->removeUser(5, 10));
+    }
+
+    public function testRemoveUserWithIncorrectStatusCodeReturnsBody(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'DELETE',
+                '/groups/5/users/10.xml',
+                'application/xml',
+                '',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = Group::fromHttpClient($client);
+
+        $this->assertSame('', $api->removeUser(5, 10));
+    }
+
+    public function testRemoveUserWithIncorrectStatusCodeThrowsException(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'DELETE',
+                '/groups/5/users/10.xml',
+                'application/xml',
+                '',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = Group::fromHttpClient($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+
+        try {
+            Future::enableForwardCompatibility();
+
+            $api->removeUser(5, 10);
+        } finally {
+            Future::disableForwardCompatibility();
+        }
     }
 }

--- a/tests/Unit/Api/Group/UpdateTest.php
+++ b/tests/Unit/Api/Group/UpdateTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Group;
+use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
 #[CoversClass(Group::class)]
@@ -89,5 +91,53 @@ class UpdateTest extends TestCase
                 '',
             ],
         ];
+    }
+
+    public function testUpdateWithIncorrectStatusCodeReturnsBody(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'PUT',
+                '/groups/1.xml',
+                'application/xml',
+                '<?xml version="1.0"?><group></group>',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = Group::fromHttpClient($client);
+
+        $this->assertSame('', $api->update(1, []));
+    }
+
+    public function testUpdateWithIncorrectStatusCodeThrowsException(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'PUT',
+                '/groups/1.xml',
+                'application/xml',
+                '<?xml version="1.0"?><group></group>',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = Group::fromHttpClient($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+
+        try {
+            Future::enableForwardCompatibility();
+
+            $api->update(1, []);
+        } finally {
+            Future::disableForwardCompatibility();
+        }
     }
 }

--- a/tests/Unit/Api/Issue/AddWatcherTest.php
+++ b/tests/Unit/Api/Issue/AddWatcherTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Issue;
+use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 use SimpleXMLElement;
 
@@ -85,5 +87,33 @@ class AddWatcherTest extends TestCase
         $return = $api->addWatcher(1, 2);
 
         $this->assertSame('', $return);
+    }
+
+    public function testAddWatcherWithIncorrectStatusCodeThrowsException(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'POST',
+                '/issues/1/watchers.xml',
+                'application/xml',
+                '<?xml version="1.0" encoding="UTF-8"?><user_id>2</user_id>',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = Issue::fromHttpClient($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+
+        try {
+            Future::enableForwardCompatibility();
+
+            $api->addWatcher(1, 2);
+        } finally {
+            Future::disableForwardCompatibility();
+        }
     }
 }

--- a/tests/Unit/Api/Issue/AddWatcherTest.php
+++ b/tests/Unit/Api/Issue/AddWatcherTest.php
@@ -89,6 +89,28 @@ class AddWatcherTest extends TestCase
         $this->assertSame('', $return);
     }
 
+    public function testAddWatcherWithIncorrectStatusCodeReturnsBody(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'POST',
+                '/issues/1/watchers.xml',
+                'application/xml',
+                '<?xml version="1.0" encoding="UTF-8"?><user_id>2</user_id>',
+                500,
+                '',
+                '<?xml version="1.0" encoding="UTF-8"?><error>error</error>',
+            ],
+        );
+
+        $api = Issue::fromHttpClient($client);
+
+        $return = $api->addWatcher(1, 2);
+
+        $this->assertXmlStringEqualsXmlString('<?xml version="1.0" encoding="UTF-8"?><error>error</error>', $return->asXML());
+    }
+
     public function testAddWatcherWithIncorrectStatusCodeThrowsException(): void
     {
         $client = AssertingHttpClient::create(

--- a/tests/Unit/Api/Issue/AttachManyTest.php
+++ b/tests/Unit/Api/Issue/AttachManyTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Issue;
+use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
 #[CoversClass(Issue::class)]
@@ -96,5 +98,53 @@ class AttachManyTest extends TestCase
                 '',
             ],
         ];
+    }
+
+    public function testAttachManyWithIncorrectStatusCodeReturnsBody(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'PUT',
+                '/issues/5.json',
+                'application/json',
+                '{"issue":{"id":5,"uploads":[]}}',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = Issue::fromHttpClient($client);
+
+        $this->assertSame('', $api->attachMany(5, []));
+    }
+
+    public function testAttachManyWithIncorrectStatusCodeThrowsException(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'PUT',
+                '/issues/5.json',
+                'application/json',
+                '{"issue":{"id":5,"uploads":[]}}',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = Issue::fromHttpClient($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+
+        try {
+            Future::enableForwardCompatibility();
+
+            $api->attachMany(5, []);
+        } finally {
+            Future::disableForwardCompatibility();
+        }
     }
 }

--- a/tests/Unit/Api/Issue/CreateTest.php
+++ b/tests/Unit/Api/Issue/CreateTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Issue;
+use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 use SimpleXMLElement;
 
@@ -239,7 +241,7 @@ class CreateTest extends TestCase
         ];
     }
 
-    public function testCreateReturnsEmptyString(): void
+    public function testCreateWithIncorrectStatusCodeReturnsEmptyString(): void
     {
         $client = AssertingHttpClient::create(
             $this,
@@ -263,6 +265,35 @@ class CreateTest extends TestCase
         $this->assertSame('', $return);
     }
 
+    public function testCreateWithIncorrectStatusCodeThrowsException(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'POST',
+                '/issues.xml',
+                'application/xml',
+                '<?xml version="1.0" encoding="UTF-8"?><issue/>',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        // Create the object under test
+        $api = Issue::fromHttpClient($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+
+        try {
+            Future::enableForwardCompatibility();
+
+            $api->create([]);
+        } finally {
+            Future::disableForwardCompatibility();
+        }
+    }
+
     public function testCreateWithHttpClientRetrievesIssueStatusId(): void
     {
         $client = AssertingHttpClient::create(
@@ -281,7 +312,7 @@ class CreateTest extends TestCase
                 '/issues.xml',
                 'application/xml',
                 '<?xml version="1.0"?><issue><status_id>123</status_id></issue>',
-                200,
+                201,
                 'application/xml',
                 '<?xml version="1.0"?><issue></issue>',
             ],
@@ -318,7 +349,7 @@ class CreateTest extends TestCase
                 '/issues.xml',
                 'application/xml',
                 '<?xml version="1.0"?><issue><project_id>3</project_id></issue>',
-                200,
+                201,
                 'application/xml',
                 '<?xml version="1.0"?><issue></issue>',
             ],
@@ -355,7 +386,7 @@ class CreateTest extends TestCase
                 '/issues.xml',
                 'application/xml',
                 '<?xml version="1.0"?><issue><project_id>3</project_id><category_id>45</category_id></issue>',
-                200,
+                201,
                 'application/xml',
                 '<?xml version="1.0"?><issue></issue>',
             ],
@@ -392,7 +423,7 @@ class CreateTest extends TestCase
                 '/issues.xml',
                 'application/xml',
                 '<?xml version="1.0"?><issue><tracker_id>9</tracker_id></issue>',
-                200,
+                201,
                 'application/xml',
                 '<?xml version="1.0"?><issue></issue>',
             ],
@@ -429,7 +460,7 @@ class CreateTest extends TestCase
                 '/issues.xml',
                 'application/xml',
                 '<?xml version="1.0"?><issue><assigned_to_id>6</assigned_to_id><author_id>5</author_id></issue>',
-                200,
+                201,
                 'application/xml',
                 '<?xml version="1.0"?><issue></issue>',
             ],
@@ -515,7 +546,7 @@ class CreateTest extends TestCase
                     <author_id>5</author_id>
                 </issue>
                 XML,
-                200,
+                201,
                 'application/xml',
                 '<?xml version="1.0"?><issue></issue>',
             ],

--- a/tests/Unit/Api/Issue/CreateTest.php
+++ b/tests/Unit/Api/Issue/CreateTest.php
@@ -265,6 +265,29 @@ class CreateTest extends TestCase
         $this->assertSame('', $return);
     }
 
+    public function testCreateWithIncorrectStatusCodeReturnsBody(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'POST',
+                '/issues.xml',
+                'application/xml',
+                '<?xml version="1.0" encoding="UTF-8"?><issue/>',
+                500,
+                '',
+                '<error>error</error>',
+            ],
+        );
+
+        $api = Issue::fromHttpClient($client);
+
+        $return = $api->create([]);
+
+        $this->assertInstanceOf(SimpleXMLElement::class, $return);
+        $this->assertXmlStringEqualsXmlString('<error>error</error>', $return->asXml());
+    }
+
     public function testCreateWithIncorrectStatusCodeThrowsException(): void
     {
         $client = AssertingHttpClient::create(

--- a/tests/Unit/Api/Issue/RemoveTest.php
+++ b/tests/Unit/Api/Issue/RemoveTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Issue;
+use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
 #[CoversClass(Issue::class)]
@@ -52,5 +54,53 @@ class RemoveTest extends TestCase
                 '',
             ],
         ];
+    }
+
+    public function testRemoveWithIncorrectStatusCodeReturnsBody(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'DELETE',
+                '/issues/25.xml',
+                'application/xml',
+                '',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = Issue::fromHttpClient($client);
+
+        $this->assertSame('', $api->remove(25));
+    }
+
+    public function testRemoveWithIncorrectStatusCodeThrowsException(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'DELETE',
+                '/issues/25.xml',
+                'application/xml',
+                '',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = Issue::fromHttpClient($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+
+        try {
+            Future::enableForwardCompatibility();
+
+            $api->remove(25);
+        } finally {
+            Future::disableForwardCompatibility();
+        }
     }
 }

--- a/tests/Unit/Api/Issue/RemoveWatcherTest.php
+++ b/tests/Unit/Api/Issue/RemoveWatcherTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Issue;
+use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
 #[CoversClass(Issue::class)]
@@ -53,5 +55,53 @@ class RemoveWatcherTest extends TestCase
                 '',
             ],
         ];
+    }
+
+    public function testRemoveWatcherWithIncorrectStatusCodeReturnsBody(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'DELETE',
+                '/issues/25/watchers/5.xml',
+                'application/xml',
+                '',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = Issue::fromHttpClient($client);
+
+        $this->assertSame('', $api->removeWatcher(25, 5));
+    }
+
+    public function testRemoveWatcherWithIncorrectStatusCodeThrowsException(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'DELETE',
+                '/issues/25/watchers/5.xml',
+                'application/xml',
+                '',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = Issue::fromHttpClient($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+
+        try {
+            Future::enableForwardCompatibility();
+
+            $api->removeWatcher(25, 5);
+        } finally {
+            Future::disableForwardCompatibility();
+        }
     }
 }

--- a/tests/Unit/Api/Issue/UpdateTest.php
+++ b/tests/Unit/Api/Issue/UpdateTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Issue;
+use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
 #[CoversClass(Issue::class)]
@@ -235,5 +237,53 @@ class UpdateTest extends TestCase
 
         // Perform the tests
         $this->assertSame('', $api->update(70, $parameters));
+    }
+
+    public function testUpdateWithIncorrectStatusCodeReturnsBody(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'PUT',
+                '/issues/1.xml',
+                'application/xml',
+                '<?xml version="1.0"?><issue><id>1</id></issue>',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = Issue::fromHttpClient($client);
+
+        $this->assertSame('', $api->update(1, []));
+    }
+
+    public function testUpdateWithIncorrectStatusCodeThrowsException(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'PUT',
+                '/issues/1.xml',
+                'application/xml',
+                '<?xml version="1.0"?><issue><id>1</id></issue>',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = Issue::fromHttpClient($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+
+        try {
+            Future::enableForwardCompatibility();
+
+            $api->update(1, []);
+        } finally {
+            Future::disableForwardCompatibility();
+        }
     }
 }

--- a/tests/Unit/Api/IssueCategory/CreateTest.php
+++ b/tests/Unit/Api/IssueCategory/CreateTest.php
@@ -9,6 +9,8 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\IssueCategory;
 use Redmine\Exception\MissingParameterException;
+use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Http\HttpClient;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 use SimpleXMLElement;
@@ -103,6 +105,34 @@ class CreateTest extends TestCase
         $return = $api->create(5, ['name' => 'Test Category']);
 
         $this->assertSame('', $return);
+    }
+
+    public function testCreateWithIncorrectStatusCodeThrowsException(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'POST',
+                '/projects/5/issue_categories.xml',
+                'application/xml',
+                '<?xml version="1.0" encoding="UTF-8"?><issue_category><name>Test Category</name></issue_category>',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = IssueCategory::fromHttpClient($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+
+        try {
+            Future::enableForwardCompatibility();
+
+            $api->create(5, ['name' => 'Test Category']);
+        } finally {
+            Future::disableForwardCompatibility();
+        }
     }
 
     public function testCreateThrowsExceptionWithEmptyParameters(): void

--- a/tests/Unit/Api/IssueCategory/CreateTest.php
+++ b/tests/Unit/Api/IssueCategory/CreateTest.php
@@ -107,6 +107,29 @@ class CreateTest extends TestCase
         $this->assertSame('', $return);
     }
 
+    public function testCreateWithIncorrectStatusCodeReturnsBody(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'POST',
+                '/projects/5/issue_categories.xml',
+                'application/xml',
+                '<?xml version="1.0" encoding="UTF-8"?><issue_category><name>Test Category</name></issue_category>',
+                500,
+                '',
+                '<error>error</error>',
+            ],
+        );
+
+        $api = IssueCategory::fromHttpClient($client);
+
+        $return = $api->create(5, ['name' => 'Test Category']);
+
+        $this->assertInstanceOf(SimpleXMLElement::class, $return);
+        $this->assertXmlStringEqualsXmlString('<error>error</error>', $return->asXml());
+    }
+
     public function testCreateWithIncorrectStatusCodeThrowsException(): void
     {
         $client = AssertingHttpClient::create(

--- a/tests/Unit/Api/IssueCategory/RemoveTest.php
+++ b/tests/Unit/Api/IssueCategory/RemoveTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\IssueCategory;
+use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
 #[CoversClass(IssueCategory::class)]
@@ -62,5 +64,53 @@ class RemoveTest extends TestCase
                 '',
             ],
         ];
+    }
+
+    public function testRemoveWithIncorrectStatusCodeReturnsBody(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'DELETE',
+                '/issue_categories/25.xml',
+                'application/xml',
+                '',
+                500,
+                '',
+                'error body',
+            ],
+        );
+
+        $api = IssueCategory::fromHttpClient($client);
+
+        $this->assertSame('error body', $api->remove(25));
+    }
+
+    public function testRemoveWithIncorrectStatusCodeThrowsException(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'DELETE',
+                '/issue_categories/25.xml',
+                'application/xml',
+                '',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = IssueCategory::fromHttpClient($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+
+        try {
+            Future::enableForwardCompatibility();
+
+            $api->remove(25);
+        } finally {
+            Future::disableForwardCompatibility();
+        }
     }
 }

--- a/tests/Unit/Api/IssueCategory/UpdateTest.php
+++ b/tests/Unit/Api/IssueCategory/UpdateTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\IssueCategory;
+use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
 #[CoversClass(IssueCategory::class)]
@@ -78,5 +80,53 @@ class UpdateTest extends TestCase
                 '',
             ],
         ];
+    }
+
+    public function testUpdateWithIncorrectStatusCodeReturnsBody(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'PUT',
+                '/issue_categories/5.xml',
+                'application/xml',
+                '<?xml version="1.0"?><issue_category><name>new name</name></issue_category>',
+                500,
+                '',
+                'error body',
+            ],
+        );
+
+        $api = IssueCategory::fromHttpClient($client);
+
+        $this->assertSame('error body', $api->update(5, ['name' => 'new name']));
+    }
+
+    public function testUpdateWithIncorrectStatusCodeThrowsException(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'PUT',
+                '/issue_categories/5.xml',
+                'application/xml',
+                '<?xml version="1.0"?><issue_category><name>new name</name></issue_category>',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = IssueCategory::fromHttpClient($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+
+        try {
+            Future::enableForwardCompatibility();
+
+            $api->update(5, ['name' => 'new name']);
+        } finally {
+            Future::disableForwardCompatibility();
+        }
     }
 }

--- a/tests/Unit/Api/IssueRelation/CreateTest.php
+++ b/tests/Unit/Api/IssueRelation/CreateTest.php
@@ -10,6 +10,8 @@ use PHPUnit\Framework\TestCase;
 use Redmine\Api\IssueRelation;
 use Redmine\Exception\MissingParameterException;
 use Redmine\Exception\SerializerException;
+use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Http\HttpClient;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
@@ -144,5 +146,33 @@ class CreateTest extends TestCase
                 ],
             ],
         ];
+    }
+
+    public function testCreateWithIncorrectStatusCodeThrowsException(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'POST',
+                '/issues/5/relations.json',
+                'application/json',
+                '{"relation":{"issue_to_id":10,"relation_type":"relates"}}',
+                500,
+                'application/json',
+                '{"relation":{}}',
+            ],
+        );
+
+        $api = IssueRelation::fromHttpClient($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+
+        try {
+            Future::enableForwardCompatibility();
+
+            $api->create(5, ['issue_to_id' => 10]);
+        } finally {
+            Future::disableForwardCompatibility();
+        }
     }
 }

--- a/tests/Unit/Api/IssueRelation/CreateTest.php
+++ b/tests/Unit/Api/IssueRelation/CreateTest.php
@@ -93,6 +93,28 @@ class CreateTest extends TestCase
         $api->create(5, ['issue_to_id' => 10]);
     }
 
+    public function testCreateWithIncorrectStatusCodeReturnsBody(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'POST',
+                '/issues/5/relations.json',
+                'application/json',
+                '{"relation":{"issue_to_id":10,"relation_type":"relates"}}',
+                500,
+                'application/json',
+                '{"relation":{"id":1,"issue_to_id":10}}',
+            ],
+        );
+
+        $api = IssueRelation::fromHttpClient($client);
+
+        $return = $api->create(5, ['issue_to_id' => 10]);
+
+        $this->assertSame(['relation' => ['id' => 1, 'issue_to_id' => 10]], $return);
+    }
+
     public function testCreateThrowsExceptionWithEmptyParameters(): void
     {
         // Create the used mock objects

--- a/tests/Unit/Api/IssueRelation/RemoveTest.php
+++ b/tests/Unit/Api/IssueRelation/RemoveTest.php
@@ -67,13 +67,13 @@ class RemoveTest extends TestCase
                 '',
                 500,
                 '',
-                '',
+                'error',
             ],
         );
 
         $api = IssueRelation::fromHttpClient($client);
 
-        $this->assertSame('', $api->remove(25));
+        $this->assertSame('error', $api->remove(25));
     }
 
     public function testRemoveWithIncorrectStatusCodeThrowsException(): void

--- a/tests/Unit/Api/IssueRelation/RemoveTest.php
+++ b/tests/Unit/Api/IssueRelation/RemoveTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\IssueRelation;
+use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
 #[CoversClass(IssueRelation::class)]
@@ -52,5 +54,53 @@ class RemoveTest extends TestCase
                 '',
             ],
         ];
+    }
+
+    public function testRemoveWithIncorrectStatusCodeReturnsBody(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'DELETE',
+                '/relations/25.xml',
+                'application/xml',
+                '',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = IssueRelation::fromHttpClient($client);
+
+        $this->assertSame('', $api->remove(25));
+    }
+
+    public function testRemoveWithIncorrectStatusCodeThrowsException(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'DELETE',
+                '/relations/25.xml',
+                'application/xml',
+                '',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = IssueRelation::fromHttpClient($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+
+        try {
+            Future::enableForwardCompatibility();
+
+            $api->remove(25);
+        } finally {
+            Future::disableForwardCompatibility();
+        }
     }
 }

--- a/tests/Unit/Api/IssueTest.php
+++ b/tests/Unit/Api/IssueTest.php
@@ -278,6 +278,9 @@ class IssueTest extends TestCase
         $legacyClient->expects($this->exactly(1))
             ->method('getLastResponseContentType')
             ->willReturn('application/xml');
+        $legacyClient->expects($this->exactly(1))
+            ->method('getLastResponseStatusCode')
+            ->willReturn(201);
 
         // Create the object under test
         $api = new Issue($legacyClient);

--- a/tests/Unit/Api/Membership/CreateTest.php
+++ b/tests/Unit/Api/Membership/CreateTest.php
@@ -98,6 +98,29 @@ class CreateTest extends TestCase
         $this->assertSame('', $return);
     }
 
+    public function testCreateWithIncorrectStatusCodeReturnsBody(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'POST',
+                '/projects/5/memberships.xml',
+                'application/xml',
+                '<?xml version="1.0" encoding="UTF-8"?><membership><user_id>4</user_id><role_ids>2</role_ids></membership>',
+                500,
+                '',
+                '<error>error</error>',
+            ],
+        );
+
+        $api = Membership::fromHttpClient($client);
+
+        $return = $api->create(5, ['user_id' => 4, 'role_ids' => 2]);
+
+        $this->assertInstanceOf(SimpleXMLElement::class, $return);
+        $this->assertXmlStringEqualsXmlString('<error>error</error>', $return->asXml());
+    }
+
     public function testCreateThrowsExceptionWithEmptyParameters(): void
     {
         $client = $this->createStub(HttpClient::class);

--- a/tests/Unit/Api/Membership/CreateTest.php
+++ b/tests/Unit/Api/Membership/CreateTest.php
@@ -9,6 +9,8 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Membership;
 use Redmine\Exception\MissingParameterException;
+use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Http\HttpClient;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 use SimpleXMLElement;
@@ -152,5 +154,33 @@ class CreateTest extends TestCase
                 ],
             ],
         ];
+    }
+
+    public function testCreateWithIncorrectStatusCodeThrowsException(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'POST',
+                '/projects/5/memberships.xml',
+                'application/xml',
+                '<?xml version="1.0" encoding="UTF-8"?><membership><user_id>4</user_id><role_ids>2</role_ids></membership>',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = Membership::fromHttpClient($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+
+        try {
+            Future::enableForwardCompatibility();
+
+            $api->create(5, ['user_id' => 4, 'role_ids' => 2]);
+        } finally {
+            Future::disableForwardCompatibility();
+        }
     }
 }

--- a/tests/Unit/Api/Membership/RemoveTest.php
+++ b/tests/Unit/Api/Membership/RemoveTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Membership;
+use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
 #[CoversClass(Membership::class)]
@@ -52,5 +54,53 @@ class RemoveTest extends TestCase
                 '',
             ],
         ];
+    }
+
+    public function testRemoveWithIncorrectStatusCodeReturnsBody(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'DELETE',
+                '/memberships/25.xml',
+                'application/xml',
+                '',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = Membership::fromHttpClient($client);
+
+        $this->assertSame('', $api->remove(25));
+    }
+
+    public function testRemoveWithIncorrectStatusCodeThrowsException(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'DELETE',
+                '/memberships/25.xml',
+                'application/xml',
+                '',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = Membership::fromHttpClient($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+
+        try {
+            Future::enableForwardCompatibility();
+
+            $api->remove(25);
+        } finally {
+            Future::disableForwardCompatibility();
+        }
     }
 }

--- a/tests/Unit/Api/Membership/RemoveTest.php
+++ b/tests/Unit/Api/Membership/RemoveTest.php
@@ -67,13 +67,13 @@ class RemoveTest extends TestCase
                 '',
                 500,
                 '',
-                '',
+                'error',
             ],
         );
 
         $api = Membership::fromHttpClient($client);
 
-        $this->assertSame('', $api->remove(25));
+        $this->assertSame('error', $api->remove(25));
     }
 
     public function testRemoveWithIncorrectStatusCodeThrowsException(): void

--- a/tests/Unit/Api/Membership/UpdateTest.php
+++ b/tests/Unit/Api/Membership/UpdateTest.php
@@ -9,6 +9,8 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Membership;
 use Redmine\Exception\MissingParameterException;
+use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Http\HttpClient;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
@@ -127,6 +129,34 @@ class UpdateTest extends TestCase
 
         // Perform the tests
         $api->update(5, $parameters);
+    }
+
+    public function testUpdateWithIncorrectStatusCodeThrowsException(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'PUT',
+                '/memberships/5.xml',
+                'application/xml',
+                '<?xml version="1.0" encoding="UTF-8"?><membership><role_ids>2</role_ids><user_id>4</user_id></membership>',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = Membership::fromHttpClient($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+
+        try {
+            Future::enableForwardCompatibility();
+
+            $api->update(5, ['user_id' => 4, 'role_ids' => 2]);
+        } finally {
+            Future::disableForwardCompatibility();
+        }
     }
 
     /**

--- a/tests/Unit/Api/Project/CreateTest.php
+++ b/tests/Unit/Api/Project/CreateTest.php
@@ -175,7 +175,7 @@ class CreateTest extends TestCase
                 '<?xml version="1.0" encoding="UTF-8"?><project><name>Test Project</name><identifier>test-project</identifier></project>',
                 500,
                 '',
-                'error',
+                '<?xml version="1.0" encoding="UTF-8"?><error>error</error>',
             ],
         );
 
@@ -183,7 +183,7 @@ class CreateTest extends TestCase
 
         $return = $api->create(['identifier' => 'test-project', 'name' => 'Test Project']);
 
-        $this->assertSame('error', $return);
+        $this->assertXmlStringEqualsXmlString('<?xml version="1.0" encoding="UTF-8"?><error>error</error>', $return->asXML());
     }
 
     public function testCreateThrowsExceptionWithEmptyParameters(): void

--- a/tests/Unit/Api/Project/CreateTest.php
+++ b/tests/Unit/Api/Project/CreateTest.php
@@ -164,6 +164,28 @@ class CreateTest extends TestCase
         $this->assertSame('', $return);
     }
 
+    public function testCreateWithIncorrectStatusCodeReturnsBody(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'POST',
+                '/projects.xml',
+                'application/xml',
+                '<?xml version="1.0" encoding="UTF-8"?><project><name>Test Project</name><identifier>test-project</identifier></project>',
+                500,
+                '',
+                'error',
+            ],
+        );
+
+        $api = Project::fromHttpClient($client);
+
+        $return = $api->create(['identifier' => 'test-project', 'name' => 'Test Project']);
+
+        $this->assertSame('error', $return);
+    }
+
     public function testCreateThrowsExceptionWithEmptyParameters(): void
     {
         // Create the used mock objects

--- a/tests/Unit/Api/Project/CreateTest.php
+++ b/tests/Unit/Api/Project/CreateTest.php
@@ -9,6 +9,8 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Project;
 use Redmine\Exception\MissingParameterException;
+use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Http\HttpClient;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 use SimpleXMLElement;
@@ -222,5 +224,33 @@ class CreateTest extends TestCase
                 ],
             ],
         ];
+    }
+
+    public function testCreateWithIncorrectStatusCodeThrowsException(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'POST',
+                '/projects.xml',
+                'application/xml',
+                '<?xml version="1.0" encoding="UTF-8"?><project><name>Test Project</name><identifier>test-project</identifier></project>',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = Project::fromHttpClient($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+
+        try {
+            Future::enableForwardCompatibility();
+
+            $api->create(['identifier' => 'test-project', 'name' => 'Test Project']);
+        } finally {
+            Future::disableForwardCompatibility();
+        }
     }
 }

--- a/tests/Unit/Api/Project/RemoveTest.php
+++ b/tests/Unit/Api/Project/RemoveTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Project;
+use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
 #[CoversClass(Project::class)]
@@ -52,5 +54,53 @@ class RemoveTest extends TestCase
                 '',
             ],
         ];
+    }
+
+    public function testRemoveWithIncorrectStatusCodeReturnsBody(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'DELETE',
+                '/projects/5.xml',
+                'application/xml',
+                '',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = Project::fromHttpClient($client);
+
+        $this->assertSame('', $api->remove(5));
+    }
+
+    public function testRemoveWithIncorrectStatusCodeThrowsException(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'DELETE',
+                '/projects/5.xml',
+                'application/xml',
+                '',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = Project::fromHttpClient($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+
+        try {
+            Future::enableForwardCompatibility();
+
+            $api->remove(5);
+        } finally {
+            Future::disableForwardCompatibility();
+        }
     }
 }

--- a/tests/Unit/Api/Project/UpdateTest.php
+++ b/tests/Unit/Api/Project/UpdateTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Project;
+use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
 #[CoversClass(Project::class)]
@@ -56,5 +58,53 @@ class UpdateTest extends TestCase
                 '',
             ],
         ];
+    }
+
+    public function testUpdateWithIncorrectStatusCodeReturnsBody(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'PUT',
+                '/projects/1.xml',
+                'application/xml',
+                '<?xml version="1.0"?><project><id>1</id></project>',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = Project::fromHttpClient($client);
+
+        $this->assertSame('', $api->update(1, []));
+    }
+
+    public function testUpdateWithIncorrectStatusCodeThrowsException(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'PUT',
+                '/projects/1.xml',
+                'application/xml',
+                '<?xml version="1.0"?><project><id>1</id></project>',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = Project::fromHttpClient($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+
+        try {
+            Future::enableForwardCompatibility();
+
+            $api->update(1, []);
+        } finally {
+            Future::disableForwardCompatibility();
+        }
     }
 }

--- a/tests/Unit/Api/TimeEntry/CreateTest.php
+++ b/tests/Unit/Api/TimeEntry/CreateTest.php
@@ -147,7 +147,7 @@ class CreateTest extends TestCase
                 '<?xml version="1.0" encoding="UTF-8"?><time_entry><issue_id>5</issue_id><hours>5.25</hours></time_entry>',
                 500,
                 '',
-                'error',
+                '<?xml version="1.0" encoding="UTF-8"?><error>error</error>',
             ],
         );
 
@@ -155,7 +155,7 @@ class CreateTest extends TestCase
 
         $return = $api->create(['issue_id' => 5, 'hours' => 5.25]);
 
-        $this->assertSame('error', $return);
+        $this->assertXmlStringEqualsXmlString('<?xml version="1.0" encoding="UTF-8"?><error>error</error>', $return->asXML());
     }
 
     public function testCreateThrowsExceptionWithEmptyParameters(): void

--- a/tests/Unit/Api/TimeEntry/CreateTest.php
+++ b/tests/Unit/Api/TimeEntry/CreateTest.php
@@ -136,6 +136,28 @@ class CreateTest extends TestCase
         $this->assertSame('', $return);
     }
 
+    public function testCreateWithIncorrectStatusCodeReturnsBody(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'POST',
+                '/time_entries.xml',
+                'application/xml',
+                '<?xml version="1.0" encoding="UTF-8"?><time_entry><issue_id>5</issue_id><hours>5.25</hours></time_entry>',
+                500,
+                '',
+                'error',
+            ],
+        );
+
+        $api = TimeEntry::fromHttpClient($client);
+
+        $return = $api->create(['issue_id' => 5, 'hours' => 5.25]);
+
+        $this->assertSame('error', $return);
+    }
+
     public function testCreateThrowsExceptionWithEmptyParameters(): void
     {
         // Test values

--- a/tests/Unit/Api/TimeEntry/CreateTest.php
+++ b/tests/Unit/Api/TimeEntry/CreateTest.php
@@ -9,6 +9,8 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\TimeEntry;
 use Redmine\Exception\MissingParameterException;
+use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Http\HttpClient;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 use SimpleXMLElement;
@@ -198,5 +200,33 @@ class CreateTest extends TestCase
                 ],
             ],
         ];
+    }
+
+    public function testCreateWithIncorrectStatusCodeThrowsException(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'POST',
+                '/time_entries.xml',
+                'application/xml',
+                '<?xml version="1.0" encoding="UTF-8"?><time_entry><issue_id>5</issue_id><hours>5.25</hours></time_entry>',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = TimeEntry::fromHttpClient($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+
+        try {
+            Future::enableForwardCompatibility();
+
+            $api->create(['issue_id' => 5, 'hours' => 5.25]);
+        } finally {
+            Future::disableForwardCompatibility();
+        }
     }
 }

--- a/tests/Unit/Api/TimeEntry/RemoveTest.php
+++ b/tests/Unit/Api/TimeEntry/RemoveTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\TimeEntry;
+use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
 #[CoversClass(TimeEntry::class)]
@@ -52,5 +54,53 @@ class RemoveTest extends TestCase
                 '',
             ],
         ];
+    }
+
+    public function testRemoveWithIncorrectStatusCodeReturnsBody(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'DELETE',
+                '/time_entries/5.xml',
+                'application/xml',
+                '',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = TimeEntry::fromHttpClient($client);
+
+        $this->assertSame('', $api->remove(5));
+    }
+
+    public function testRemoveWithIncorrectStatusCodeThrowsException(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'DELETE',
+                '/time_entries/5.xml',
+                'application/xml',
+                '',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = TimeEntry::fromHttpClient($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+
+        try {
+            Future::enableForwardCompatibility();
+
+            $api->remove(5);
+        } finally {
+            Future::disableForwardCompatibility();
+        }
     }
 }

--- a/tests/Unit/Api/TimeEntry/RemoveTest.php
+++ b/tests/Unit/Api/TimeEntry/RemoveTest.php
@@ -67,13 +67,13 @@ class RemoveTest extends TestCase
                 '',
                 500,
                 '',
-                '',
+                'error',
             ],
         );
 
         $api = TimeEntry::fromHttpClient($client);
 
-        $this->assertSame('', $api->remove(5));
+        $this->assertSame('error', $api->remove(5));
     }
 
     public function testRemoveWithIncorrectStatusCodeThrowsException(): void

--- a/tests/Unit/Api/TimeEntry/UpdateTest.php
+++ b/tests/Unit/Api/TimeEntry/UpdateTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\TimeEntry;
+use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
 #[CoversClass(TimeEntry::class)]
@@ -39,6 +41,54 @@ class UpdateTest extends TestCase
 
         // Perform the tests
         $this->assertSame('', $api->update($id, $parameters));
+    }
+
+    public function testUpdateWithIncorrectStatusCodeReturnsBody(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'PUT',
+                '/time_entries/1.xml',
+                'application/xml',
+                '<?xml version="1.0"?><time_entry><id>1</id><hours>10.25</hours></time_entry>',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = TimeEntry::fromHttpClient($client);
+
+        $this->assertSame('', $api->update(1, ['hours' => '10.25']));
+    }
+
+    public function testUpdateWithIncorrectStatusCodeThrowsException(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'PUT',
+                '/time_entries/1.xml',
+                'application/xml',
+                '<?xml version="1.0"?><time_entry><id>1</id><hours>10.25</hours></time_entry>',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = TimeEntry::fromHttpClient($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+
+        try {
+            Future::enableForwardCompatibility();
+
+            $api->update(1, ['hours' => '10.25']);
+        } finally {
+            Future::disableForwardCompatibility();
+        }
     }
 
     /**

--- a/tests/Unit/Api/User/CreateTest.php
+++ b/tests/Unit/Api/User/CreateTest.php
@@ -123,6 +123,28 @@ class CreateTest extends TestCase
         $this->assertSame('', $return);
     }
 
+    public function testCreateWithIncorrectStatusCodeReturnsBody(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'POST',
+                '/users.xml',
+                'application/xml',
+                '<?xml version="1.0" encoding="UTF-8"?><user><login>user</login><lastname>last</lastname><firstname>first</firstname><mail>mail@example.com</mail></user>',
+                500,
+                '',
+                'error',
+            ],
+        );
+
+        $api = User::fromHttpClient($client);
+
+        $return = $api->create(['login' => 'user', 'lastname' => 'last', 'firstname' => 'first', 'mail' => 'mail@example.com']);
+
+        $this->assertSame('error', $return);
+    }
+
     public function testCreateThrowsExceptionWithEmptyParameters(): void
     {
         // Test values

--- a/tests/Unit/Api/User/CreateTest.php
+++ b/tests/Unit/Api/User/CreateTest.php
@@ -9,6 +9,8 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\User;
 use Redmine\Exception\MissingParameterException;
+use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Http\HttpClient;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 use SimpleXMLElement;
@@ -205,5 +207,33 @@ class CreateTest extends TestCase
                 ],
             ],
         ];
+    }
+
+    public function testCreateWithIncorrectStatusCodeThrowsException(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'POST',
+                '/users.xml',
+                'application/xml',
+                '<?xml version="1.0" encoding="UTF-8"?><user><login>user</login><lastname>last</lastname><firstname>first</firstname><mail>mail@example.com</mail></user>',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = User::fromHttpClient($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+
+        try {
+            Future::enableForwardCompatibility();
+
+            $api->create(['login' => 'user', 'lastname' => 'last', 'firstname' => 'first', 'mail' => 'mail@example.com']);
+        } finally {
+            Future::disableForwardCompatibility();
+        }
     }
 }

--- a/tests/Unit/Api/User/CreateTest.php
+++ b/tests/Unit/Api/User/CreateTest.php
@@ -134,7 +134,7 @@ class CreateTest extends TestCase
                 '<?xml version="1.0" encoding="UTF-8"?><user><login>user</login><lastname>last</lastname><firstname>first</firstname><mail>mail@example.com</mail></user>',
                 500,
                 '',
-                'error',
+                '<?xml version="1.0" encoding="UTF-8"?><error>error</error>',
             ],
         );
 
@@ -142,7 +142,7 @@ class CreateTest extends TestCase
 
         $return = $api->create(['login' => 'user', 'lastname' => 'last', 'firstname' => 'first', 'mail' => 'mail@example.com']);
 
-        $this->assertSame('error', $return);
+        $this->assertXmlStringEqualsXmlString('<?xml version="1.0" encoding="UTF-8"?><error>error</error>', $return->asXML());
     }
 
     public function testCreateThrowsExceptionWithEmptyParameters(): void

--- a/tests/Unit/Api/User/RemoveTest.php
+++ b/tests/Unit/Api/User/RemoveTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\User;
+use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
 #[CoversClass(User::class)]
@@ -52,5 +54,53 @@ class RemoveTest extends TestCase
                 '',
             ],
         ];
+    }
+
+    public function testRemoveWithIncorrectStatusCodeReturnsBody(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'DELETE',
+                '/users/5.xml',
+                'application/xml',
+                '',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = User::fromHttpClient($client);
+
+        $this->assertSame('', $api->remove(5));
+    }
+
+    public function testRemoveWithIncorrectStatusCodeThrowsException(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'DELETE',
+                '/users/5.xml',
+                'application/xml',
+                '',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = User::fromHttpClient($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+
+        try {
+            Future::enableForwardCompatibility();
+
+            $api->remove(5);
+        } finally {
+            Future::disableForwardCompatibility();
+        }
     }
 }

--- a/tests/Unit/Api/User/UpdateTest.php
+++ b/tests/Unit/Api/User/UpdateTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\User;
+use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
 #[CoversClass(User::class)]
@@ -113,5 +115,53 @@ class UpdateTest extends TestCase
                 '',
             ],
         ];
+    }
+
+    public function testUpdateWithIncorrectStatusCodeReturnsBody(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'PUT',
+                '/users/5.xml',
+                'application/xml',
+                '<?xml version="1.0"?><user><id>5</id></user>',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = User::fromHttpClient($client);
+
+        $this->assertSame('', $api->update(5, []));
+    }
+
+    public function testUpdateWithIncorrectStatusCodeThrowsException(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'PUT',
+                '/users/5.xml',
+                'application/xml',
+                '<?xml version="1.0"?><user><id>5</id></user>',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = User::fromHttpClient($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+
+        try {
+            Future::enableForwardCompatibility();
+
+            $api->update(5, []);
+        } finally {
+            Future::disableForwardCompatibility();
+        }
     }
 }

--- a/tests/Unit/Api/Version/CreateTest.php
+++ b/tests/Unit/Api/Version/CreateTest.php
@@ -10,6 +10,8 @@ use PHPUnit\Framework\TestCase;
 use Redmine\Api\Version;
 use Redmine\Exception\InvalidParameterException;
 use Redmine\Exception\MissingParameterException;
+use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Http\HttpClient;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 use SimpleXMLElement;
@@ -216,5 +218,33 @@ class CreateTest extends TestCase
 
         // Perform the tests
         $api->create('test', $parameters);
+    }
+
+    public function testCreateWithIncorrectStatusCodeThrowsException(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'POST',
+                '/projects/5/versions.xml',
+                'application/xml',
+                '<?xml version="1.0" encoding="UTF-8"?><version><name>test</name></version>',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = Version::fromHttpClient($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+
+        try {
+            Future::enableForwardCompatibility();
+
+            $api->create(5, ['name' => 'test']);
+        } finally {
+            Future::disableForwardCompatibility();
+        }
     }
 }

--- a/tests/Unit/Api/Version/CreateTest.php
+++ b/tests/Unit/Api/Version/CreateTest.php
@@ -163,6 +163,28 @@ class CreateTest extends TestCase
         $this->assertSame('', $return);
     }
 
+    public function testCreateWithIncorrectStatusCodeReturnsBody(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'POST',
+                '/projects/5/versions.xml',
+                'application/xml',
+                '<?xml version="1.0" encoding="UTF-8"?><version><name>test</name></version>',
+                500,
+                '',
+                'error',
+            ],
+        );
+
+        $api = Version::fromHttpClient($client);
+
+        $return = $api->create(5, ['name' => 'test']);
+
+        $this->assertSame('error', $return);
+    }
+
     public function testCreateWithEmptyParametersThrowsMissingParameterException(): void
     {
         // Create the used mock objects

--- a/tests/Unit/Api/Version/CreateTest.php
+++ b/tests/Unit/Api/Version/CreateTest.php
@@ -174,7 +174,7 @@ class CreateTest extends TestCase
                 '<?xml version="1.0" encoding="UTF-8"?><version><name>test</name></version>',
                 500,
                 '',
-                'error',
+                '<?xml version="1.0" encoding="UTF-8"?><error>error</error>',
             ],
         );
 
@@ -182,7 +182,7 @@ class CreateTest extends TestCase
 
         $return = $api->create(5, ['name' => 'test']);
 
-        $this->assertSame('error', $return);
+        $this->assertXmlStringEqualsXmlString('<?xml version="1.0" encoding="UTF-8"?><error>error</error>', $return->asXML());
     }
 
     public function testCreateWithEmptyParametersThrowsMissingParameterException(): void

--- a/tests/Unit/Api/Version/RemoveTest.php
+++ b/tests/Unit/Api/Version/RemoveTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Version;
+use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
 #[CoversClass(Version::class)]
@@ -60,5 +62,53 @@ class RemoveTest extends TestCase
                 '',
             ],
         ];
+    }
+
+    public function testRemoveWithIncorrectStatusCodeReturnsBody(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'DELETE',
+                '/versions/5.xml',
+                'application/xml',
+                '',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = Version::fromHttpClient($client);
+
+        $this->assertSame('', $api->remove(5));
+    }
+
+    public function testRemoveWithIncorrectStatusCodeThrowsException(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'DELETE',
+                '/versions/5.xml',
+                'application/xml',
+                '',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = Version::fromHttpClient($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+
+        try {
+            Future::enableForwardCompatibility();
+
+            $api->remove(5);
+        } finally {
+            Future::disableForwardCompatibility();
+        }
     }
 }

--- a/tests/Unit/Api/Version/RemoveTest.php
+++ b/tests/Unit/Api/Version/RemoveTest.php
@@ -75,13 +75,13 @@ class RemoveTest extends TestCase
                 '',
                 500,
                 '',
-                '',
+                'error',
             ],
         );
 
         $api = Version::fromHttpClient($client);
 
-        $this->assertSame('', $api->remove(5));
+        $this->assertSame('error', $api->remove(5));
     }
 
     public function testRemoveWithIncorrectStatusCodeThrowsException(): void

--- a/tests/Unit/Api/Version/UpdateTest.php
+++ b/tests/Unit/Api/Version/UpdateTest.php
@@ -9,6 +9,8 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Version;
 use Redmine\Exception\InvalidParameterException;
+use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Http\HttpClient;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
@@ -222,5 +224,53 @@ class UpdateTest extends TestCase
 
         // Perform the tests
         $api->update(5, $parameters);
+    }
+
+    public function testUpdateWithIncorrectStatusCodeReturnsBody(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'PUT',
+                '/versions/5.xml',
+                'application/xml',
+                '<?xml version="1.0" encoding="UTF-8"?><version></version>',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = Version::fromHttpClient($client);
+
+        $this->assertSame('', $api->update(5, []));
+    }
+
+    public function testUpdateWithIncorrectStatusCodeThrowsException(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'PUT',
+                '/versions/5.xml',
+                'application/xml',
+                '<?xml version="1.0" encoding="UTF-8"?><version></version>',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = Version::fromHttpClient($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+
+        try {
+            Future::enableForwardCompatibility();
+
+            $api->update(5, []);
+        } finally {
+            Future::disableForwardCompatibility();
+        }
     }
 }

--- a/tests/Unit/Api/Wiki/CreateTest.php
+++ b/tests/Unit/Api/Wiki/CreateTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Wiki;
+use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 use SimpleXMLElement;
 
@@ -96,5 +98,53 @@ class CreateTest extends TestCase
                 '<?xml version="1.0" encoding="UTF-8"?><wiki_page></wiki_page>',
             ],
         ];
+    }
+
+    public function testCreateWithIncorrectStatusCodeReturnsBody(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'PUT',
+                '/projects/5/wiki/test.xml',
+                'application/xml',
+                '<?xml version="1.0"?><wiki_page/>',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = Wiki::fromHttpClient($client);
+
+        $this->assertSame('', $api->create(5, 'test', []));
+    }
+
+    public function testCreateWithIncorrectStatusCodeThrowsException(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'PUT',
+                '/projects/5/wiki/test.xml',
+                'application/xml',
+                '<?xml version="1.0"?><wiki_page/>',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = Wiki::fromHttpClient($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+
+        try {
+            Future::enableForwardCompatibility();
+
+            $api->create(5, 'test', []);
+        } finally {
+            Future::disableForwardCompatibility();
+        }
     }
 }

--- a/tests/Unit/Api/Wiki/CreateTest.php
+++ b/tests/Unit/Api/Wiki/CreateTest.php
@@ -111,13 +111,13 @@ class CreateTest extends TestCase
                 '<?xml version="1.0"?><wiki_page/>',
                 500,
                 '',
-                '',
+                'error',
             ],
         );
 
         $api = Wiki::fromHttpClient($client);
 
-        $this->assertSame('', $api->create(5, 'test', []));
+        $this->assertSame('error', $api->create(5, 'test', []));
     }
 
     public function testCreateWithIncorrectStatusCodeThrowsException(): void

--- a/tests/Unit/Api/Wiki/CreateTest.php
+++ b/tests/Unit/Api/Wiki/CreateTest.php
@@ -111,13 +111,15 @@ class CreateTest extends TestCase
                 '<?xml version="1.0"?><wiki_page/>',
                 500,
                 '',
-                'error',
+                '<?xml version="1.0" encoding="UTF-8"?><error>error</error>',
             ],
         );
 
         $api = Wiki::fromHttpClient($client);
 
-        $this->assertSame('error', $api->create(5, 'test', []));
+        $return = $api->create(5, 'test', []);
+
+        $this->assertXmlStringEqualsXmlString('<?xml version="1.0" encoding="UTF-8"?><error>error</error>', $return->asXML());
     }
 
     public function testCreateWithIncorrectStatusCodeThrowsException(): void

--- a/tests/Unit/Api/Wiki/RemoveTest.php
+++ b/tests/Unit/Api/Wiki/RemoveTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Wiki;
+use Redmine\Exception\UnexpectedResponseException;
+use Redmine\Future;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 
 #[CoversClass(Wiki::class)]
@@ -60,5 +62,53 @@ class RemoveTest extends TestCase
                 '',
             ],
         ];
+    }
+
+    public function testRemoveWithIncorrectStatusCodeReturnsBody(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'DELETE',
+                '/projects/5/wiki/test.xml',
+                'application/xml',
+                '',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = Wiki::fromHttpClient($client);
+
+        $this->assertSame('', $api->remove(5, 'test'));
+    }
+
+    public function testRemoveWithIncorrectStatusCodeThrowsException(): void
+    {
+        $client = AssertingHttpClient::create(
+            $this,
+            [
+                'DELETE',
+                '/projects/5/wiki/test.xml',
+                'application/xml',
+                '',
+                500,
+                '',
+                '',
+            ],
+        );
+
+        $api = Wiki::fromHttpClient($client);
+
+        $this->expectException(UnexpectedResponseException::class);
+
+        try {
+            Future::enableForwardCompatibility();
+
+            $api->remove(5, 'test');
+        } finally {
+            Future::disableForwardCompatibility();
+        }
     }
 }

--- a/tests/Unit/Client/NativeCurlClient/EnableFutureModeTest.php
+++ b/tests/Unit/Client/NativeCurlClient/EnableFutureModeTest.php
@@ -16,14 +16,16 @@ final class EnableFutureModeTest extends TestCase
     {
         Future::disableForwardCompatibility();
 
-        $client = new NativeCurlClient(
-            '',
-            '',
-        );
-        $client->enableFutureMode();
+        try {
+            $client = new NativeCurlClient(
+                '',
+                '',
+            );
+            $client->enableFutureMode();
 
-        self::assertTrue(Future::isForwardCompatibilityEnabled());
-
-        Future::disableForwardCompatibility();
+            self::assertTrue(Future::isForwardCompatibilityEnabled());
+        } finally {
+            Future::disableForwardCompatibility();
+        }
     }
 }

--- a/tests/Unit/Client/NativeCurlClient/EnableFutureModeTest.php
+++ b/tests/Unit/Client/NativeCurlClient/EnableFutureModeTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Redmine\Tests\Unit\Client\NativeCurlClient;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Redmine\Client\NativeCurlClient;
+use Redmine\Future;
+
+#[CoversClass(NativeCurlClient::class)]
+final class EnableFutureModeTest extends TestCase
+{
+    public function testEnableFutureModeEnablesFutureMode(): void
+    {
+        Future::disableForwardCompatibility();
+
+        $client = new NativeCurlClient(
+            '',
+            '',
+        );
+        $client->enableFutureMode();
+
+        self::assertTrue(Future::isForwardCompatibilityEnabled());
+
+        Future::disableForwardCompatibility();
+    }
+}

--- a/tests/Unit/Client/Psr18Client/EnableFutureModeTest.php
+++ b/tests/Unit/Client/Psr18Client/EnableFutureModeTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Redmine\Tests\Unit\Client\Psr18Client;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Redmine\Client\Psr18Client;
+use Redmine\Future;
+
+#[CoversClass(Psr18Client::class)]
+final class EnableFutureModeTest extends TestCase
+{
+    public function testEnableFutureModeEnablesFutureMode(): void
+    {
+        Future::disableForwardCompatibility();
+
+        $client = new Psr18Client(
+            $this->createStub(ClientInterface::class),
+            $this->createStub(RequestFactoryInterface::class),
+            $this->createStub(StreamFactoryInterface::class),
+            '',
+            '',
+        );
+        $client->enableFutureMode();
+
+        self::assertTrue(Future::isForwardCompatibilityEnabled());
+
+        Future::disableForwardCompatibility();
+    }
+}

--- a/tests/Unit/Client/Psr18Client/EnableFutureModeTest.php
+++ b/tests/Unit/Client/Psr18Client/EnableFutureModeTest.php
@@ -19,17 +19,19 @@ final class EnableFutureModeTest extends TestCase
     {
         Future::disableForwardCompatibility();
 
-        $client = new Psr18Client(
-            $this->createStub(ClientInterface::class),
-            $this->createStub(RequestFactoryInterface::class),
-            $this->createStub(StreamFactoryInterface::class),
-            '',
-            '',
-        );
-        $client->enableFutureMode();
+        try {
+            $client = new Psr18Client(
+                $this->createStub(ClientInterface::class),
+                $this->createStub(RequestFactoryInterface::class),
+                $this->createStub(StreamFactoryInterface::class),
+                '',
+                '',
+            );
+            $client->enableFutureMode();
 
-        self::assertTrue(Future::isForwardCompatibilityEnabled());
-
-        Future::disableForwardCompatibility();
+            self::assertTrue(Future::isForwardCompatibilityEnabled());
+        } finally {
+            Future::disableForwardCompatibility();
+        }
     }
 }

--- a/tests/Unit/FutureTest.php
+++ b/tests/Unit/FutureTest.php
@@ -13,4 +13,11 @@ final class FutureTest extends TestCase
     {
         self::assertFalse(Future::isForwardCompatibilityEnabled());
     }
+
+    public function testEnableForwardCompatabilityLetIsForwardCompatabilityEnabledReturnsTrue(): void
+    {
+        Future::enableForwardCompatibility();
+
+        self::assertTrue(Future::isForwardCompatibilityEnabled());
+    }
 }

--- a/tests/Unit/FutureTest.php
+++ b/tests/Unit/FutureTest.php
@@ -14,10 +14,17 @@ final class FutureTest extends TestCase
         self::assertFalse(Future::isForwardCompatibilityEnabled());
     }
 
-    public function testEnableForwardCompatabilityLetIsForwardCompatabilityEnabledReturnsTrue(): void
+    public function testEnableForwardCompatabilityLetsIsForwardCompatabilityEnabledReturnTrue(): void
     {
         Future::enableForwardCompatibility();
 
         self::assertTrue(Future::isForwardCompatibilityEnabled());
+    }
+
+    public function testDisableForwardCompatabilityLetsIsForwardCompatabilityEnabledReturnFalse(): void
+    {
+        Future::disableForwardCompatibility();
+
+        self::assertFalse(Future::isForwardCompatibilityEnabled());
     }
 }

--- a/tests/Unit/FutureTest.php
+++ b/tests/Unit/FutureTest.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Redmine\Tests\Unit;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Redmine\Future;
 
+#[CoversClass(Future::class)]
 final class FutureTest extends TestCase
 {
     public function testIsForwardCompatabilityEnabledReturnsFalseByDefault(): void

--- a/tests/Unit/FutureTest.php
+++ b/tests/Unit/FutureTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Redmine\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Redmine\Future;
+
+final class FutureTest extends TestCase
+{
+    public function testIsForwardCompatabilityEnabledReturnsFalseByDefault(): void
+    {
+        self::assertFalse(Future::isForwardCompatibilityEnabled());
+    }
+}

--- a/tests/Unit/FutureTest.php
+++ b/tests/Unit/FutureTest.php
@@ -18,9 +18,13 @@ final class FutureTest extends TestCase
 
     public function testEnableForwardCompatabilityLetsIsForwardCompatabilityEnabledReturnTrue(): void
     {
-        Future::enableForwardCompatibility();
+        try {
+            Future::enableForwardCompatibility();
 
-        self::assertTrue(Future::isForwardCompatibilityEnabled());
+            self::assertTrue(Future::isForwardCompatibilityEnabled());
+        } finally {
+            Future::disableForwardCompatibility();
+        }
     }
 
     public function testDisableForwardCompatabilityLetsIsForwardCompatabilityEnabledReturnFalse(): void


### PR DESCRIPTION
Fixes #367

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in forward-compatibility mode you can enable on API clients.
* **Bug Fixes**
  * API operations now validate expected HTTP success status codes.
  * When responses don’t match expectations, behavior changes based on forward-compatibility: return the response body when off, or throw `UnexpectedResponseException` when on.
* **Tests**
  * Expanded unit tests across attachments, projects, issues, groups, wiki, time entries, user and related endpoints to cover both incorrect-status return-body and exception scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->