### PR TITLE
Issue::update(): allow to unset fixed_version_id (fixes #466)

### DIFF
--- a/src/Redmine/Api/Issue.php
+++ b/src/Redmine/Api/Issue.php
@@ -294,6 +294,11 @@ class Issue extends AbstractApi
             $sanitizedParams['assigned_to_id'] = '';
         }
 
+        // Allow fixed_version_id to be `` (empty string) to unassign a version from an issue
+        if (array_key_exists('fixed_version_id', $params) && '' === $params['fixed_version_id']) {
+            $sanitizedParams['fixed_version_id'] = '';
+        }
+
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeXmlRequest(
             'PUT',
             '/issues/' . urlencode(strval($id)) . '.xml',

--- a/tests/Unit/Api/Issue/UpdateTest.php
+++ b/tests/Unit/Api/Issue/UpdateTest.php
@@ -110,6 +110,38 @@ class UpdateTest extends TestCase
                 204,
                 '',
             ],
+            'test assign fixed_version_id to issue' => [
+                1,
+                [
+                    'fixed_version_id' => 5,
+                ],
+                '/issues/1.xml',
+                <<< XML
+                <?xml version="1.0"?>
+                <issue>
+                    <id>1</id>
+                    <fixed_version_id>5</fixed_version_id>
+                </issue>
+                XML,
+                204,
+                '',
+            ],
+            'test unassign user from issue' => [
+                1,
+                [
+                    'fixed_version_id' => '',
+                ],
+                '/issues/1.xml',
+                <<< XML
+                <?xml version="1.0"?>
+                <issue>
+                    <id>1</id>
+                    <fixed_version_id></fixed_version_id>
+                </issue>
+                XML,
+                204,
+                '',
+            ],
         ];
     }
 

--- a/tests/Unit/Api/Issue/UpdateTest.php
+++ b/tests/Unit/Api/Issue/UpdateTest.php
@@ -126,7 +126,7 @@ class UpdateTest extends TestCase
                 204,
                 '',
             ],
-            'test unassign user from issue' => [
+            'test unassign fixed_version_id from issue' => [
                 1,
                 [
                     'fixed_version_id' => '',


### PR DESCRIPTION
See #466 for details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * You can now unassign a fixed version from an issue by clearing the version field when updating an issue; updates will send an explicit empty value to remove the fixed version.

* **Tests**
  * Added tests covering assigning a fixed version and unassigning it (empty value) to ensure the update payloads and handling behave as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->