### PR TITLE
Housekeeping for v2.10.0-dev

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -9,13 +9,17 @@ $finder = \PhpCsFixer\Finder::create()
     ])
 ;
 
-return (new \PhpCsFixer\Config())->setRules([
+return (new \PhpCsFixer\Config())
+    ->setRules([
         '@PER-CS3x0' => true,
         '@PER-CS3x0:risky' => true,
         '@PHPUnit100Migration:risky' => true,
         'linebreak_after_opening_tag' => true,
         'ordered_imports' => true,
         'no_empty_phpdoc' => true,
+        'no_useless_return' => true,
+        'return_assignment' => true,
+        'simplified_null_return' => true,
         'no_superfluous_phpdoc_tags' => ['allow_mixed' => true],
         'phpdoc_add_missing_param_annotation' => true,
         'phpdoc_indent' => true,

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -17,6 +17,7 @@ return (new \PhpCsFixer\Config())
         'linebreak_after_opening_tag' => true,
         'ordered_imports' => true,
         'no_empty_phpdoc' => true,
+        'no_unused_imports' => true,
         'no_useless_return' => true,
         'return_assignment' => true,
         'simplified_null_return' => true,

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -12,10 +12,13 @@ return $config->setRules([
         '@PER-CS3x0' => true,
         '@PER-CS3x0:risky' => true,
         '@PHPUnit100Migration:risky' => true,
-        'array_syntax' => ['syntax' => 'short'],
         'linebreak_after_opening_tag' => true,
         'ordered_imports' => true,
         'phpdoc_order' => true,
+        'no_empty_phpdoc' => true,
+        'no_superfluous_phpdoc_tags' => ['allow_mixed' => true],
+        'phpdoc_add_missing_param_annotation' => true,
+        'phpdoc_indent' => true,
         'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['arguments', 'arrays']], // Remove this rule after dropping support for PHP 7.4
     ])
     ->setFinder($finder)

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -25,6 +25,12 @@ return (new \PhpCsFixer\Config())->setRules([
         'phpdoc_order' => true,
         'phpdoc_param_order' => true,
         'phpdoc_separation' => ['skip_unlisted_annotations' => false],
+        'phpdoc_trim_consecutive_blank_line_separation' => true,
+        'phpdoc_trim' => true,
+        'phpdoc_types' => true,
+        'phpdoc_types_no_duplicates' => true,
+        'phpdoc_var_annotation_correct_order' => true,
+        'phpdoc_var_without_name' => true,
         'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['arguments', 'arrays']], // Remove this rule after dropping support for PHP 7.4
     ])
     ->setFinder($finder)

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -9,8 +9,8 @@ $finder = PhpCsFixer\Finder::create()
 
 $config = new PhpCsFixer\Config();
 return $config->setRules([
-        '@PER-CS2.0' => true,
-        '@PER-CS2.0:risky' => true,
+        '@PER-CS3x0' => true,
+        '@PER-CS3x0:risky' => true,
         '@PHPUnit100Migration:risky' => true,
         'array_syntax' => ['syntax' => 'short'],
         'linebreak_after_opening_tag' => true,

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,24 +1,30 @@
 <?php
 
-$finder = PhpCsFixer\Finder::create()
+declare(strict_types=1);
+
+$finder = \PhpCsFixer\Finder::create()
     ->in(__DIR__)
     ->exclude([
         'vendor',
     ])
 ;
 
-$config = new PhpCsFixer\Config();
-return $config->setRules([
+return (new \PhpCsFixer\Config())->setRules([
         '@PER-CS3x0' => true,
         '@PER-CS3x0:risky' => true,
         '@PHPUnit100Migration:risky' => true,
         'linebreak_after_opening_tag' => true,
         'ordered_imports' => true,
-        'phpdoc_order' => true,
         'no_empty_phpdoc' => true,
         'no_superfluous_phpdoc_tags' => ['allow_mixed' => true],
         'phpdoc_add_missing_param_annotation' => true,
         'phpdoc_indent' => true,
+        'phpdoc_no_access' => true,
+        'phpdoc_no_empty_return' => true,
+        'phpdoc_order_by_value' => true,
+        'phpdoc_order' => true,
+        'phpdoc_param_order' => true,
+        'phpdoc_separation' => ['skip_unlisted_annotations' => false],
         'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['arguments', 'arrays']], // Remove this rule after dropping support for PHP 7.4
     ])
     ->setFinder($finder)

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -9,11 +9,6 @@ parameters:
 
     ignoreErrors:
         -
-            # Ignore imprecise return types for methods in tests
-            message: '(^Method .+ return type has no.* type specified.+\.$)'
-            path: tests
-            count: 109
-        -
             # Ignore missing return types for methods in tests
             message: '(^Method .+ has no return type specified\.$)'
             path: tests

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -6,10 +6,3 @@ parameters:
         - tests/
 
     treatPhpDocTypesAsCertain: false
-
-    ignoreErrors:
-        -
-            # Ignore missing return types for methods in tests
-            message: '(^Method .+ has no return type specified\.$)'
-            path: tests
-            count: 90

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -9,11 +9,6 @@ parameters:
 
     ignoreErrors:
         -
-            # Ignore missing or imprecise parameter types for methods in tests
-            message: '(^Method .+ has parameter .+ with no.* type specified.*\.$)'
-            path: tests
-            count: 62
-        -
             # Ignore imprecise return types for methods in tests
             message: '(^Method .+ return type has no.* type specified.+\.$)'
             path: tests

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -12,7 +12,7 @@ parameters:
             # Ignore missing or imprecise parameter types for methods in tests
             message: '(^Method .+ has parameter .+ with no.* type specified.*\.$)'
             path: tests
-            count: 163
+            count: 62
         -
             # Ignore imprecise return types for methods in tests
             message: '(^Method .+ return type has no.* type specified.+\.$)'

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -12,12 +12,12 @@ parameters:
             # Ignore missing or imprecise parameter types for methods in tests
             message: '(^Method .+ has parameter .+ with no.* type specified.*\.$)'
             path: tests
-            count: 171
+            count: 163
         -
             # Ignore imprecise return types for methods in tests
             message: '(^Method .+ return type has no.* type specified.+\.$)'
             path: tests
-            count: 118
+            count: 109
         -
             # Ignore missing return types for methods in tests
             message: '(^Method .+ has no return type specified\.$)'

--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -12,11 +12,14 @@ parameters:
             # Ignore missing or imprecise parameter types for methods in tests
             message: '(^Method .+ has parameter .+ with no.* type specified.*\.$)'
             path: tests
+            count: 171
         -
             # Ignore imprecise return types for methods in tests
             message: '(^Method .+ return type has no.* type specified.+\.$)'
             path: tests
+            count: 118
         -
             # Ignore missing return types for methods in tests
             message: '(^Method .+ has no return type specified\.$)'
             path: tests
+            count: 90

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "kbsali/redmine-api",
-    "version": "v2.9.1",
+    "version": "v2.10.0-dev",
     "type": "library",
     "description": "Redmine API client",
     "homepage": "https://github.com/kbsali/php-redmine-api",

--- a/src/Redmine/Api/AbstractApi.php
+++ b/src/Redmine/Api/AbstractApi.php
@@ -235,10 +235,10 @@ abstract class AbstractApi implements Api
     protected function isNotNull($var)
     {
         return
-            false !== $var &&
-            null !== $var &&
-            '' !== $var &&
-            !((is_array($var) || is_object($var)) && empty($var));
+            false !== $var
+            && null !== $var
+            && '' !== $var
+            && !((is_array($var) || is_object($var)) && empty($var));
     }
 
     /**

--- a/src/Redmine/Api/CustomField.php
+++ b/src/Redmine/Api/CustomField.php
@@ -107,7 +107,6 @@ class CustomField extends AbstractApi
      *
      * @deprecated v2.4.0 Use list() instead.
      * @see CustomField::list()
-     *
      * @see http://www.redmine.org/projects/redmine/wiki/Rest_CustomFields#GET
      *
      * @param array<mixed> $params optional parameters to be passed to the api (offset, limit, ...)

--- a/src/Redmine/Api/Group.php
+++ b/src/Redmine/Api/Group.php
@@ -109,7 +109,6 @@ class Group extends AbstractApi
      *
      * @deprecated v2.4.0 Use list() instead.
      * @see Group::list()
-     *
      * @see http://www.redmine.org/projects/redmine/wiki/Rest_Groups#GET
      *
      * @param array<mixed> $params optional parameters to be passed to the api (offset, limit, ...)

--- a/src/Redmine/Api/Group.php
+++ b/src/Redmine/Api/Group.php
@@ -237,7 +237,7 @@ class Group extends AbstractApi
      * available $params :
      * - include: a coma separated list of associations to include in the response: users,memberships
      *
-     * @param int          $id     the group id
+     * @param string|int $id the group id
      * @param array<mixed> $params params to pass to url
      *
      * @return array<mixed>|false|string information about the group as array or false|string on error

--- a/src/Redmine/Api/Issue.php
+++ b/src/Redmine/Api/Issue.php
@@ -140,7 +140,6 @@ class Issue extends AbstractApi
      *
      * @deprecated v2.4.0 Use list() instead.
      * @see Issue::list()
-     *
      * @see http://www.redmine.org/projects/redmine/wiki/Rest_Issues
      * available $params :
      * - offset: skip this number of issues in response (optional)

--- a/src/Redmine/Api/IssueCategory.php
+++ b/src/Redmine/Api/IssueCategory.php
@@ -134,7 +134,6 @@ class IssueCategory extends AbstractApi
      *
      * @deprecated v2.4.0 Use listByProject() instead.
      * @see IssueCategory::listByProject()
-     *
      * @see http://www.redmine.org/projects/redmine/wiki/Rest_IssueCategories#GET
      *
      * @param string|int   $project project id or literal identifier

--- a/src/Redmine/Api/IssueCategory.php
+++ b/src/Redmine/Api/IssueCategory.php
@@ -30,8 +30,8 @@ class IssueCategory extends AbstractApi
     }
 
     /**
-    * @var null|array<mixed>
-    */
+     * @var null|array<mixed>
+     */
     private ?array $issueCategories = null;
 
     /**

--- a/src/Redmine/Api/IssuePriority.php
+++ b/src/Redmine/Api/IssuePriority.php
@@ -73,7 +73,6 @@ class IssuePriority extends AbstractApi
      *
      * @deprecated v2.4.0 Use list() instead.
      * @see IssuePriority::list()
-     *
      * @see http://www.redmine.org/projects/redmine/wiki/Rest_Enumerations#enumerationsissue_prioritiesformat
      *
      * @param array<mixed> $params optional parameters to be passed to the api (offset, limit, ...)

--- a/src/Redmine/Api/IssueRelation.php
+++ b/src/Redmine/Api/IssueRelation.php
@@ -77,7 +77,6 @@ class IssueRelation extends AbstractApi
      *
      * @deprecated v2.4.0 Use listByIssueId() instead.
      * @see IssueRelation::listByIssueId()
-     *
      * @see http://www.redmine.org/projects/redmine/wiki/Rest_IssueRelations#GET
      *
      * @param int          $issueId the issue id

--- a/src/Redmine/Api/IssueStatus.php
+++ b/src/Redmine/Api/IssueStatus.php
@@ -107,7 +107,6 @@ class IssueStatus extends AbstractApi
      *
      * @deprecated v2.4.0 Use list() instead.
      * @see IssueStatus::list()
-     *
      * @see http://www.redmine.org/projects/redmine/wiki/Rest_IssueStatuses#GET
      *
      * @param array<mixed> $params optional parameters to be passed to the api (offset, limit, ...)

--- a/src/Redmine/Api/Membership.php
+++ b/src/Redmine/Api/Membership.php
@@ -87,7 +87,6 @@ class Membership extends AbstractApi
      *
      * @deprecated v2.4.0 Use listByProject() instead.
      * @see Membership::listByProject()
-     *
      * @see http://www.redmine.org/projects/redmine/wiki/Rest_Memberships#GET
      *
      * @param string|int   $project project id or literal identifier

--- a/src/Redmine/Api/News.php
+++ b/src/Redmine/Api/News.php
@@ -102,7 +102,6 @@ class News extends AbstractApi
      * @deprecated v2.4.0 Use list() or listByProject() instead.
      * @see News::list()
      * @see News::listByProject()
-     *
      * @see http://www.redmine.org/projects/redmine/wiki/Rest_News#GET
      *
      * @param string|int   $project project id or literal identifier [optional]

--- a/src/Redmine/Api/Project.php
+++ b/src/Redmine/Api/Project.php
@@ -127,7 +127,6 @@ class Project extends AbstractApi
      *
      * @deprecated v2.4.0 Use list() instead.
      * @see Project::list()
-     *
      * @see http://www.redmine.org/projects/redmine/wiki/Rest_Projects
      *
      * @param array<mixed> $params optional parameters to be passed to the api (offset, limit, ...)

--- a/src/Redmine/Api/Query.php
+++ b/src/Redmine/Api/Query.php
@@ -73,7 +73,6 @@ class Query extends AbstractApi
      *
      * @deprecated v2.4.0 Use list() instead.
      * @see Query::list()
-     *
      * @see http://www.redmine.org/projects/redmine/wiki/Rest_Queries#GET
      *
      * @param array<mixed> $params optional parameters to be passed to the api (offset, limit, ...)

--- a/src/Redmine/Api/Role.php
+++ b/src/Redmine/Api/Role.php
@@ -108,7 +108,6 @@ class Role extends AbstractApi
      *
      * @deprecated v2.4.0 Use list() instead.
      * @see Role::list()
-     *
      * @see http://www.redmine.org/projects/redmine/wiki/Rest_Roles#GET
      *
      * @param array<mixed> $params optional parameters to be passed to the api (offset, limit, ...)

--- a/src/Redmine/Api/Search.php
+++ b/src/Redmine/Api/Search.php
@@ -72,7 +72,6 @@ class Search extends AbstractApi
      *
      * @deprecated v2.4.0 Use listByQuery() instead.
      * @see Search::listByQuery()
-     *
      * @see   http://www.redmine.org/projects/redmine/wiki/Rest_Search
      *
      * @param string        $query  string to search

--- a/src/Redmine/Api/TimeEntry.php
+++ b/src/Redmine/Api/TimeEntry.php
@@ -78,7 +78,6 @@ class TimeEntry extends AbstractApi
      *
      * @deprecated v2.4.0 Use list() instead.
      * @see TimeEntry::list()
-     *
      * @see http://www.redmine.org/projects/redmine/wiki/Rest_TimeEntries
      *
      * @param array<mixed> $params optional parameters to be passed to the api (offset, limit, ...)

--- a/src/Redmine/Api/Tracker.php
+++ b/src/Redmine/Api/Tracker.php
@@ -106,7 +106,6 @@ class Tracker extends AbstractApi
      *
      * @deprecated v2.4.0 Use list() instead.
      * @see Tracker::list()
-     *
      * @see http://www.redmine.org/projects/redmine/wiki/Rest_Trackers#GET
      *
      * @param array<mixed> $params optional parameters to be passed to the api (offset, limit, ...)

--- a/src/Redmine/Api/User.php
+++ b/src/Redmine/Api/User.php
@@ -126,7 +126,6 @@ class User extends AbstractApi
      *
      * @deprecated v2.4.0 Use list() instead.
      * @see User::list()
-     *
      * @see http://www.redmine.org/projects/redmine/wiki/Rest_Users#GET
      *
      * @param array<mixed> $params to allow offset/limit (and more) to be passed

--- a/src/Redmine/Api/Version.php
+++ b/src/Redmine/Api/Version.php
@@ -132,7 +132,6 @@ class Version extends AbstractApi
      *
      * @deprecated v2.4.0 Use listByProject() instead.
      * @see Version::listByProject()
-     *
      * @see http://www.redmine.org/projects/redmine/wiki/Rest_Versions#GET
      *
      * @param string|int   $project project id or literal identifier

--- a/src/Redmine/Api/Wiki.php
+++ b/src/Redmine/Api/Wiki.php
@@ -87,7 +87,6 @@ class Wiki extends AbstractApi
      *
      * @deprecated v2.4.0 Use listByProject() instead.
      * @see Wiki::listByProject()
-     *
      * @see http://www.redmine.org/projects/redmine/wiki/Rest_WikiPages#Getting-the-pages-list-of-a-wiki
      *
      * @param int|string   $project project name

--- a/tests/Behat/Bootstrap/AttachmentContextTrait.php
+++ b/tests/Behat/Bootstrap/AttachmentContextTrait.php
@@ -12,7 +12,7 @@ trait AttachmentContextTrait
     /**
      * @When I upload the content of the file :filepath with the following data
      */
-    public function iUploadTheContentOfTheFileWithTheFollowingData(string $filepath, TableNode $table)
+    public function iUploadTheContentOfTheFileWithTheFollowingData(string $filepath, TableNode $table): void
     {
         $data = [];
 
@@ -34,7 +34,7 @@ trait AttachmentContextTrait
     /**
      * @When I update the attachment with the id :attachmentId with the following data
      */
-    public function iUpdateTheAttachmentWithTheIdWithTheFollowingData(int $attachmentId, TableNode $table)
+    public function iUpdateTheAttachmentWithTheIdWithTheFollowingData(int $attachmentId, TableNode $table): void
     {
         $data = [];
 
@@ -54,7 +54,7 @@ trait AttachmentContextTrait
     /**
      * @When I show the attachment with the id :attachmentId
      */
-    public function iShowTheAttachmentWithTheId(int $attachmentId)
+    public function iShowTheAttachmentWithTheId(int $attachmentId): void
     {
         /** @var Attachment */
         $api = $this->getNativeCurlClient()->getApi('attachment');
@@ -68,7 +68,7 @@ trait AttachmentContextTrait
     /**
      * @When I download the attachment with the id :attachmentId
      */
-    public function iDownloadTheAttachmentWithTheId(int $attachmentId)
+    public function iDownloadTheAttachmentWithTheId(int $attachmentId): void
     {
         /** @var Attachment */
         $api = $this->getNativeCurlClient()->getApi('attachment');
@@ -84,7 +84,7 @@ trait AttachmentContextTrait
      *
      * @param mixed $attachmentId
      */
-    public function iRemoveTheAttachmentWithTheId($attachmentId)
+    public function iRemoveTheAttachmentWithTheId($attachmentId): void
     {
         /** @var Attachment */
         $api = $this->getNativeCurlClient()->getApi('attachment');

--- a/tests/Behat/Bootstrap/AttachmentContextTrait.php
+++ b/tests/Behat/Bootstrap/AttachmentContextTrait.php
@@ -81,6 +81,7 @@ trait AttachmentContextTrait
 
     /**
      * @When I remove the attachment with the id :attachmentId
+     * @param mixed $attachmentId
      */
     public function iRemoveTheAttachmentWithTheId($attachmentId)
     {

--- a/tests/Behat/Bootstrap/AttachmentContextTrait.php
+++ b/tests/Behat/Bootstrap/AttachmentContextTrait.php
@@ -81,6 +81,7 @@ trait AttachmentContextTrait
 
     /**
      * @When I remove the attachment with the id :attachmentId
+     *
      * @param mixed $attachmentId
      */
     public function iRemoveTheAttachmentWithTheId($attachmentId)

--- a/tests/Behat/Bootstrap/CustomFieldContextTrait.php
+++ b/tests/Behat/Bootstrap/CustomFieldContextTrait.php
@@ -13,7 +13,7 @@ trait CustomFieldContextTrait
      *
      * @param mixed $customFieldName
      */
-    public function iCreateACustomFieldForIssuesWithTheName($customFieldName)
+    public function iCreateACustomFieldForIssuesWithTheName($customFieldName): void
     {
         // support for creating custom fields via REST API is missing
         $this->redmine->excecuteDatabaseQuery(
@@ -36,7 +36,7 @@ trait CustomFieldContextTrait
      * @param mixed $trackerId
      * @param mixed $customFieldId
      */
-    public function iEnableTheTrackerWithIdForCustomFieldWithId($trackerId, $customFieldId)
+    public function iEnableTheTrackerWithIdForCustomFieldWithId($trackerId, $customFieldId): void
     {
         // support for enabling custom fields for trackers via REST API is missing
         $this->redmine->excecuteDatabaseQuery(
@@ -52,7 +52,7 @@ trait CustomFieldContextTrait
     /**
      * @When I list all custom fields
      */
-    public function iListAllCustomFields()
+    public function iListAllCustomFields(): void
     {
         /** @var CustomField */
         $api = $this->getNativeCurlClient()->getApi('custom_fields');
@@ -66,7 +66,7 @@ trait CustomFieldContextTrait
     /**
      * @When I list all custom field names
      */
-    public function iListAllCustomFieldNames()
+    public function iListAllCustomFieldNames(): void
     {
         /** @var CustomField */
         $api = $this->getNativeCurlClient()->getApi('custom_fields');

--- a/tests/Behat/Bootstrap/CustomFieldContextTrait.php
+++ b/tests/Behat/Bootstrap/CustomFieldContextTrait.php
@@ -10,6 +10,7 @@ trait CustomFieldContextTrait
 {
     /**
      * @Given I create a custom field for issues with the name :customFieldName
+     * @param mixed $customFieldName
      */
     public function iCreateACustomFieldForIssuesWithTheName($customFieldName)
     {
@@ -30,6 +31,8 @@ trait CustomFieldContextTrait
 
     /**
      * @Given I enable the tracker with ID :trackerId for custom field with ID :customFieldId
+     * @param mixed $trackerId
+     * @param mixed $customFieldId
      */
     public function iEnableTheTrackerWithIdForCustomFieldWithId($trackerId, $customFieldId)
     {

--- a/tests/Behat/Bootstrap/CustomFieldContextTrait.php
+++ b/tests/Behat/Bootstrap/CustomFieldContextTrait.php
@@ -10,6 +10,7 @@ trait CustomFieldContextTrait
 {
     /**
      * @Given I create a custom field for issues with the name :customFieldName
+     *
      * @param mixed $customFieldName
      */
     public function iCreateACustomFieldForIssuesWithTheName($customFieldName)
@@ -31,6 +32,7 @@ trait CustomFieldContextTrait
 
     /**
      * @Given I enable the tracker with ID :trackerId for custom field with ID :customFieldId
+     *
      * @param mixed $trackerId
      * @param mixed $customFieldId
      */

--- a/tests/Behat/Bootstrap/FeatureContext.php
+++ b/tests/Behat/Bootstrap/FeatureContext.php
@@ -348,6 +348,9 @@ final class FeatureContext implements Context
         }
     }
 
+    /**
+     * @return array<mixed>
+     */
     private function getLastReturnAsArray(): array
     {
         if (isset($this->lastReturnAsArray)) {

--- a/tests/Behat/Bootstrap/FeatureContext.php
+++ b/tests/Behat/Bootstrap/FeatureContext.php
@@ -97,6 +97,7 @@ final class FeatureContext implements Context
 
     /**
      * @Given I have a :clientName client
+     * @param mixed $clientName
      */
     public function iHaveAClient($clientName): void
     {

--- a/tests/Behat/Bootstrap/FeatureContext.php
+++ b/tests/Behat/Bootstrap/FeatureContext.php
@@ -383,6 +383,8 @@ final class FeatureContext implements Context
      * Get item from an array by key supporting "dot" notation.
      *
      * @param array<mixed> $array
+     *
+     * @return mixed
      */
     private function getItemFromArray(array $array, ?string $key)
     {

--- a/tests/Behat/Bootstrap/FeatureContext.php
+++ b/tests/Behat/Bootstrap/FeatureContext.php
@@ -97,6 +97,7 @@ final class FeatureContext implements Context
 
     /**
      * @Given I have a :clientName client
+     *
      * @param mixed $clientName
      */
     public function iHaveAClient($clientName): void

--- a/tests/Behat/Bootstrap/FeatureContext.php
+++ b/tests/Behat/Bootstrap/FeatureContext.php
@@ -117,6 +117,9 @@ final class FeatureContext implements Context
         return $this->client;
     }
 
+    /**
+     * @param mixed $lastReturn
+     */
     private function registerClientResponse($lastReturn, Response $lastResponse): void
     {
         unset($this->lastReturnAsArray);
@@ -375,6 +378,8 @@ final class FeatureContext implements Context
 
     /**
      * Get item from an array by key supporting "dot" notation.
+     *
+     * @param array<mixed> $array
      */
     private function getItemFromArray(array $array, ?string $key)
     {
@@ -393,6 +398,9 @@ final class FeatureContext implements Context
         return $array;
     }
 
+    /**
+     * @param array<mixed> $data
+     */
     private function assertTableNodeIsSameAsArray(TableNode $table, array $data): void
     {
         foreach ($table as $row) {

--- a/tests/Behat/Bootstrap/GroupContextTrait.php
+++ b/tests/Behat/Bootstrap/GroupContextTrait.php
@@ -107,6 +107,8 @@ trait GroupContextTrait
 
     /**
      * @When I add the user with id :userId to the group with id :groupId
+     * @param mixed $userId
+     * @param mixed $groupId
      */
     public function iAddTheUserWithIdToTheGroupWithId($userId, $groupId)
     {
@@ -121,6 +123,8 @@ trait GroupContextTrait
 
     /**
      * @When I remove the user with id :userId from the group with id :groupId
+     * @param mixed $userId
+     * @param mixed $groupId
      */
     public function iRemoveTheUserWithIdFromTheGroupWithId($userId, $groupId)
     {
@@ -135,6 +139,7 @@ trait GroupContextTrait
 
     /**
      * @When I remove the group with id :groupId
+     * @param mixed $groupId
      */
     public function iRemoveTheGroupWithId($groupId)
     {

--- a/tests/Behat/Bootstrap/GroupContextTrait.php
+++ b/tests/Behat/Bootstrap/GroupContextTrait.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Redmine\Tests\Behat\Bootstrap;
 
-use Behat\Behat\Tester\Exception\PendingException;
 use Behat\Gherkin\Node\TableNode;
 use Redmine\Api\Group;
 

--- a/tests/Behat/Bootstrap/GroupContextTrait.php
+++ b/tests/Behat/Bootstrap/GroupContextTrait.php
@@ -13,7 +13,7 @@ trait GroupContextTrait
     /**
      * @When I create a group with name :groupName
      */
-    public function iCreateAGroupWithName(string $groupName)
+    public function iCreateAGroupWithName(string $groupName): void
     {
         $table = new TableNode([
             ['property', 'value'],
@@ -26,7 +26,7 @@ trait GroupContextTrait
     /**
      * @When I create a group with the following data
      */
-    public function iCreateAGroupWithTheFollowingData(TableNode $table)
+    public function iCreateAGroupWithTheFollowingData(TableNode $table): void
     {
         $data = [];
 
@@ -46,7 +46,7 @@ trait GroupContextTrait
     /**
      * @When I list all groups
      */
-    public function iListAllGroups()
+    public function iListAllGroups(): void
     {
         /** @var Group */
         $api = $this->getNativeCurlClient()->getApi('group');
@@ -60,7 +60,7 @@ trait GroupContextTrait
     /**
      * @When I list the names of all groups
      */
-    public function iListTheNamesOfAllGroups()
+    public function iListTheNamesOfAllGroups(): void
     {
         /** @var Group */
         $api = $this->getNativeCurlClient()->getApi('group');
@@ -74,7 +74,7 @@ trait GroupContextTrait
     /**
      * @When I show the group with id :groupId
      */
-    public function iShowTheGroupWithId(int $groupId)
+    public function iShowTheGroupWithId(int $groupId): void
     {
         /** @var Group */
         $api = $this->getNativeCurlClient()->getApi('group');
@@ -88,7 +88,7 @@ trait GroupContextTrait
     /**
      * @When I update the group with id :groupId with the following data
      */
-    public function iUpdateTheGroupWithIdWithTheFollowingData(int $groupId, TableNode $table)
+    public function iUpdateTheGroupWithIdWithTheFollowingData(int $groupId, TableNode $table): void
     {
         $data = [];
 
@@ -111,7 +111,7 @@ trait GroupContextTrait
      * @param mixed $userId
      * @param mixed $groupId
      */
-    public function iAddTheUserWithIdToTheGroupWithId($userId, $groupId)
+    public function iAddTheUserWithIdToTheGroupWithId($userId, $groupId): void
     {
         /** @var Group */
         $api = $this->getNativeCurlClient()->getApi('group');
@@ -128,7 +128,7 @@ trait GroupContextTrait
      * @param mixed $userId
      * @param mixed $groupId
      */
-    public function iRemoveTheUserWithIdFromTheGroupWithId($userId, $groupId)
+    public function iRemoveTheUserWithIdFromTheGroupWithId($userId, $groupId): void
     {
         /** @var Group */
         $api = $this->getNativeCurlClient()->getApi('group');
@@ -144,7 +144,7 @@ trait GroupContextTrait
      *
      * @param mixed $groupId
      */
-    public function iRemoveTheGroupWithId($groupId)
+    public function iRemoveTheGroupWithId($groupId): void
     {
         /** @var Group */
         $api = $this->getNativeCurlClient()->getApi('group');

--- a/tests/Behat/Bootstrap/GroupContextTrait.php
+++ b/tests/Behat/Bootstrap/GroupContextTrait.php
@@ -107,6 +107,7 @@ trait GroupContextTrait
 
     /**
      * @When I add the user with id :userId to the group with id :groupId
+     *
      * @param mixed $userId
      * @param mixed $groupId
      */
@@ -123,6 +124,7 @@ trait GroupContextTrait
 
     /**
      * @When I remove the user with id :userId from the group with id :groupId
+     *
      * @param mixed $userId
      * @param mixed $groupId
      */
@@ -139,6 +141,7 @@ trait GroupContextTrait
 
     /**
      * @When I remove the group with id :groupId
+     *
      * @param mixed $groupId
      */
     public function iRemoveTheGroupWithId($groupId)

--- a/tests/Behat/Bootstrap/IssueCategoryContextTrait.php
+++ b/tests/Behat/Bootstrap/IssueCategoryContextTrait.php
@@ -11,6 +11,7 @@ trait IssueCategoryContextTrait
 {
     /**
      * @Given I create :count issue categories for project identifier :identifier
+     * @param mixed $identifier
      */
     public function iCreateIssueCategoriesForProjectIdentifier(int $count, $identifier)
     {
@@ -26,6 +27,8 @@ trait IssueCategoryContextTrait
 
     /**
      * @When I create an issue category for project identifier :identifier and with the name :name
+     * @param mixed $identifier
+     * @param mixed $name
      */
     public function iCreateAnIssueCategoryForProjectIdentifierAndWithTheName($identifier, $name)
     {
@@ -39,6 +42,7 @@ trait IssueCategoryContextTrait
 
     /**
      * @When I create an issue category for project identifier :identifier and with the following data
+     * @param mixed $identifier
      */
     public function iCreateAnIssueCategoryForProjectIdentifierAndWithTheFollowingData($identifier, TableNode $table)
     {
@@ -59,6 +63,7 @@ trait IssueCategoryContextTrait
 
     /**
      * @When I list all issue categories for project identifier :identifier
+     * @param mixed $identifier
      */
     public function iListAllIssueCategoriesForProjectIdentifier($identifier)
     {
@@ -73,6 +78,7 @@ trait IssueCategoryContextTrait
 
     /**
      * @When I list all issue category names for project identifier :identifier
+     * @param mixed $identifier
      */
     public function iListAllIssueCategoryNamesForProjectIdentifier($identifier)
     {
@@ -87,6 +93,7 @@ trait IssueCategoryContextTrait
 
     /**
      * @When I update the issue category with id :id and the following data
+     * @param mixed $id
      */
     public function iUpdateTheIssueCategoryWithIdAndTheFollowingData($id, TableNode $table)
     {
@@ -107,6 +114,7 @@ trait IssueCategoryContextTrait
 
     /**
      * @When I remove the issue category with id :id
+     * @param mixed $id
      */
     public function iRemoveTheIssueCategoryWithId($id)
     {

--- a/tests/Behat/Bootstrap/IssueCategoryContextTrait.php
+++ b/tests/Behat/Bootstrap/IssueCategoryContextTrait.php
@@ -11,6 +11,7 @@ trait IssueCategoryContextTrait
 {
     /**
      * @Given I create :count issue categories for project identifier :identifier
+     *
      * @param mixed $identifier
      */
     public function iCreateIssueCategoriesForProjectIdentifier(int $count, $identifier)
@@ -27,6 +28,7 @@ trait IssueCategoryContextTrait
 
     /**
      * @When I create an issue category for project identifier :identifier and with the name :name
+     *
      * @param mixed $identifier
      * @param mixed $name
      */
@@ -42,6 +44,7 @@ trait IssueCategoryContextTrait
 
     /**
      * @When I create an issue category for project identifier :identifier and with the following data
+     *
      * @param mixed $identifier
      */
     public function iCreateAnIssueCategoryForProjectIdentifierAndWithTheFollowingData($identifier, TableNode $table)
@@ -63,6 +66,7 @@ trait IssueCategoryContextTrait
 
     /**
      * @When I list all issue categories for project identifier :identifier
+     *
      * @param mixed $identifier
      */
     public function iListAllIssueCategoriesForProjectIdentifier($identifier)
@@ -78,6 +82,7 @@ trait IssueCategoryContextTrait
 
     /**
      * @When I list all issue category names for project identifier :identifier
+     *
      * @param mixed $identifier
      */
     public function iListAllIssueCategoryNamesForProjectIdentifier($identifier)
@@ -93,6 +98,7 @@ trait IssueCategoryContextTrait
 
     /**
      * @When I update the issue category with id :id and the following data
+     *
      * @param mixed $id
      */
     public function iUpdateTheIssueCategoryWithIdAndTheFollowingData($id, TableNode $table)
@@ -114,6 +120,7 @@ trait IssueCategoryContextTrait
 
     /**
      * @When I remove the issue category with id :id
+     *
      * @param mixed $id
      */
     public function iRemoveTheIssueCategoryWithId($id)

--- a/tests/Behat/Bootstrap/IssueCategoryContextTrait.php
+++ b/tests/Behat/Bootstrap/IssueCategoryContextTrait.php
@@ -14,7 +14,7 @@ trait IssueCategoryContextTrait
      *
      * @param mixed $identifier
      */
-    public function iCreateIssueCategoriesForProjectIdentifier(int $count, $identifier)
+    public function iCreateIssueCategoriesForProjectIdentifier(int $count, $identifier): void
     {
         while ($count > 0) {
             $this->iCreateAnIssueCategoryForProjectIdentifierAndWithTheName(
@@ -32,7 +32,7 @@ trait IssueCategoryContextTrait
      * @param mixed $identifier
      * @param mixed $name
      */
-    public function iCreateAnIssueCategoryForProjectIdentifierAndWithTheName($identifier, $name)
+    public function iCreateAnIssueCategoryForProjectIdentifierAndWithTheName($identifier, $name): void
     {
         $table = new TableNode([
             ['property', 'value'],
@@ -47,7 +47,7 @@ trait IssueCategoryContextTrait
      *
      * @param mixed $identifier
      */
-    public function iCreateAnIssueCategoryForProjectIdentifierAndWithTheFollowingData($identifier, TableNode $table)
+    public function iCreateAnIssueCategoryForProjectIdentifierAndWithTheFollowingData($identifier, TableNode $table): void
     {
         $data = [];
 
@@ -69,7 +69,7 @@ trait IssueCategoryContextTrait
      *
      * @param mixed $identifier
      */
-    public function iListAllIssueCategoriesForProjectIdentifier($identifier)
+    public function iListAllIssueCategoriesForProjectIdentifier($identifier): void
     {
         /** @var IssueCategory */
         $api = $this->getNativeCurlClient()->getApi('issue_category');
@@ -85,7 +85,7 @@ trait IssueCategoryContextTrait
      *
      * @param mixed $identifier
      */
-    public function iListAllIssueCategoryNamesForProjectIdentifier($identifier)
+    public function iListAllIssueCategoryNamesForProjectIdentifier($identifier): void
     {
         /** @var IssueCategory */
         $api = $this->getNativeCurlClient()->getApi('issue_category');
@@ -101,7 +101,7 @@ trait IssueCategoryContextTrait
      *
      * @param mixed $id
      */
-    public function iUpdateTheIssueCategoryWithIdAndTheFollowingData($id, TableNode $table)
+    public function iUpdateTheIssueCategoryWithIdAndTheFollowingData($id, TableNode $table): void
     {
         $data = [];
 
@@ -123,7 +123,7 @@ trait IssueCategoryContextTrait
      *
      * @param mixed $id
      */
-    public function iRemoveTheIssueCategoryWithId($id)
+    public function iRemoveTheIssueCategoryWithId($id): void
     {
         /** @var IssueCategory */
         $api = $this->getNativeCurlClient()->getApi('issue_category');

--- a/tests/Behat/Bootstrap/IssueContextTrait.php
+++ b/tests/Behat/Bootstrap/IssueContextTrait.php
@@ -110,6 +110,9 @@ trait IssueContextTrait
         );
     }
 
+    /**
+     * @return array<mixed>
+     */
     private function prepareIssueData(TableNode $table): array
     {
         $data = [];

--- a/tests/Behat/Bootstrap/IssueContextTrait.php
+++ b/tests/Behat/Bootstrap/IssueContextTrait.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Redmine\Tests\Behat\Bootstrap;
 
-use Behat\Behat\Tester\Exception\PendingException;
 use Behat\Gherkin\Node\TableNode;
 use Redmine\Api\Issue;
 

--- a/tests/Behat/Bootstrap/IssueContextTrait.php
+++ b/tests/Behat/Bootstrap/IssueContextTrait.php
@@ -13,7 +13,7 @@ trait IssueContextTrait
     /**
      * @When I create an issue with the following data
      */
-    public function iCreateAnIssueWithTheFollowingData(TableNode $table)
+    public function iCreateAnIssueWithTheFollowingData(TableNode $table): void
     {
         $data = $this->prepareIssueData($table);
 
@@ -31,7 +31,7 @@ trait IssueContextTrait
      *
      * @param mixed $issueId
      */
-    public function iUpdateTheIssueWithIdAndTheFollowingData($issueId, TableNode $table)
+    public function iUpdateTheIssueWithIdAndTheFollowingData($issueId, TableNode $table): void
     {
         $data = $this->prepareIssueData($table);
 
@@ -49,7 +49,7 @@ trait IssueContextTrait
      *
      * @param mixed $issueId
      */
-    public function iShowTheIssueWithId($issueId)
+    public function iShowTheIssueWithId($issueId): void
     {
         /** @var Issue */
         $api = $this->getNativeCurlClient()->getApi('issue');
@@ -66,7 +66,7 @@ trait IssueContextTrait
      * @param mixed $userId
      * @param mixed $issueId
      */
-    public function iAddTheUserIdAsAWatcherToTheIssueWithId($userId, $issueId)
+    public function iAddTheUserIdAsAWatcherToTheIssueWithId($userId, $issueId): void
     {
         /** @var Issue */
         $api = $this->getNativeCurlClient()->getApi('issue');
@@ -83,7 +83,7 @@ trait IssueContextTrait
      * @param mixed $userId
      * @param mixed $issueId
      */
-    public function iRemoveTheUserIdAsAWatcherFromTheIssueWithId($userId, $issueId)
+    public function iRemoveTheUserIdAsAWatcherFromTheIssueWithId($userId, $issueId): void
     {
         /** @var Issue */
         $api = $this->getNativeCurlClient()->getApi('issue');
@@ -99,7 +99,7 @@ trait IssueContextTrait
      *
      * @param mixed $issueId
      */
-    public function iRemoveTheIssueWithId($issueId)
+    public function iRemoveTheIssueWithId($issueId): void
     {
         /** @var Issue */
         $api = $this->getNativeCurlClient()->getApi('issue');

--- a/tests/Behat/Bootstrap/IssueContextTrait.php
+++ b/tests/Behat/Bootstrap/IssueContextTrait.php
@@ -28,6 +28,7 @@ trait IssueContextTrait
 
     /**
      * @When I update the issue with id :issueId and the following data
+     * @param mixed $issueId
      */
     public function iUpdateTheIssueWithIdAndTheFollowingData($issueId, TableNode $table)
     {
@@ -44,6 +45,7 @@ trait IssueContextTrait
 
     /**
      * @When I show the issue with id :issueId
+     * @param mixed $issueId
      */
     public function iShowTheIssueWithId($issueId)
     {
@@ -58,6 +60,8 @@ trait IssueContextTrait
 
     /**
      * @When I add the user id :userId as a watcher to the issue with id :issueId
+     * @param mixed $userId
+     * @param mixed $issueId
      */
     public function iAddTheUserIdAsAWatcherToTheIssueWithId($userId, $issueId)
     {
@@ -72,6 +76,8 @@ trait IssueContextTrait
 
     /**
      * @When I remove the user id :userId as a watcher from the issue with id :issueId
+     * @param mixed $userId
+     * @param mixed $issueId
      */
     public function iRemoveTheUserIdAsAWatcherFromTheIssueWithId($userId, $issueId)
     {
@@ -86,6 +92,7 @@ trait IssueContextTrait
 
     /**
      * @When I remove the issue with id :issueId
+     * @param mixed $issueId
      */
     public function iRemoveTheIssueWithId($issueId)
     {

--- a/tests/Behat/Bootstrap/IssueContextTrait.php
+++ b/tests/Behat/Bootstrap/IssueContextTrait.php
@@ -28,6 +28,7 @@ trait IssueContextTrait
 
     /**
      * @When I update the issue with id :issueId and the following data
+     *
      * @param mixed $issueId
      */
     public function iUpdateTheIssueWithIdAndTheFollowingData($issueId, TableNode $table)
@@ -45,6 +46,7 @@ trait IssueContextTrait
 
     /**
      * @When I show the issue with id :issueId
+     *
      * @param mixed $issueId
      */
     public function iShowTheIssueWithId($issueId)
@@ -60,6 +62,7 @@ trait IssueContextTrait
 
     /**
      * @When I add the user id :userId as a watcher to the issue with id :issueId
+     *
      * @param mixed $userId
      * @param mixed $issueId
      */
@@ -76,6 +79,7 @@ trait IssueContextTrait
 
     /**
      * @When I remove the user id :userId as a watcher from the issue with id :issueId
+     *
      * @param mixed $userId
      * @param mixed $issueId
      */
@@ -92,6 +96,7 @@ trait IssueContextTrait
 
     /**
      * @When I remove the issue with id :issueId
+     *
      * @param mixed $issueId
      */
     public function iRemoveTheIssueWithId($issueId)

--- a/tests/Behat/Bootstrap/IssuePriorityContextTrait.php
+++ b/tests/Behat/Bootstrap/IssuePriorityContextTrait.php
@@ -9,7 +9,7 @@ trait IssuePriorityContextTrait
     /**
      * @Given I have an issue priority with the name :priority
      */
-    public function iHaveAnIssuePriorityWithTheName(string $priority)
+    public function iHaveAnIssuePriorityWithTheName(string $priority): void
     {
         // support for creating time entry activity via REST API is missing
         $this->redmine->excecuteDatabaseQuery(

--- a/tests/Behat/Bootstrap/IssueRelationContextTrait.php
+++ b/tests/Behat/Bootstrap/IssueRelationContextTrait.php
@@ -12,7 +12,7 @@ trait IssueRelationContextTrait
     /**
      * @When I create an issue relation for issue id :issueId with the following data
      */
-    public function iCreateAnIssueRelationForIssueIdWithTheFollowingData(int $issueId, TableNode $table)
+    public function iCreateAnIssueRelationForIssueIdWithTheFollowingData(int $issueId, TableNode $table): void
     {
         $data = [];
 
@@ -34,7 +34,7 @@ trait IssueRelationContextTrait
      *
      * @param mixed $relationId
      */
-    public function iDeleteTheIssueRelationWithTheId($relationId)
+    public function iDeleteTheIssueRelationWithTheId($relationId): void
     {
         /** @var IssueRelation */
         $api = $this->getNativeCurlClient()->getApi('issue_relation');

--- a/tests/Behat/Bootstrap/IssueRelationContextTrait.php
+++ b/tests/Behat/Bootstrap/IssueRelationContextTrait.php
@@ -31,6 +31,7 @@ trait IssueRelationContextTrait
 
     /**
      * @When I delete the issue relation with the id :relationId
+     * @param mixed $relationId
      */
     public function iDeleteTheIssueRelationWithTheId($relationId)
     {

--- a/tests/Behat/Bootstrap/IssueRelationContextTrait.php
+++ b/tests/Behat/Bootstrap/IssueRelationContextTrait.php
@@ -31,6 +31,7 @@ trait IssueRelationContextTrait
 
     /**
      * @When I delete the issue relation with the id :relationId
+     *
      * @param mixed $relationId
      */
     public function iDeleteTheIssueRelationWithTheId($relationId)

--- a/tests/Behat/Bootstrap/IssueStatusContextTrait.php
+++ b/tests/Behat/Bootstrap/IssueStatusContextTrait.php
@@ -13,7 +13,7 @@ trait IssueStatusContextTrait
      *
      * @param mixed $issueStatusName
      */
-    public function iHaveAnIssueStatusWithTheName($issueStatusName)
+    public function iHaveAnIssueStatusWithTheName($issueStatusName): void
     {
         // support for creating issue status via REST API is missing
         $this->redmine->excecuteDatabaseQuery(
@@ -30,7 +30,7 @@ trait IssueStatusContextTrait
     /**
      * @When I list all issue statuses
      */
-    public function iListAllIssueStatuses()
+    public function iListAllIssueStatuses(): void
     {
         /** @var IssueStatus */
         $api = $this->getNativeCurlClient()->getApi('issue_status');
@@ -44,7 +44,7 @@ trait IssueStatusContextTrait
     /**
      * @When I list all issue status names
      */
-    public function iListAllIssueStatusNames()
+    public function iListAllIssueStatusNames(): void
     {
         /** @var IssueStatus */
         $api = $this->getNativeCurlClient()->getApi('issue_status');

--- a/tests/Behat/Bootstrap/IssueStatusContextTrait.php
+++ b/tests/Behat/Bootstrap/IssueStatusContextTrait.php
@@ -10,6 +10,7 @@ trait IssueStatusContextTrait
 {
     /**
      * @Given I have an issue status with the name :issueStatusName
+     *
      * @param mixed $issueStatusName
      */
     public function iHaveAnIssueStatusWithTheName($issueStatusName)

--- a/tests/Behat/Bootstrap/IssueStatusContextTrait.php
+++ b/tests/Behat/Bootstrap/IssueStatusContextTrait.php
@@ -10,6 +10,7 @@ trait IssueStatusContextTrait
 {
     /**
      * @Given I have an issue status with the name :issueStatusName
+     * @param mixed $issueStatusName
      */
     public function iHaveAnIssueStatusWithTheName($issueStatusName)
     {

--- a/tests/Behat/Bootstrap/MembershipContextTrait.php
+++ b/tests/Behat/Bootstrap/MembershipContextTrait.php
@@ -14,7 +14,7 @@ trait MembershipContextTrait
      *
      * @param mixed $identifier
      */
-    public function iCreateAMembershipToProjectWithIdentifierAndTheFollowingData($identifier, TableNode $table)
+    public function iCreateAMembershipToProjectWithIdentifierAndTheFollowingData($identifier, TableNode $table): void
     {
         $data = [];
 
@@ -40,7 +40,7 @@ trait MembershipContextTrait
      *
      * @param mixed $id
      */
-    public function iUpdateTheMembershipWithIdAndTheFollowingData($id, TableNode $table)
+    public function iUpdateTheMembershipWithIdAndTheFollowingData($id, TableNode $table): void
     {
         $data = [];
 
@@ -66,7 +66,7 @@ trait MembershipContextTrait
      *
      * @param mixed $id
      */
-    public function iRemoveTheMembershipWithId($id)
+    public function iRemoveTheMembershipWithId($id): void
     {
         /** @var Membership */
         $api = $this->getNativeCurlClient()->getApi('membership');
@@ -83,7 +83,7 @@ trait MembershipContextTrait
      * @param mixed $userId
      * @param mixed $identifier
      */
-    public function iRemoveTheUserWithIdFromTheProjectWithIdentifier($userId, $identifier)
+    public function iRemoveTheUserWithIdFromTheProjectWithIdentifier($userId, $identifier): void
     {
         /** @var Membership */
         $api = $this->getNativeCurlClient()->getApi('membership');

--- a/tests/Behat/Bootstrap/MembershipContextTrait.php
+++ b/tests/Behat/Bootstrap/MembershipContextTrait.php
@@ -11,6 +11,7 @@ trait MembershipContextTrait
 {
     /**
      * @When I create a membership to project with identifier :identifier and the following data
+     * @param mixed $identifier
      */
     public function iCreateAMembershipToProjectWithIdentifierAndTheFollowingData($identifier, TableNode $table)
     {
@@ -35,6 +36,7 @@ trait MembershipContextTrait
 
     /**
      * @When I update the membership with id :id and the following data
+     * @param mixed $id
      */
     public function iUpdateTheMembershipWithIdAndTheFollowingData($id, TableNode $table)
     {
@@ -59,6 +61,7 @@ trait MembershipContextTrait
 
     /**
      * @When I remove the membership with id :id
+     * @param mixed $id
      */
     public function iRemoveTheMembershipWithId($id)
     {
@@ -73,6 +76,8 @@ trait MembershipContextTrait
 
     /**
      * @When I remove the user with id :userId from the project with identifier :identifier
+     * @param mixed $userId
+     * @param mixed $identifier
      */
     public function iRemoveTheUserWithIdFromTheProjectWithIdentifier($userId, $identifier)
     {

--- a/tests/Behat/Bootstrap/MembershipContextTrait.php
+++ b/tests/Behat/Bootstrap/MembershipContextTrait.php
@@ -11,6 +11,7 @@ trait MembershipContextTrait
 {
     /**
      * @When I create a membership to project with identifier :identifier and the following data
+     *
      * @param mixed $identifier
      */
     public function iCreateAMembershipToProjectWithIdentifierAndTheFollowingData($identifier, TableNode $table)
@@ -36,6 +37,7 @@ trait MembershipContextTrait
 
     /**
      * @When I update the membership with id :id and the following data
+     *
      * @param mixed $id
      */
     public function iUpdateTheMembershipWithIdAndTheFollowingData($id, TableNode $table)
@@ -61,6 +63,7 @@ trait MembershipContextTrait
 
     /**
      * @When I remove the membership with id :id
+     *
      * @param mixed $id
      */
     public function iRemoveTheMembershipWithId($id)
@@ -76,6 +79,7 @@ trait MembershipContextTrait
 
     /**
      * @When I remove the user with id :userId from the project with identifier :identifier
+     *
      * @param mixed $userId
      * @param mixed $identifier
      */

--- a/tests/Behat/Bootstrap/ProjectContextTrait.php
+++ b/tests/Behat/Bootstrap/ProjectContextTrait.php
@@ -175,6 +175,7 @@ trait ProjectContextTrait
 
     /**
      * @When I remove the project with identifier :identifier
+     *
      * @param mixed $identifier
      */
     public function iRemoveTheProjectWithIdentifier($identifier)

--- a/tests/Behat/Bootstrap/ProjectContextTrait.php
+++ b/tests/Behat/Bootstrap/ProjectContextTrait.php
@@ -12,7 +12,7 @@ trait ProjectContextTrait
     /**
      * @When I create a project with name :name and identifier :identifier
      */
-    public function iCreateAProjectWithNameAndIdentifier(string $name, string $identifier)
+    public function iCreateAProjectWithNameAndIdentifier(string $name, string $identifier): void
     {
         $table = new TableNode([
             ['property', 'value'],
@@ -26,7 +26,7 @@ trait ProjectContextTrait
     /**
      * @When I create a project with the following data
      */
-    public function iCreateAProjectWithTheFollowingData(TableNode $table)
+    public function iCreateAProjectWithTheFollowingData(TableNode $table): void
     {
         $data = [];
 
@@ -46,7 +46,7 @@ trait ProjectContextTrait
     /**
      * @Given I create :count projects
      */
-    public function iCreateProjects(int $count)
+    public function iCreateProjects(int $count): void
     {
         while ($count > 0) {
             $this->iCreateAProjectWithNameAndIdentifier('Test Project ' . $count, 'test-project-' . $count);
@@ -58,7 +58,7 @@ trait ProjectContextTrait
     /**
      * @When I list all projects
      */
-    public function iListAllProjects()
+    public function iListAllProjects(): void
     {
         /** @var Project */
         $api = $this->getNativeCurlClient()->getApi('project');
@@ -72,7 +72,7 @@ trait ProjectContextTrait
     /**
      * @When I list all project names
      */
-    public function iListAllProjectNames()
+    public function iListAllProjectNames(): void
     {
         /** @var Project */
         $api = $this->getNativeCurlClient()->getApi('project');
@@ -86,7 +86,7 @@ trait ProjectContextTrait
     /**
      * @When I show the project with identifier :identifier
      */
-    public function iShowTheProjectWithIdentifier(string $identifier)
+    public function iShowTheProjectWithIdentifier(string $identifier): void
     {
         /** @var Project */
         $api = $this->getNativeCurlClient()->getApi('project');
@@ -100,7 +100,7 @@ trait ProjectContextTrait
     /**
      * @When I update the project with identifier :identifier with the following data
      */
-    public function iUpdateTheProjectWithIdentifierWithTheFollowingData(string $identifier, TableNode $table)
+    public function iUpdateTheProjectWithIdentifierWithTheFollowingData(string $identifier, TableNode $table): void
     {
         $data = [];
 
@@ -120,7 +120,7 @@ trait ProjectContextTrait
     /**
      * @When I close the project with identifier :identifier
      */
-    public function iCloseTheProjectWithIdentifier(string $identifier)
+    public function iCloseTheProjectWithIdentifier(string $identifier): void
     {
         /** @var Project */
         $api = $this->getNativeCurlClient()->getApi('project');
@@ -134,7 +134,7 @@ trait ProjectContextTrait
     /**
      * @When I reopen the project with identifier :identifier
      */
-    public function iReopenTheProjectWithIdentifier(string $identifier)
+    public function iReopenTheProjectWithIdentifier(string $identifier): void
     {
         /** @var Project */
         $api = $this->getNativeCurlClient()->getApi('project');
@@ -148,7 +148,7 @@ trait ProjectContextTrait
     /**
      * @When I archive the project with identifier :identifier
      */
-    public function iArchiveTheProjectWithIdentifier(string $identifier)
+    public function iArchiveTheProjectWithIdentifier(string $identifier): void
     {
         /** @var Project */
         $api = $this->getNativeCurlClient()->getApi('project');
@@ -162,7 +162,7 @@ trait ProjectContextTrait
     /**
      * @When I unarchive the project with identifier :identifier
      */
-    public function iUnarchiveTheProjectWithIdentifier(string $identifier)
+    public function iUnarchiveTheProjectWithIdentifier(string $identifier): void
     {
         /** @var Project */
         $api = $this->getNativeCurlClient()->getApi('project');
@@ -178,7 +178,7 @@ trait ProjectContextTrait
      *
      * @param mixed $identifier
      */
-    public function iRemoveTheProjectWithIdentifier($identifier)
+    public function iRemoveTheProjectWithIdentifier($identifier): void
     {
         /** @var Project */
         $api = $this->getNativeCurlClient()->getApi('project');

--- a/tests/Behat/Bootstrap/ProjectContextTrait.php
+++ b/tests/Behat/Bootstrap/ProjectContextTrait.php
@@ -175,6 +175,7 @@ trait ProjectContextTrait
 
     /**
      * @When I remove the project with identifier :identifier
+     * @param mixed $identifier
      */
     public function iRemoveTheProjectWithIdentifier($identifier)
     {

--- a/tests/Behat/Bootstrap/RoleContextTrait.php
+++ b/tests/Behat/Bootstrap/RoleContextTrait.php
@@ -13,7 +13,7 @@ trait RoleContextTrait
      *
      * @param mixed $name
      */
-    public function iHaveARoleWithTheName($name)
+    public function iHaveARoleWithTheName($name): void
     {
         // support for creating issue status via REST API is missing
         $this->redmine->excecuteDatabaseQuery(
@@ -36,7 +36,7 @@ trait RoleContextTrait
     /**
      * @When I list all roles
      */
-    public function iListAllRoles()
+    public function iListAllRoles(): void
     {
         /** @var Role */
         $api = $this->getNativeCurlClient()->getApi('role');
@@ -50,7 +50,7 @@ trait RoleContextTrait
     /**
      * @When I list all role names
      */
-    public function iListAllRoleNames()
+    public function iListAllRoleNames(): void
     {
         /** @var Role */
         $api = $this->getNativeCurlClient()->getApi('role');

--- a/tests/Behat/Bootstrap/RoleContextTrait.php
+++ b/tests/Behat/Bootstrap/RoleContextTrait.php
@@ -10,6 +10,7 @@ trait RoleContextTrait
 {
     /**
      * @Given I have a role with the name :name
+     * @param mixed $name
      */
     public function iHaveARoleWithTheName($name)
     {

--- a/tests/Behat/Bootstrap/RoleContextTrait.php
+++ b/tests/Behat/Bootstrap/RoleContextTrait.php
@@ -10,6 +10,7 @@ trait RoleContextTrait
 {
     /**
      * @Given I have a role with the name :name
+     *
      * @param mixed $name
      */
     public function iHaveARoleWithTheName($name)

--- a/tests/Behat/Bootstrap/TimeEntryActivityContextTrait.php
+++ b/tests/Behat/Bootstrap/TimeEntryActivityContextTrait.php
@@ -11,7 +11,7 @@ trait TimeEntryActivityContextTrait
     /**
      * @Given I have a time entry activiy with name :activityName
      */
-    public function iHaveATimeEntryActiviyWithName(string $activityName)
+    public function iHaveATimeEntryActiviyWithName(string $activityName): void
     {
         // support for creating time entry activity via REST API is missing
         $this->redmine->excecuteDatabaseQuery(
@@ -30,7 +30,7 @@ trait TimeEntryActivityContextTrait
     /**
      * @When I list all time entry activities
      */
-    public function iListAllTimeEntryActivities()
+    public function iListAllTimeEntryActivities(): void
     {
         /** @var TimeEntryActivity */
         $api = $this->getNativeCurlClient()->getApi('time_entry_activity');
@@ -44,7 +44,7 @@ trait TimeEntryActivityContextTrait
     /**
      * @When I list all time entry activity names
      */
-    public function iListAllTimeEntryActivityNames()
+    public function iListAllTimeEntryActivityNames(): void
     {
         /** @var TimeEntryActivity */
         $api = $this->getNativeCurlClient()->getApi('time_entry_activity');

--- a/tests/Behat/Bootstrap/TimeEntryContextTrait.php
+++ b/tests/Behat/Bootstrap/TimeEntryContextTrait.php
@@ -12,7 +12,7 @@ trait TimeEntryContextTrait
     /**
      * @When I create a time entry with the following data
      */
-    public function iCreateATimeEntryWithTheFollowingData(TableNode $table)
+    public function iCreateATimeEntryWithTheFollowingData(TableNode $table): void
     {
         $data = [];
 
@@ -34,7 +34,7 @@ trait TimeEntryContextTrait
      *
      * @param mixed $id
      */
-    public function iUpdateTheTimeEntryWithIdAndTheFollowingData($id, TableNode $table)
+    public function iUpdateTheTimeEntryWithIdAndTheFollowingData($id, TableNode $table): void
     {
         $data = [];
 
@@ -54,7 +54,7 @@ trait TimeEntryContextTrait
     /**
      * @When I show the time entry with the id :activityId
      */
-    public function iShowTheTimeEntryWithTheId(int $activityId)
+    public function iShowTheTimeEntryWithTheId(int $activityId): void
     {
         /** @var TimeEntry */
         $api = $this->getNativeCurlClient()->getApi('time_entry');
@@ -70,7 +70,7 @@ trait TimeEntryContextTrait
      *
      * @param mixed $activityId
      */
-    public function iRemoveTheTimeEntryWithId($activityId)
+    public function iRemoveTheTimeEntryWithId($activityId): void
     {
         /** @var TimeEntry */
         $api = $this->getNativeCurlClient()->getApi('time_entry');

--- a/tests/Behat/Bootstrap/TimeEntryContextTrait.php
+++ b/tests/Behat/Bootstrap/TimeEntryContextTrait.php
@@ -31,6 +31,7 @@ trait TimeEntryContextTrait
 
     /**
      * @When I update the time entry with id :id and the following data
+     *
      * @param mixed $id
      */
     public function iUpdateTheTimeEntryWithIdAndTheFollowingData($id, TableNode $table)
@@ -66,6 +67,7 @@ trait TimeEntryContextTrait
 
     /**
      * @When I remove the time entry with id :activityId
+     *
      * @param mixed $activityId
      */
     public function iRemoveTheTimeEntryWithId($activityId)

--- a/tests/Behat/Bootstrap/TimeEntryContextTrait.php
+++ b/tests/Behat/Bootstrap/TimeEntryContextTrait.php
@@ -31,6 +31,7 @@ trait TimeEntryContextTrait
 
     /**
      * @When I update the time entry with id :id and the following data
+     * @param mixed $id
      */
     public function iUpdateTheTimeEntryWithIdAndTheFollowingData($id, TableNode $table)
     {
@@ -65,6 +66,7 @@ trait TimeEntryContextTrait
 
     /**
      * @When I remove the time entry with id :activityId
+     * @param mixed $activityId
      */
     public function iRemoveTheTimeEntryWithId($activityId)
     {

--- a/tests/Behat/Bootstrap/TrackerContextTrait.php
+++ b/tests/Behat/Bootstrap/TrackerContextTrait.php
@@ -11,7 +11,7 @@ trait TrackerContextTrait
     /**
      * @Given I have a tracker with the name :trackerName and default status id :statusId
      */
-    public function iHaveATrackerWithTheNameAndDefaultStatusId(string $trackerName, int $statusId)
+    public function iHaveATrackerWithTheNameAndDefaultStatusId(string $trackerName, int $statusId): void
     {
         // support for creating tracker via REST API is missing
         $this->redmine->excecuteDatabaseQuery(
@@ -30,7 +30,7 @@ trait TrackerContextTrait
     /**
      * @When I list all trackers
      */
-    public function iListAllTrackers()
+    public function iListAllTrackers(): void
     {
         /** @var Tracker */
         $api = $this->getNativeCurlClient()->getApi('tracker');
@@ -44,7 +44,7 @@ trait TrackerContextTrait
     /**
      * @When I list all tracker names
      */
-    public function iListAllTrackerNames()
+    public function iListAllTrackerNames(): void
     {
         /** @var Tracker */
         $api = $this->getNativeCurlClient()->getApi('tracker');

--- a/tests/Behat/Bootstrap/UserContextTrait.php
+++ b/tests/Behat/Bootstrap/UserContextTrait.php
@@ -93,6 +93,7 @@ trait UserContextTrait
 
     /**
      * @When I update the user with id :id and the following data
+     *
      * @param mixed $id
      */
     public function iUpdateTheUserWithIdAndTheFollowingData($id, TableNode $table)
@@ -114,6 +115,7 @@ trait UserContextTrait
 
     /**
      * @When I remove the user with id :userId
+     *
      * @param mixed $userId
      */
     public function iRemoveTheUserWithId($userId)

--- a/tests/Behat/Bootstrap/UserContextTrait.php
+++ b/tests/Behat/Bootstrap/UserContextTrait.php
@@ -93,6 +93,7 @@ trait UserContextTrait
 
     /**
      * @When I update the user with id :id and the following data
+     * @param mixed $id
      */
     public function iUpdateTheUserWithIdAndTheFollowingData($id, TableNode $table)
     {
@@ -113,6 +114,7 @@ trait UserContextTrait
 
     /**
      * @When I remove the user with id :userId
+     * @param mixed $userId
      */
     public function iRemoveTheUserWithId($userId)
     {

--- a/tests/Behat/Bootstrap/UserContextTrait.php
+++ b/tests/Behat/Bootstrap/UserContextTrait.php
@@ -12,7 +12,7 @@ trait UserContextTrait
     /**
      * @Given I create :count users
      */
-    public function iCreateUsers(int $count)
+    public function iCreateUsers(int $count): void
     {
         while ($count > 0) {
             $table = new TableNode([
@@ -32,7 +32,7 @@ trait UserContextTrait
     /**
      * @When I create a user with the following data
      */
-    public function iCreateAUserWithTheFollowingData(TableNode $table)
+    public function iCreateAUserWithTheFollowingData(TableNode $table): void
     {
         $data = [];
 
@@ -52,7 +52,7 @@ trait UserContextTrait
     /**
      * @When I show the user with id :userId
      */
-    public function iShowTheUserWithId(int $userId)
+    public function iShowTheUserWithId(int $userId): void
     {
         /** @var User */
         $api = $this->getNativeCurlClient()->getApi('user');
@@ -66,7 +66,7 @@ trait UserContextTrait
     /**
      * @When I list all users
      */
-    public function iListAllUsers()
+    public function iListAllUsers(): void
     {
         /** @var User */
         $api = $this->getNativeCurlClient()->getApi('user');
@@ -80,7 +80,7 @@ trait UserContextTrait
     /**
      * @When I list all user logins
      */
-    public function iListAllUserLogins()
+    public function iListAllUserLogins(): void
     {
         /** @var User */
         $api = $this->getNativeCurlClient()->getApi('user');
@@ -96,7 +96,7 @@ trait UserContextTrait
      *
      * @param mixed $id
      */
-    public function iUpdateTheUserWithIdAndTheFollowingData($id, TableNode $table)
+    public function iUpdateTheUserWithIdAndTheFollowingData($id, TableNode $table): void
     {
         $data = [];
 
@@ -118,7 +118,7 @@ trait UserContextTrait
      *
      * @param mixed $userId
      */
-    public function iRemoveTheUserWithId($userId)
+    public function iRemoveTheUserWithId($userId): void
     {
         /** @var User */
         $api = $this->getNativeCurlClient()->getApi('user');

--- a/tests/Behat/Bootstrap/VersionContextTrait.php
+++ b/tests/Behat/Bootstrap/VersionContextTrait.php
@@ -60,6 +60,7 @@ trait VersionContextTrait
 
     /**
      * @When I list all versions for project identifier :identifier
+     *
      * @param mixed $identifier
      */
     public function iListAllVersionsForProjectIdentifier($identifier)
@@ -75,6 +76,7 @@ trait VersionContextTrait
 
     /**
      * @When I list all version names for project identifier :identifier
+     *
      * @param mixed $identifier
      */
     public function iListAllVersionNamesForProjectIdentifier($identifier)
@@ -90,6 +92,7 @@ trait VersionContextTrait
 
     /**
      * @When I update the version with id :id and the following data
+     *
      * @param mixed $id
      */
     public function iUpdateTheVersionWithIdAndTheFollowingData($id, TableNode $table)
@@ -111,6 +114,7 @@ trait VersionContextTrait
 
     /**
      * @When I remove the version with id :versionId
+     *
      * @param mixed $versionId
      */
     public function iRemoveTheVersionWithId($versionId)

--- a/tests/Behat/Bootstrap/VersionContextTrait.php
+++ b/tests/Behat/Bootstrap/VersionContextTrait.php
@@ -60,6 +60,7 @@ trait VersionContextTrait
 
     /**
      * @When I list all versions for project identifier :identifier
+     * @param mixed $identifier
      */
     public function iListAllVersionsForProjectIdentifier($identifier)
     {
@@ -74,6 +75,7 @@ trait VersionContextTrait
 
     /**
      * @When I list all version names for project identifier :identifier
+     * @param mixed $identifier
      */
     public function iListAllVersionNamesForProjectIdentifier($identifier)
     {
@@ -88,6 +90,7 @@ trait VersionContextTrait
 
     /**
      * @When I update the version with id :id and the following data
+     * @param mixed $id
      */
     public function iUpdateTheVersionWithIdAndTheFollowingData($id, TableNode $table)
     {
@@ -108,6 +111,7 @@ trait VersionContextTrait
 
     /**
      * @When I remove the version with id :versionId
+     * @param mixed $versionId
      */
     public function iRemoveTheVersionWithId($versionId)
     {

--- a/tests/Behat/Bootstrap/VersionContextTrait.php
+++ b/tests/Behat/Bootstrap/VersionContextTrait.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Redmine\Tests\Behat\Bootstrap;
 
-use Behat\Behat\Tester\Exception\PendingException;
 use Behat\Gherkin\Node\TableNode;
 use Redmine\Api\Version;
 

--- a/tests/Behat/Bootstrap/VersionContextTrait.php
+++ b/tests/Behat/Bootstrap/VersionContextTrait.php
@@ -13,7 +13,7 @@ trait VersionContextTrait
     /**
      * @When I create a version with name :versionName and project identifier :identifier
      */
-    public function iCreateAVersionWithNameAndProjectIdentifier(string $versionName, string $identifier)
+    public function iCreateAVersionWithNameAndProjectIdentifier(string $versionName, string $identifier): void
     {
         $this->iCreateAVersionWithProjectIdentifierAndWithTheFollowingData(
             $identifier,
@@ -27,7 +27,7 @@ trait VersionContextTrait
     /**
      * @When I create a version with project identifier :identifier with the following data
      */
-    public function iCreateAVersionWithProjectIdentifierAndWithTheFollowingData(string $identifier, TableNode $table)
+    public function iCreateAVersionWithProjectIdentifierAndWithTheFollowingData(string $identifier, TableNode $table): void
     {
         $data = [];
 
@@ -47,7 +47,7 @@ trait VersionContextTrait
     /**
      * @When I show the version with id :versionId
      */
-    public function iShowTheVersionWithId(int $versionId)
+    public function iShowTheVersionWithId(int $versionId): void
     {
         /** @var Version */
         $api = $this->getNativeCurlClient()->getApi('version');
@@ -63,7 +63,7 @@ trait VersionContextTrait
      *
      * @param mixed $identifier
      */
-    public function iListAllVersionsForProjectIdentifier($identifier)
+    public function iListAllVersionsForProjectIdentifier($identifier): void
     {
         /** @var Version */
         $api = $this->getNativeCurlClient()->getApi('version');
@@ -79,7 +79,7 @@ trait VersionContextTrait
      *
      * @param mixed $identifier
      */
-    public function iListAllVersionNamesForProjectIdentifier($identifier)
+    public function iListAllVersionNamesForProjectIdentifier($identifier): void
     {
         /** @var Version */
         $api = $this->getNativeCurlClient()->getApi('version');
@@ -95,7 +95,7 @@ trait VersionContextTrait
      *
      * @param mixed $id
      */
-    public function iUpdateTheVersionWithIdAndTheFollowingData($id, TableNode $table)
+    public function iUpdateTheVersionWithIdAndTheFollowingData($id, TableNode $table): void
     {
         $data = [];
 
@@ -117,7 +117,7 @@ trait VersionContextTrait
      *
      * @param mixed $versionId
      */
-    public function iRemoveTheVersionWithId($versionId)
+    public function iRemoveTheVersionWithId($versionId): void
     {
         /** @var Version */
         $api = $this->getNativeCurlClient()->getApi('version');

--- a/tests/Behat/Bootstrap/WikiContextTrait.php
+++ b/tests/Behat/Bootstrap/WikiContextTrait.php
@@ -13,7 +13,7 @@ trait WikiContextTrait
     /**
      * @When I create a wiki page with name :pageName and project identifier :identifier
      */
-    public function iCreateAWikiPageWithNameAndProjectIdentifier(string $pageName, string $identifier)
+    public function iCreateAWikiPageWithNameAndProjectIdentifier(string $pageName, string $identifier): void
     {
         $this->iCreateAWikiPageWithNameAndProjectIdentifierWithTheFollowingData(
             $pageName,
@@ -25,7 +25,7 @@ trait WikiContextTrait
     /**
      * @When I create a wiki page with name :pageName and project identifier :identifier with the following data
      */
-    public function iCreateAWikiPageWithNameAndProjectIdentifierWithTheFollowingData(string $pageName, string $identifier, TableNode $table)
+    public function iCreateAWikiPageWithNameAndProjectIdentifierWithTheFollowingData(string $pageName, string $identifier, TableNode $table): void
     {
         $data = $this->prepareWikiData($table);
 
@@ -41,7 +41,7 @@ trait WikiContextTrait
     /**
      * @When I show the wiki page with name :pageName and project identifier :identifier
      */
-    public function iShowTheWikiPageWithNameAndProjectIdentifier(string $pageName, string $identifier)
+    public function iShowTheWikiPageWithNameAndProjectIdentifier(string $pageName, string $identifier): void
     {
         /** @var Wiki */
         $api = $this->getNativeCurlClient()->getApi('wiki');
@@ -55,7 +55,7 @@ trait WikiContextTrait
     /**
      * @When I update the wiki page with name :pageName and project identifier :identifier with the following data
      */
-    public function iUpdateTheWikiPageWithNameAndProjectIdentifierWithTheFollowingData(string $pageName, string $identifier, TableNode $table)
+    public function iUpdateTheWikiPageWithNameAndProjectIdentifierWithTheFollowingData(string $pageName, string $identifier, TableNode $table): void
     {
         $data = $this->prepareWikiData($table);
 
@@ -74,7 +74,7 @@ trait WikiContextTrait
      * @param mixed $pageName
      * @param mixed $identifier
      */
-    public function iRemoveTheWikiPageWithNameAndProjectIdentifier($pageName, $identifier)
+    public function iRemoveTheWikiPageWithNameAndProjectIdentifier($pageName, $identifier): void
     {
         /** @var Wiki */
         $api = $this->getNativeCurlClient()->getApi('wiki');

--- a/tests/Behat/Bootstrap/WikiContextTrait.php
+++ b/tests/Behat/Bootstrap/WikiContextTrait.php
@@ -85,6 +85,9 @@ trait WikiContextTrait
         );
     }
 
+    /**
+     * @return array<mixed>
+     */
     private function prepareWikiData(TableNode $table): array
     {
         $data = [];

--- a/tests/Behat/Bootstrap/WikiContextTrait.php
+++ b/tests/Behat/Bootstrap/WikiContextTrait.php
@@ -70,6 +70,7 @@ trait WikiContextTrait
 
     /**
      * @When I remove the wiki page with name :pageName and project identifier :identifier
+     *
      * @param mixed $pageName
      * @param mixed $identifier
      */

--- a/tests/Behat/Bootstrap/WikiContextTrait.php
+++ b/tests/Behat/Bootstrap/WikiContextTrait.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Redmine\Tests\Behat\Bootstrap;
 
-use Behat\Behat\Tester\Exception\PendingException;
 use Behat\Gherkin\Node\TableNode;
 use Redmine\Api\Wiki;
 

--- a/tests/Behat/Bootstrap/WikiContextTrait.php
+++ b/tests/Behat/Bootstrap/WikiContextTrait.php
@@ -70,6 +70,8 @@ trait WikiContextTrait
 
     /**
      * @When I remove the wiki page with name :pageName and project identifier :identifier
+     * @param mixed $pageName
+     * @param mixed $identifier
      */
     public function iRemoveTheWikiPageWithNameAndProjectIdentifier($pageName, $identifier)
     {

--- a/tests/Fixtures/AssertingHttpClient.php
+++ b/tests/Fixtures/AssertingHttpClient.php
@@ -6,7 +6,6 @@ namespace Redmine\Tests\Fixtures;
 
 use PHPUnit\Framework\MockObject\MockBuilder;
 use PHPUnit\Framework\MockObject\Rule\InvokedCount;
-use PHPUnit\Framework\MockObject\TestStubBuilder;
 use PHPUnit\Framework\TestCase;
 use Redmine\Http\HttpClient;
 use Redmine\Http\Request;
@@ -19,6 +18,10 @@ use Redmine\Http\Response;
  */
 final class AssertingHttpClient implements HttpClient
 {
+    /**
+     * @param array<mixed> $dataSet
+     * @param array<array<mixed>> $dataSets
+     */
     public static function create(TestCase $testCase, array $dataSet, ...$dataSets): self
     {
         $dataSets = array_merge([$dataSet], $dataSets);

--- a/tests/Fixtures/TestDataProvider.php
+++ b/tests/Fixtures/TestDataProvider.php
@@ -8,6 +8,9 @@ use stdClass;
 
 final class TestDataProvider
 {
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getInvalidProjectIdentifiers(): array
     {
         return [

--- a/tests/Integration/Psr18ClientRequestGenerationTest.php
+++ b/tests/Integration/Psr18ClientRequestGenerationTest.php
@@ -21,6 +21,7 @@ class Psr18ClientRequestGenerationTest extends TestCase
 {
     /**
      * @dataProvider createdGetRequestsData
+     *
      * @param mixed $data
      */
     #[DataProvider('createdGetRequestsData')]

--- a/tests/Integration/Psr18ClientRequestGenerationTest.php
+++ b/tests/Integration/Psr18ClientRequestGenerationTest.php
@@ -102,6 +102,9 @@ class Psr18ClientRequestGenerationTest extends TestCase
         $client->$method($path, $data);
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function createdGetRequestsData(): array
     {
         return [

--- a/tests/Integration/Psr18ClientRequestGenerationTest.php
+++ b/tests/Integration/Psr18ClientRequestGenerationTest.php
@@ -54,9 +54,9 @@ class Psr18ClientRequestGenerationTest extends TestCase
                 $request->getProtocolVersion(),
             );
 
-            $fullRequest = $statusLine . \PHP_EOL .
-                $headers . \PHP_EOL .
-                $content
+            $fullRequest = $statusLine . \PHP_EOL
+                . $headers . \PHP_EOL
+                . $content
             ;
 
             $this->assertSame($expectedOutput, $fullRequest);
@@ -106,99 +106,99 @@ class Psr18ClientRequestGenerationTest extends TestCase
             'Test username/password in auth header' => [
                 'http://test.local', 'username', 'password', null,
                 'requestGet', '/path', null,
-                'GET http://test.local/path HTTP/1.1' . \PHP_EOL .
-                'Host: test.local' . \PHP_EOL .
-                'Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=' . \PHP_EOL .
-                \PHP_EOL,
+                'GET http://test.local/path HTTP/1.1' . \PHP_EOL
+                . 'Host: test.local' . \PHP_EOL
+                . 'Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=' . \PHP_EOL
+                . \PHP_EOL,
             ],
             'Test access token in X-Redmine-API-Key header' => [
                 'http://test.local', 'access_token', null, null,
                 'requestGet', '/path', null,
-                'GET http://test.local/path HTTP/1.1' . \PHP_EOL .
-                'Host: test.local' . \PHP_EOL .
-                'X-Redmine-API-Key: access_token' . \PHP_EOL .
-                \PHP_EOL,
+                'GET http://test.local/path HTTP/1.1' . \PHP_EOL
+                . 'Host: test.local' . \PHP_EOL
+                . 'X-Redmine-API-Key: access_token' . \PHP_EOL
+                . \PHP_EOL,
             ],
             'Test user impersonate in X-Redmine-Switch-User header' => [
                 'http://test.local', 'access_token', null, 'Robin',
                 'requestGet', '/path', null,
-                'GET http://test.local/path HTTP/1.1' . \PHP_EOL .
-                'Host: test.local' . \PHP_EOL .
-                'X-Redmine-API-Key: access_token' . \PHP_EOL .
-                'X-Redmine-Switch-User: Robin' . \PHP_EOL .
-                \PHP_EOL,
+                'GET http://test.local/path HTTP/1.1' . \PHP_EOL
+                . 'Host: test.local' . \PHP_EOL
+                . 'X-Redmine-API-Key: access_token' . \PHP_EOL
+                . 'X-Redmine-Switch-User: Robin' . \PHP_EOL
+                . \PHP_EOL,
             ],
             'Test POST' => [
                 'http://test.local', 'access_token', null, null,
                 'requestPost', '/path.json', '{"foo":"bar"}',
-                'POST http://test.local/path.json HTTP/1.1' . \PHP_EOL .
-                'Host: test.local' . \PHP_EOL .
-                'X-Redmine-API-Key: access_token' . \PHP_EOL .
-                'Content-Type: application/json' . \PHP_EOL .
-                \PHP_EOL .
-                '{"foo":"bar"}',
+                'POST http://test.local/path.json HTTP/1.1' . \PHP_EOL
+                . 'Host: test.local' . \PHP_EOL
+                . 'X-Redmine-API-Key: access_token' . \PHP_EOL
+                . 'Content-Type: application/json' . \PHP_EOL
+                . \PHP_EOL
+                . '{"foo":"bar"}',
             ],
             'Test fileupload with file content' => [
                 // @see https://www.redmine.org/projects/redmine/wiki/Rest_api#Attaching-files
                 'http://test.local', 'access_token', null, null,
                 'requestPost', '/uploads.json?filename=textfile.md', 'The content of the file',
-                'POST http://test.local/uploads.json?filename=textfile.md HTTP/1.1' . \PHP_EOL .
-                'Host: test.local' . \PHP_EOL .
-                'X-Redmine-API-Key: access_token' . \PHP_EOL .
-                'Content-Type: application/octet-stream' . \PHP_EOL .
-                \PHP_EOL .
-                'The content of the file',
+                'POST http://test.local/uploads.json?filename=textfile.md HTTP/1.1' . \PHP_EOL
+                . 'Host: test.local' . \PHP_EOL
+                . 'X-Redmine-API-Key: access_token' . \PHP_EOL
+                . 'Content-Type: application/octet-stream' . \PHP_EOL
+                . \PHP_EOL
+                . 'The content of the file',
             ],
             'Test fileupload with file path' => [
                 // @see https://www.redmine.org/projects/redmine/wiki/Rest_api#Attaching-files
                 'http://test.local', 'access_token', null, null,
                 'requestPost', '/uploads.json?filename=textfile.md', realpath(__DIR__ . '/../Fixtures/testfile_01.txt'),
-                'POST http://test.local/uploads.json?filename=textfile.md HTTP/1.1' . \PHP_EOL .
-                'Host: test.local' . \PHP_EOL .
-                'X-Redmine-API-Key: access_token' . \PHP_EOL .
-                'Content-Type: application/octet-stream' . \PHP_EOL .
-                \PHP_EOL .
-                'This is a test file.' . "\n" .
-                'It will be needed for testing file uploads.' . "\n",
+                'POST http://test.local/uploads.json?filename=textfile.md HTTP/1.1' . \PHP_EOL
+                . 'Host: test.local' . \PHP_EOL
+                . 'X-Redmine-API-Key: access_token' . \PHP_EOL
+                . 'Content-Type: application/octet-stream' . \PHP_EOL
+                . \PHP_EOL
+                . 'This is a test file.' . "\n"
+                . 'It will be needed for testing file uploads.' . "\n",
             ],
             'Test fileupload with file path to image' => [
                 // @see https://www.redmine.org/projects/redmine/wiki/Rest_api#Attaching-files
                 'http://test.local', 'access_token', null, null,
                 'requestPost', '/uploads.json?filename=1x1.png', realpath(__DIR__ . '/../Fixtures/FF4D00-1.png'),
-                'POST http://test.local/uploads.json?filename=1x1.png HTTP/1.1' . \PHP_EOL .
-                'Host: test.local' . \PHP_EOL .
-                'X-Redmine-API-Key: access_token' . \PHP_EOL .
-                'Content-Type: application/octet-stream' . \PHP_EOL .
-                \PHP_EOL .
-                base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEX/TQBcNTh/AAAACklEQVR4nGNiAAAABgADNjd8qAAAAABJRU5ErkJggg=='),
+                'POST http://test.local/uploads.json?filename=1x1.png HTTP/1.1' . \PHP_EOL
+                . 'Host: test.local' . \PHP_EOL
+                . 'X-Redmine-API-Key: access_token' . \PHP_EOL
+                . 'Content-Type: application/octet-stream' . \PHP_EOL
+                . \PHP_EOL
+                . base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEX/TQBcNTh/AAAACklEQVR4nGNiAAAABgADNjd8qAAAAABJRU5ErkJggg=='),
             ],
             'Test PUT' => [
                 'http://test.local', 'access_token', null, null,
                 'requestPut', '/path.json', '{"foo":"bar"}',
-                'PUT http://test.local/path.json HTTP/1.1' . \PHP_EOL .
-                'Host: test.local' . \PHP_EOL .
-                'X-Redmine-API-Key: access_token' . \PHP_EOL .
-                'Content-Type: application/json' . \PHP_EOL .
-                \PHP_EOL .
-                '{"foo":"bar"}',
+                'PUT http://test.local/path.json HTTP/1.1' . \PHP_EOL
+                . 'Host: test.local' . \PHP_EOL
+                . 'X-Redmine-API-Key: access_token' . \PHP_EOL
+                . 'Content-Type: application/json' . \PHP_EOL
+                . \PHP_EOL
+                . '{"foo":"bar"}',
             ],
             'Test DELETE' => [
                 'http://test.local', 'access_token', null, null,
                 'requestDelete', '/path.json', '{"foo":"bar"}',
-                'DELETE http://test.local/path.json HTTP/1.1' . \PHP_EOL .
-                'Host: test.local' . \PHP_EOL .
-                'X-Redmine-API-Key: access_token' . \PHP_EOL .
-                'Content-Type: application/json' . \PHP_EOL .
-                \PHP_EOL,
+                'DELETE http://test.local/path.json HTTP/1.1' . \PHP_EOL
+                . 'Host: test.local' . \PHP_EOL
+                . 'X-Redmine-API-Key: access_token' . \PHP_EOL
+                . 'Content-Type: application/json' . \PHP_EOL
+                . \PHP_EOL,
             ],
             'Test body will be ignored on DELETE' => [
                 'http://test.local', 'access_token', null, null,
                 'requestDelete', '/path.json', '{"foo":"bar"}',
-                'DELETE http://test.local/path.json HTTP/1.1' . \PHP_EOL .
-                'Host: test.local' . \PHP_EOL .
-                'X-Redmine-API-Key: access_token' . \PHP_EOL .
-                'Content-Type: application/json' . \PHP_EOL .
-                \PHP_EOL,
+                'DELETE http://test.local/path.json HTTP/1.1' . \PHP_EOL
+                . 'Host: test.local' . \PHP_EOL
+                . 'X-Redmine-API-Key: access_token' . \PHP_EOL
+                . 'Content-Type: application/json' . \PHP_EOL
+                . \PHP_EOL,
             ],
         ];
     }

--- a/tests/Integration/Psr18ClientRequestGenerationTest.php
+++ b/tests/Integration/Psr18ClientRequestGenerationTest.php
@@ -21,6 +21,7 @@ class Psr18ClientRequestGenerationTest extends TestCase
 {
     /**
      * @dataProvider createdGetRequestsData
+     * @param mixed $data
      */
     #[DataProvider('createdGetRequestsData')]
     public function testPsr18ClientCreatesCorrectRequests(

--- a/tests/RedmineExtension/BehatHookTracer.php
+++ b/tests/RedmineExtension/BehatHookTracer.php
@@ -12,13 +12,10 @@ use RuntimeException;
 
 final class BehatHookTracer implements InstanceRegistration
 {
-    /**
-     * @var RedmineInstance[] $instances
-     */
     private static ?BehatHookTracer $tracer = null;
 
     /**
-     * @var RedmineInstance[] $instances
+     * @var RedmineInstance[]
      */
     private static array $instances = [];
 

--- a/tests/RedmineExtension/RedmineInstance.php
+++ b/tests/RedmineExtension/RedmineInstance.php
@@ -152,6 +152,9 @@ final class RedmineInstance
 
     /**
      * Allows tests to prepare the database
+     *
+     * @param array<mixed> $options
+     * @param null|array<mixed> $params
      */
     public function excecuteDatabaseQuery(string $query, array $options = [], ?array $params = null): void
     {

--- a/tests/Unit/Api/AbstractApi/DeleteTest.php
+++ b/tests/Unit/Api/AbstractApi/DeleteTest.php
@@ -66,6 +66,9 @@ class DeleteTest extends TestCase
         $this->assertSame($expected, $return);
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getXmlDecodingFromDeleteMethodData(): array
     {
         return [

--- a/tests/Unit/Api/AbstractApi/GetTest.php
+++ b/tests/Unit/Api/AbstractApi/GetTest.php
@@ -72,6 +72,9 @@ class GetTest extends TestCase
         }
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getJsonDecodingFromGetMethodData(): array
     {
         return [
@@ -133,6 +136,9 @@ class GetTest extends TestCase
         $this->assertXmlStringEqualsXmlString($expected, $return->asXML());
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getXmlDecodingFromGetMethodData(): array
     {
         return [

--- a/tests/Unit/Api/AbstractApi/GetTest.php
+++ b/tests/Unit/Api/AbstractApi/GetTest.php
@@ -47,6 +47,7 @@ class GetTest extends TestCase
 
     /**
      * @dataProvider getJsonDecodingFromGetMethodData
+     *
      * @param mixed $expected
      */
     #[DataProvider('getJsonDecodingFromGetMethodData')]

--- a/tests/Unit/Api/AbstractApi/GetTest.php
+++ b/tests/Unit/Api/AbstractApi/GetTest.php
@@ -47,6 +47,7 @@ class GetTest extends TestCase
 
     /**
      * @dataProvider getJsonDecodingFromGetMethodData
+     * @param mixed $expected
      */
     #[DataProvider('getJsonDecodingFromGetMethodData')]
     public function testJsonDecodingFromGetMethod(string $response, ?bool $shouldDecode, $expected): void

--- a/tests/Unit/Api/AbstractApi/PostTest.php
+++ b/tests/Unit/Api/AbstractApi/PostTest.php
@@ -69,6 +69,9 @@ class PostTest extends TestCase
         $this->assertXmlStringEqualsXmlString($expected, $return->asXML());
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getXmlDecodingFromPostMethodData(): array
     {
         return [

--- a/tests/Unit/Api/AbstractApi/PutTest.php
+++ b/tests/Unit/Api/AbstractApi/PutTest.php
@@ -69,6 +69,9 @@ class PutTest extends TestCase
         $this->assertXmlStringEqualsXmlString($expected, $return->asXML());
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getXmlDecodingFromPutMethodData(): array
     {
         return [

--- a/tests/Unit/Api/AbstractApiTest.php
+++ b/tests/Unit/Api/AbstractApiTest.php
@@ -202,6 +202,9 @@ class AbstractApiTest extends TestCase
         $this->assertSame($expected, $method->invoke($api, $value));
     }
 
+    /**
+     * @return array<array{bool, mixed}>
+     */
     public static function getIsNotNullReturnsCorrectBooleanData(): array
     {
         return [
@@ -304,6 +307,9 @@ class AbstractApiTest extends TestCase
         $this->assertSame($expectedBoolean, $api->lastCallFailed());
     }
 
+    /**
+     * @return array<array{int, bool}>
+     */
     public static function getLastCallFailedData(): array
     {
         return [
@@ -398,6 +404,9 @@ class AbstractApiTest extends TestCase
         $this->assertSame($expected, $method->invoke($api, $path));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function retrieveDataData(): array
     {
         return [
@@ -486,6 +495,9 @@ class AbstractApiTest extends TestCase
         $method->invoke($api, '/issues.json');
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getRetrieveDataToExceptionData(): array
     {
         return [
@@ -516,6 +528,9 @@ class AbstractApiTest extends TestCase
         $this->assertSame($expected, $method->invoke($api, ''));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getRetrieveAllData(): array
     {
         return [

--- a/tests/Unit/Api/AbstractApiTest.php
+++ b/tests/Unit/Api/AbstractApiTest.php
@@ -60,7 +60,7 @@ class AbstractApiTest extends TestCase
         $client = $this->createStub(HttpClient::class);
 
         $api = new class ($client) extends AbstractApi {
-            public function runGet($path)
+            public function runGet(string $path)
             {
                 return $this->get($path);
             }
@@ -97,7 +97,10 @@ class AbstractApiTest extends TestCase
         $client = $this->createStub(HttpClient::class);
 
         $api = new class ($client) extends AbstractApi {
-            public function runPost($path, $data)
+            /**
+             * @param mixed $data
+             */
+            public function runPost(string $path, $data)
             {
                 return $this->post($path, $data);
             }
@@ -125,7 +128,10 @@ class AbstractApiTest extends TestCase
         $client = $this->createStub(HttpClient::class);
 
         $api = new class ($client) extends AbstractApi {
-            public function runPut($path, $data)
+            /**
+             * @param mixed $data
+             */
+            public function runPut(string $path, $data)
             {
                 return $this->put($path, $data);
             }
@@ -153,7 +159,7 @@ class AbstractApiTest extends TestCase
         $client = $this->createStub(HttpClient::class);
 
         $api = new class ($client) extends AbstractApi {
-            public function runDelete($path)
+            public function runDelete(string $path)
             {
                 return $this->delete($path);
             }
@@ -371,6 +377,8 @@ class AbstractApiTest extends TestCase
 
     /**
      * @dataProvider retrieveDataData
+     *
+     * @param array<mixed> $expected
      */
     #[DataProvider('retrieveDataData')]
     public function testRetrieveData(string $path, string $contentType, string $response, array $expected): void

--- a/tests/Unit/Api/AbstractApiTest.php
+++ b/tests/Unit/Api/AbstractApiTest.php
@@ -178,6 +178,7 @@ class AbstractApiTest extends TestCase
 
     /**
      * @dataProvider getIsNotNullReturnsCorrectBooleanData
+     * @param mixed $value
      */
     #[DataProvider('getIsNotNullReturnsCorrectBooleanData')]
     public function testIsNotNullReturnsCorrectBoolean(bool $expected, $value): void
@@ -485,6 +486,7 @@ class AbstractApiTest extends TestCase
 
     /**
      * @dataProvider getRetrieveAllData
+     * @param mixed $expected
      */
     #[DataProvider('getRetrieveAllData')]
     public function testDeprecatedRetrieveAll(string $content, string $contentType, $expected): void

--- a/tests/Unit/Api/AbstractApiTest.php
+++ b/tests/Unit/Api/AbstractApiTest.php
@@ -60,6 +60,9 @@ class AbstractApiTest extends TestCase
         $client = $this->createStub(HttpClient::class);
 
         $api = new class ($client) extends AbstractApi {
+            /**
+             * @return mixed
+             */
             public function runGet(string $path)
             {
                 return $this->get($path);
@@ -99,6 +102,8 @@ class AbstractApiTest extends TestCase
         $api = new class ($client) extends AbstractApi {
             /**
              * @param mixed $data
+             *
+             * @return mixed
              */
             public function runPost(string $path, $data)
             {
@@ -130,6 +135,8 @@ class AbstractApiTest extends TestCase
         $api = new class ($client) extends AbstractApi {
             /**
              * @param mixed $data
+             *
+             * @return mixed
              */
             public function runPut(string $path, $data)
             {
@@ -159,7 +166,7 @@ class AbstractApiTest extends TestCase
         $client = $this->createStub(HttpClient::class);
 
         $api = new class ($client) extends AbstractApi {
-            public function runDelete(string $path)
+            public function runDelete(string $path): string
             {
                 return $this->delete($path);
             }

--- a/tests/Unit/Api/AbstractApiTest.php
+++ b/tests/Unit/Api/AbstractApiTest.php
@@ -178,6 +178,7 @@ class AbstractApiTest extends TestCase
 
     /**
      * @dataProvider getIsNotNullReturnsCorrectBooleanData
+     *
      * @param mixed $value
      */
     #[DataProvider('getIsNotNullReturnsCorrectBooleanData')]
@@ -486,6 +487,7 @@ class AbstractApiTest extends TestCase
 
     /**
      * @dataProvider getRetrieveAllData
+     *
      * @param mixed $expected
      */
     #[DataProvider('getRetrieveAllData')]

--- a/tests/Unit/Api/Attachment/DownloadTest.php
+++ b/tests/Unit/Api/Attachment/DownloadTest.php
@@ -40,6 +40,9 @@ class DownloadTest extends TestCase
         $this->assertSame($expectedReturn, $api->download($id));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getDownloadData(): array
     {
         return [

--- a/tests/Unit/Api/Attachment/DownloadTest.php
+++ b/tests/Unit/Api/Attachment/DownloadTest.php
@@ -13,6 +13,8 @@ class DownloadTest extends TestCase
 {
     /**
      * @dataProvider getDownloadData
+     * @param mixed $id
+     * @param mixed $expectedReturn
      */
     #[DataProvider('getDownloadData')]
     public function testDownloadReturnsCorrectResponse($id, string $expectedPath, int $responseCode, string $response, $expectedReturn): void

--- a/tests/Unit/Api/Attachment/DownloadTest.php
+++ b/tests/Unit/Api/Attachment/DownloadTest.php
@@ -13,6 +13,7 @@ class DownloadTest extends TestCase
 {
     /**
      * @dataProvider getDownloadData
+     *
      * @param mixed $id
      * @param mixed $expectedReturn
      */

--- a/tests/Unit/Api/Attachment/ShowTest.php
+++ b/tests/Unit/Api/Attachment/ShowTest.php
@@ -13,6 +13,8 @@ class ShowTest extends TestCase
 {
     /**
      * @dataProvider getShowData
+     * @param mixed $id
+     * @param mixed $expectedReturn
      */
     #[DataProvider('getShowData')]
     public function testShowReturnsCorrectResponse($id, string $expectedPath, string $response, $expectedReturn): void

--- a/tests/Unit/Api/Attachment/ShowTest.php
+++ b/tests/Unit/Api/Attachment/ShowTest.php
@@ -46,8 +46,7 @@ class ShowTest extends TestCase
                 '["API Response"]',
                 ['API Response'],
             ],
-            'array response with string id' =>
-            [
+            'array response with string id' => [
                 '5',
                 '/attachments/5.json',
                 '["API Response"]',

--- a/tests/Unit/Api/Attachment/ShowTest.php
+++ b/tests/Unit/Api/Attachment/ShowTest.php
@@ -40,6 +40,9 @@ class ShowTest extends TestCase
         $this->assertSame($expectedReturn, $api->show($id));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getShowData(): array
     {
         return [

--- a/tests/Unit/Api/Attachment/ShowTest.php
+++ b/tests/Unit/Api/Attachment/ShowTest.php
@@ -13,6 +13,7 @@ class ShowTest extends TestCase
 {
     /**
      * @dataProvider getShowData
+     *
      * @param mixed $id
      * @param mixed $expectedReturn
      */

--- a/tests/Unit/Api/Attachment/UpdateTest.php
+++ b/tests/Unit/Api/Attachment/UpdateTest.php
@@ -14,9 +14,11 @@ class UpdateTest extends TestCase
 {
     /**
      * @dataProvider getUpdateData
+     *
+     * @param array<mixed> $parameters
      */
     #[DataProvider('getUpdateData')]
-    public function testUpdateReturnsCorrectResponse(int $id, array $params, string $expectedPath, string $expectedContent, bool $expectedReturn): void
+    public function testUpdateReturnsCorrectResponse(int $id, array $parameters, string $expectedPath, string $expectedContent, bool $expectedReturn): void
     {
         $client = AssertingHttpClient::create(
             $this,
@@ -35,7 +37,7 @@ class UpdateTest extends TestCase
         $api = Attachment::fromHttpClient($client);
 
         // Perform the tests
-        $this->assertSame($expectedReturn, $api->update($id, $params));
+        $this->assertSame($expectedReturn, $api->update($id, $parameters));
     }
 
     public static function getUpdateData(): array

--- a/tests/Unit/Api/Attachment/UpdateTest.php
+++ b/tests/Unit/Api/Attachment/UpdateTest.php
@@ -40,6 +40,9 @@ class UpdateTest extends TestCase
         $this->assertSame($expectedReturn, $api->update($id, $parameters));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getUpdateData(): array
     {
         return [

--- a/tests/Unit/Api/Attachment/UploadTest.php
+++ b/tests/Unit/Api/Attachment/UploadTest.php
@@ -13,9 +13,11 @@ class UploadTest extends TestCase
 {
     /**
      * @dataProvider getUploadData
+     *
+     * @param array<mixed> $parameters
      */
     #[DataProvider('getUploadData')]
-    public function testUploadReturnsCorrectResponse(string $attachment, array $params, string $expectedAttachment, string $expectedPath, int $responseCode, string $response, string $expectedReturn): void
+    public function testUploadReturnsCorrectResponse(string $attachment, array $parameters, string $expectedAttachment, string $expectedPath, int $responseCode, string $response, string $expectedReturn): void
     {
         $client = AssertingHttpClient::create(
             $this,
@@ -34,7 +36,7 @@ class UploadTest extends TestCase
         $api = Attachment::fromHttpClient($client);
 
         // Perform the tests
-        $this->assertSame($expectedReturn, $api->upload($attachment, $params));
+        $this->assertSame($expectedReturn, $api->upload($attachment, $parameters));
     }
 
     public static function getUploadData(): array

--- a/tests/Unit/Api/Attachment/UploadTest.php
+++ b/tests/Unit/Api/Attachment/UploadTest.php
@@ -39,6 +39,9 @@ class UploadTest extends TestCase
         $this->assertSame($expectedReturn, $api->upload($attachment, $parameters));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getUploadData(): array
     {
         return [

--- a/tests/Unit/Api/AttachmentTest.php
+++ b/tests/Unit/Api/AttachmentTest.php
@@ -94,7 +94,7 @@ class AttachmentTest extends TestCase
     /**
      * Data provider for response code and expected state.
      *
-     * @return array[]
+     * @return array<array<mixed>>
      */
     public static function responseCodeProvider(): array
     {

--- a/tests/Unit/Api/AttachmentTest.php
+++ b/tests/Unit/Api/AttachmentTest.php
@@ -6,7 +6,6 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Attachment;
-use Redmine\Client\Client;
 use Redmine\Http\HttpClient;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 

--- a/tests/Unit/Api/CustomField/ListNamesTest.php
+++ b/tests/Unit/Api/CustomField/ListNamesTest.php
@@ -41,6 +41,9 @@ class ListNamesTest extends TestCase
         $this->assertSame($expectedResponse, $api->listNames());
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getListNamesData(): array
     {
         return [

--- a/tests/Unit/Api/CustomField/ListNamesTest.php
+++ b/tests/Unit/Api/CustomField/ListNamesTest.php
@@ -15,6 +15,8 @@ class ListNamesTest extends TestCase
 {
     /**
      * @dataProvider getListNamesData
+     *
+     * @param array<mixed> $expectedResponse
      */
     #[DataProvider('getListNamesData')]
     public function testListNamesReturnsCorrectResponse(string $expectedPath, int $responseCode, string $response, array $expectedResponse): void

--- a/tests/Unit/Api/CustomFieldTest.php
+++ b/tests/Unit/Api/CustomFieldTest.php
@@ -81,6 +81,7 @@ class CustomFieldTest extends TestCase
      * Test all().
      *
      * @dataProvider getAllData
+     *
      * @param mixed $expectedResponse
      */
     #[DataProvider('getAllData')]

--- a/tests/Unit/Api/CustomFieldTest.php
+++ b/tests/Unit/Api/CustomFieldTest.php
@@ -107,6 +107,9 @@ class CustomFieldTest extends TestCase
         $this->assertSame($expectedResponse, $api->all());
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getAllData(): array
     {
         return [

--- a/tests/Unit/Api/CustomFieldTest.php
+++ b/tests/Unit/Api/CustomFieldTest.php
@@ -81,6 +81,7 @@ class CustomFieldTest extends TestCase
      * Test all().
      *
      * @dataProvider getAllData
+     * @param mixed $expectedResponse
      */
     #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse(string $response, string $responseType, $expectedResponse): void

--- a/tests/Unit/Api/Group/AddUserTest.php
+++ b/tests/Unit/Api/Group/AddUserTest.php
@@ -41,6 +41,9 @@ class AddUserTest extends TestCase
         $this->assertXmlStringEqualsXmlString($response, $return->asXml());
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getAddUserData(): array
     {
         return [

--- a/tests/Unit/Api/Group/CreateTest.php
+++ b/tests/Unit/Api/Group/CreateTest.php
@@ -47,6 +47,9 @@ class CreateTest extends TestCase
         $this->assertXmlStringEqualsXmlString($response, $return->asXml());
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getCreateData(): array
     {
         return [

--- a/tests/Unit/Api/Group/CreateTest.php
+++ b/tests/Unit/Api/Group/CreateTest.php
@@ -18,6 +18,8 @@ class CreateTest extends TestCase
 {
     /**
      * @dataProvider getCreateData
+     *
+     * @param array<mixed> $parameters
      */
     #[DataProvider('getCreateData')]
     public function testCreateReturnsCorrectResponse(array $parameters, string $expectedPath, string $expectedBody, int $responseCode, string $response): void

--- a/tests/Unit/Api/Group/ListNamesTest.php
+++ b/tests/Unit/Api/Group/ListNamesTest.php
@@ -41,6 +41,9 @@ class ListNamesTest extends TestCase
         $this->assertSame($expectedResponse, $api->listNames());
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getListNamesData(): array
     {
         return [

--- a/tests/Unit/Api/Group/ListNamesTest.php
+++ b/tests/Unit/Api/Group/ListNamesTest.php
@@ -15,6 +15,8 @@ class ListNamesTest extends TestCase
 {
     /**
      * @dataProvider getListNamesData
+     *
+     * @param array<mixed> $expectedResponse
      */
     #[DataProvider('getListNamesData')]
     public function testListNamesReturnsCorrectResponse(string $expectedPath, int $responseCode, string $response, array $expectedResponse): void

--- a/tests/Unit/Api/Group/ShowTest.php
+++ b/tests/Unit/Api/Group/ShowTest.php
@@ -13,6 +13,7 @@ class ShowTest extends TestCase
 {
     /**
      * @dataProvider getShowData
+     *
      * @param mixed $groupId
      * @param mixed $expectedReturn
      */

--- a/tests/Unit/Api/Group/ShowTest.php
+++ b/tests/Unit/Api/Group/ShowTest.php
@@ -14,11 +14,12 @@ class ShowTest extends TestCase
     /**
      * @dataProvider getShowData
      *
-     * @param mixed $groupId
+     * @param string|int $groupId
+     * @param array<mixed> $parameters
      * @param mixed $expectedReturn
      */
     #[DataProvider('getShowData')]
-    public function testShowReturnsCorrectResponse($groupId, array $params, string $expectedPath, string $response, $expectedReturn): void
+    public function testShowReturnsCorrectResponse($groupId, array $parameters, string $expectedPath, string $response, $expectedReturn): void
     {
         $client = AssertingHttpClient::create(
             $this,
@@ -37,7 +38,7 @@ class ShowTest extends TestCase
         $api = Group::fromHttpClient($client);
 
         // Perform the tests
-        $this->assertSame($expectedReturn, $api->show($groupId, $params));
+        $this->assertSame($expectedReturn, $api->show($groupId, $parameters));
     }
 
     public static function getShowData(): array

--- a/tests/Unit/Api/Group/ShowTest.php
+++ b/tests/Unit/Api/Group/ShowTest.php
@@ -13,6 +13,8 @@ class ShowTest extends TestCase
 {
     /**
      * @dataProvider getShowData
+     * @param mixed $groupId
+     * @param mixed $expectedReturn
      */
     #[DataProvider('getShowData')]
     public function testShowReturnsCorrectResponse($groupId, array $params, string $expectedPath, string $response, $expectedReturn): void

--- a/tests/Unit/Api/Group/ShowTest.php
+++ b/tests/Unit/Api/Group/ShowTest.php
@@ -41,6 +41,9 @@ class ShowTest extends TestCase
         $this->assertSame($expectedReturn, $api->show($groupId, $parameters));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getShowData(): array
     {
         return [

--- a/tests/Unit/Api/Group/UpdateTest.php
+++ b/tests/Unit/Api/Group/UpdateTest.php
@@ -41,6 +41,9 @@ class UpdateTest extends TestCase
         $this->assertSame('', $api->update($id, $parameters));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getUpdateData(): array
     {
         return [

--- a/tests/Unit/Api/Group/UpdateTest.php
+++ b/tests/Unit/Api/Group/UpdateTest.php
@@ -15,6 +15,8 @@ class UpdateTest extends TestCase
 {
     /**
      * @dataProvider getUpdateData
+     *
+     * @param array<mixed> $parameters
      */
     #[DataProvider('getUpdateData')]
     public function testUpdateReturnsCorrectResponse(int $id, array $parameters, string $expectedPath, string $expectedBody, int $responseCode, string $response): void

--- a/tests/Unit/Api/GroupTest.php
+++ b/tests/Unit/Api/GroupTest.php
@@ -83,6 +83,7 @@ class GroupTest extends TestCase
      * Test all().
      *
      * @dataProvider getAllData
+     * @param mixed $expectedResponse
      */
     #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse(string $response, string $responseType, $expectedResponse): void

--- a/tests/Unit/Api/GroupTest.php
+++ b/tests/Unit/Api/GroupTest.php
@@ -109,6 +109,9 @@ class GroupTest extends TestCase
         $this->assertSame($expectedResponse, $api->all());
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getAllData(): array
     {
         return [

--- a/tests/Unit/Api/GroupTest.php
+++ b/tests/Unit/Api/GroupTest.php
@@ -83,6 +83,7 @@ class GroupTest extends TestCase
      * Test all().
      *
      * @dataProvider getAllData
+     *
      * @param mixed $expectedResponse
      */
     #[DataProvider('getAllData')]

--- a/tests/Unit/Api/Issue/AddNoteToIssueTest.php
+++ b/tests/Unit/Api/Issue/AddNoteToIssueTest.php
@@ -39,6 +39,9 @@ class AddNoteToIssueTest extends TestCase
         $this->assertSame('', $api->addNoteToIssue($id, $note, $isPrivate));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getAddNoteToIssueData(): array
     {
         return [

--- a/tests/Unit/Api/Issue/AddWatcherTest.php
+++ b/tests/Unit/Api/Issue/AddWatcherTest.php
@@ -41,6 +41,9 @@ class AddWatcherTest extends TestCase
         $this->assertXmlStringEqualsXmlString($response, $return->asXml());
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getAddWatcherData(): array
     {
         return [

--- a/tests/Unit/Api/Issue/AttachManyTest.php
+++ b/tests/Unit/Api/Issue/AttachManyTest.php
@@ -13,6 +13,8 @@ class AttachManyTest extends TestCase
 {
     /**
      * @dataProvider getAttachManyData
+     *
+     * @param array<mixed> $parameters
      */
     #[DataProvider('getAttachManyData')]
     public function testAttachManyReturnsCorrectResponse(int $issueId, array $parameters, string $expectedPath, string $expectedBody, int $responseCode, string $response): void

--- a/tests/Unit/Api/Issue/AttachManyTest.php
+++ b/tests/Unit/Api/Issue/AttachManyTest.php
@@ -39,6 +39,9 @@ class AttachManyTest extends TestCase
         $this->assertSame('', $api->attachMany($issueId, $parameters));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getAttachManyData(): array
     {
         return [

--- a/tests/Unit/Api/Issue/AttachTest.php
+++ b/tests/Unit/Api/Issue/AttachTest.php
@@ -13,6 +13,8 @@ class AttachTest extends TestCase
 {
     /**
      * @dataProvider getAttachData
+     *
+     * @param array<mixed> $parameters
      */
     #[DataProvider('getAttachData')]
     public function testAttachReturnsCorrectResponse(int $issueId, array $parameters, string $expectedPath, string $expectedBody, int $responseCode, string $response): void

--- a/tests/Unit/Api/Issue/AttachTest.php
+++ b/tests/Unit/Api/Issue/AttachTest.php
@@ -39,6 +39,9 @@ class AttachTest extends TestCase
         $this->assertSame('', $api->attach($issueId, $parameters));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getAttachData(): array
     {
         return [

--- a/tests/Unit/Api/Issue/CreateTest.php
+++ b/tests/Unit/Api/Issue/CreateTest.php
@@ -14,6 +14,8 @@ class CreateTest extends TestCase
 {
     /**
      * @dataProvider getCreateData
+     *
+     * @param array<mixed> $parameters
      */
     #[DataProvider('getCreateData')]
     public function testCreateReturnsCorrectResponse(array $parameters, string $expectedPath, string $expectedBody, int $responseCode, string $response): void

--- a/tests/Unit/Api/Issue/CreateTest.php
+++ b/tests/Unit/Api/Issue/CreateTest.php
@@ -43,6 +43,9 @@ class CreateTest extends TestCase
         $this->assertXmlStringEqualsXmlString($response, $return->asXml());
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getCreateData(): array
     {
         return [

--- a/tests/Unit/Api/Issue/RemoveTest.php
+++ b/tests/Unit/Api/Issue/RemoveTest.php
@@ -37,6 +37,9 @@ class RemoveTest extends TestCase
         $this->assertSame($response, $api->remove($issueId));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getRemoveData(): array
     {
         return [

--- a/tests/Unit/Api/Issue/RemoveWatcherTest.php
+++ b/tests/Unit/Api/Issue/RemoveWatcherTest.php
@@ -37,6 +37,9 @@ class RemoveWatcherTest extends TestCase
         $this->assertSame($response, $api->removeWatcher($issueId, $watcherUserId));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getRemoveWatcherData(): array
     {
         return [

--- a/tests/Unit/Api/Issue/ShowTest.php
+++ b/tests/Unit/Api/Issue/ShowTest.php
@@ -41,6 +41,9 @@ class ShowTest extends TestCase
         $this->assertSame($expectedReturn, $api->show($issueId, $parameters));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getShowData(): array
     {
         return [

--- a/tests/Unit/Api/Issue/ShowTest.php
+++ b/tests/Unit/Api/Issue/ShowTest.php
@@ -13,6 +13,8 @@ class ShowTest extends TestCase
 {
     /**
      * @dataProvider getShowData
+     * @param mixed $issueId
+     * @param mixed $expectedReturn
      */
     #[DataProvider('getShowData')]
     public function testShowReturnsCorrectResponse($issueId, array $params, string $expectedPath, string $response, $expectedReturn): void

--- a/tests/Unit/Api/Issue/ShowTest.php
+++ b/tests/Unit/Api/Issue/ShowTest.php
@@ -15,10 +15,11 @@ class ShowTest extends TestCase
      * @dataProvider getShowData
      *
      * @param mixed $issueId
+     * @param array<mixed> $parameters
      * @param mixed $expectedReturn
      */
     #[DataProvider('getShowData')]
-    public function testShowReturnsCorrectResponse($issueId, array $params, string $expectedPath, string $response, $expectedReturn): void
+    public function testShowReturnsCorrectResponse($issueId, array $parameters, string $expectedPath, string $response, $expectedReturn): void
     {
         $client = AssertingHttpClient::create(
             $this,
@@ -37,7 +38,7 @@ class ShowTest extends TestCase
         $api = Issue::fromHttpClient($client);
 
         // Perform the tests
-        $this->assertSame($expectedReturn, $api->show($issueId, $params));
+        $this->assertSame($expectedReturn, $api->show($issueId, $parameters));
     }
 
     public static function getShowData(): array

--- a/tests/Unit/Api/Issue/ShowTest.php
+++ b/tests/Unit/Api/Issue/ShowTest.php
@@ -13,6 +13,7 @@ class ShowTest extends TestCase
 {
     /**
      * @dataProvider getShowData
+     *
      * @param mixed $issueId
      * @param mixed $expectedReturn
      */

--- a/tests/Unit/Api/Issue/UpdateTest.php
+++ b/tests/Unit/Api/Issue/UpdateTest.php
@@ -41,6 +41,9 @@ class UpdateTest extends TestCase
         $this->assertSame('', $api->update($id, $parameters));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getUpdateData(): array
     {
         return [

--- a/tests/Unit/Api/Issue/UpdateTest.php
+++ b/tests/Unit/Api/Issue/UpdateTest.php
@@ -15,6 +15,8 @@ class UpdateTest extends TestCase
 {
     /**
      * @dataProvider getUpdateData
+     *
+     * @param array<mixed> $parameters
      */
     #[DataProvider('getUpdateData')]
     public function testUpdateReturnsCorrectResponse(int $id, array $parameters, string $expectedPath, string $expectedBody, int $responseCode, string $response): void

--- a/tests/Unit/Api/IssueCategory/CreateTest.php
+++ b/tests/Unit/Api/IssueCategory/CreateTest.php
@@ -46,6 +46,9 @@ class CreateTest extends TestCase
         $this->assertXmlStringEqualsXmlString($response, $return->asXml());
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getCreateData(): array
     {
         return [
@@ -139,7 +142,7 @@ class CreateTest extends TestCase
     /**
      * Provider for incomplete create parameters.
      *
-     * @return array[]
+     * @return array<array<mixed>>
      */
     public static function incompleteCreateParameterProvider(): array
     {

--- a/tests/Unit/Api/IssueCategory/CreateTest.php
+++ b/tests/Unit/Api/IssueCategory/CreateTest.php
@@ -17,7 +17,8 @@ class CreateTest extends TestCase
     /**
      * @dataProvider getCreateData
      *
-     * @param mixed $identifier
+     * @param string|int $identifier
+     * @param array<mixed> $parameters
      */
     #[DataProvider('getCreateData')]
     public function testCreateReturnsCorrectResponse($identifier, array $parameters, string $expectedPath, string $expectedBody, int $responseCode, string $response): void
@@ -116,6 +117,8 @@ class CreateTest extends TestCase
 
     /**
      * @dataProvider incompleteCreateParameterProvider
+     *
+     * @param array<mixed> $parameters
      */
     #[DataProvider('incompleteCreateParameterProvider')]
     public function testCreateThrowsExceptionIfMandatoyParametersAreMissing(array $parameters): void

--- a/tests/Unit/Api/IssueCategory/CreateTest.php
+++ b/tests/Unit/Api/IssueCategory/CreateTest.php
@@ -16,6 +16,7 @@ class CreateTest extends TestCase
 {
     /**
      * @dataProvider getCreateData
+     * @param mixed $identifier
      */
     #[DataProvider('getCreateData')]
     public function testCreateReturnsCorrectResponse($identifier, array $parameters, string $expectedPath, string $expectedBody, int $responseCode, string $response): void

--- a/tests/Unit/Api/IssueCategory/CreateTest.php
+++ b/tests/Unit/Api/IssueCategory/CreateTest.php
@@ -16,6 +16,7 @@ class CreateTest extends TestCase
 {
     /**
      * @dataProvider getCreateData
+     *
      * @param mixed $identifier
      */
     #[DataProvider('getCreateData')]

--- a/tests/Unit/Api/IssueCategory/ListByProjectTest.php
+++ b/tests/Unit/Api/IssueCategory/ListByProjectTest.php
@@ -72,6 +72,7 @@ class ListByProjectTest extends TestCase
 
     /**
      * @dataProvider Redmine\Tests\Fixtures\TestDataProvider::getInvalidProjectIdentifiers
+     *
      * @param mixed $projectIdentifier
      */
     #[DataProviderExternal(TestDataProvider::class, 'getInvalidProjectIdentifiers')]

--- a/tests/Unit/Api/IssueCategory/ListByProjectTest.php
+++ b/tests/Unit/Api/IssueCategory/ListByProjectTest.php
@@ -72,6 +72,7 @@ class ListByProjectTest extends TestCase
 
     /**
      * @dataProvider Redmine\Tests\Fixtures\TestDataProvider::getInvalidProjectIdentifiers
+     * @param mixed $projectIdentifier
      */
     #[DataProviderExternal(TestDataProvider::class, 'getInvalidProjectIdentifiers')]
     public function testListByProjectWithWrongProjectIdentifierThrowsException($projectIdentifier): void

--- a/tests/Unit/Api/IssueCategory/ListNamesByProjectTest.php
+++ b/tests/Unit/Api/IssueCategory/ListNamesByProjectTest.php
@@ -20,7 +20,8 @@ class ListNamesByProjectTest extends TestCase
     /**
      * @dataProvider getListNamesByProjectData
      *
-     * @param mixed $projectIdentifier
+     * @param string|int $projectIdentifier
+     * @param array<mixed> $expectedResponse
      */
     #[DataProvider('getListNamesByProjectData')]
     public function testListNamesByProjectReturnsCorrectResponse($projectIdentifier, string $expectedPath, int $responseCode, string $response, array $expectedResponse): void

--- a/tests/Unit/Api/IssueCategory/ListNamesByProjectTest.php
+++ b/tests/Unit/Api/IssueCategory/ListNamesByProjectTest.php
@@ -19,6 +19,7 @@ class ListNamesByProjectTest extends TestCase
 {
     /**
      * @dataProvider getListNamesByProjectData
+     * @param mixed $projectIdentifier
      */
     #[DataProvider('getListNamesByProjectData')]
     public function testListNamesByProjectReturnsCorrectResponse($projectIdentifier, string $expectedPath, int $responseCode, string $response, array $expectedResponse): void
@@ -114,6 +115,7 @@ class ListNamesByProjectTest extends TestCase
 
     /**
      * @dataProvider Redmine\Tests\Fixtures\TestDataProvider::getInvalidProjectIdentifiers
+     * @param mixed $projectIdentifier
      */
     #[DataProviderExternal(TestDataProvider::class, 'getInvalidProjectIdentifiers')]
     public function testListNamesByProjectWithWrongProjectIdentifierThrowsException($projectIdentifier): void

--- a/tests/Unit/Api/IssueCategory/ListNamesByProjectTest.php
+++ b/tests/Unit/Api/IssueCategory/ListNamesByProjectTest.php
@@ -19,6 +19,7 @@ class ListNamesByProjectTest extends TestCase
 {
     /**
      * @dataProvider getListNamesByProjectData
+     *
      * @param mixed $projectIdentifier
      */
     #[DataProvider('getListNamesByProjectData')]
@@ -115,6 +116,7 @@ class ListNamesByProjectTest extends TestCase
 
     /**
      * @dataProvider Redmine\Tests\Fixtures\TestDataProvider::getInvalidProjectIdentifiers
+     *
      * @param mixed $projectIdentifier
      */
     #[DataProviderExternal(TestDataProvider::class, 'getInvalidProjectIdentifiers')]

--- a/tests/Unit/Api/IssueCategory/ListNamesByProjectTest.php
+++ b/tests/Unit/Api/IssueCategory/ListNamesByProjectTest.php
@@ -46,6 +46,9 @@ class ListNamesByProjectTest extends TestCase
         $this->assertSame($expectedResponse, $api->listNamesByProject($projectIdentifier));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getListNamesByProjectData(): array
     {
         return [

--- a/tests/Unit/Api/IssueCategory/RemoveTest.php
+++ b/tests/Unit/Api/IssueCategory/RemoveTest.php
@@ -39,6 +39,9 @@ class RemoveTest extends TestCase
         $this->assertSame($response, $api->remove($issueId, $parameters));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getRemoveData(): array
     {
         return [

--- a/tests/Unit/Api/IssueCategory/RemoveTest.php
+++ b/tests/Unit/Api/IssueCategory/RemoveTest.php
@@ -13,9 +13,11 @@ class RemoveTest extends TestCase
 {
     /**
      * @dataProvider getRemoveData
+     *
+     * @param array<mixed> $parameters
      */
     #[DataProvider('getRemoveData')]
-    public function testRemoveReturnsCorrectResponse(int $issueId, array $params, string $expectedPath, int $responseCode, string $response): void
+    public function testRemoveReturnsCorrectResponse(int $issueId, array $parameters, string $expectedPath, int $responseCode, string $response): void
     {
         $client = AssertingHttpClient::create(
             $this,
@@ -34,7 +36,7 @@ class RemoveTest extends TestCase
         $api = IssueCategory::fromHttpClient($client);
 
         // Perform the tests
-        $this->assertSame($response, $api->remove($issueId, $params));
+        $this->assertSame($response, $api->remove($issueId, $parameters));
     }
 
     public static function getRemoveData(): array

--- a/tests/Unit/Api/IssueCategory/ShowTest.php
+++ b/tests/Unit/Api/IssueCategory/ShowTest.php
@@ -13,6 +13,8 @@ class ShowTest extends TestCase
 {
     /**
      * @dataProvider getShowData
+     * @param mixed $id
+     * @param mixed $expectedReturn
      */
     #[DataProvider('getShowData')]
     public function testShowReturnsCorrectResponse($id, string $expectedPath, string $response, $expectedReturn): void

--- a/tests/Unit/Api/IssueCategory/ShowTest.php
+++ b/tests/Unit/Api/IssueCategory/ShowTest.php
@@ -40,6 +40,9 @@ class ShowTest extends TestCase
         $this->assertSame($expectedReturn, $api->show($id));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getShowData(): array
     {
         return [

--- a/tests/Unit/Api/IssueCategory/ShowTest.php
+++ b/tests/Unit/Api/IssueCategory/ShowTest.php
@@ -13,6 +13,7 @@ class ShowTest extends TestCase
 {
     /**
      * @dataProvider getShowData
+     *
      * @param mixed $id
      * @param mixed $expectedReturn
      */

--- a/tests/Unit/Api/IssueCategory/UpdateTest.php
+++ b/tests/Unit/Api/IssueCategory/UpdateTest.php
@@ -41,6 +41,9 @@ class UpdateTest extends TestCase
         $this->assertSame('', $api->update($id, $parameters));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getUpdateData(): array
     {
         return [

--- a/tests/Unit/Api/IssueCategory/UpdateTest.php
+++ b/tests/Unit/Api/IssueCategory/UpdateTest.php
@@ -15,6 +15,8 @@ class UpdateTest extends TestCase
 {
     /**
      * @dataProvider getUpdateData
+     *
+     * @param array<mixed> $parameters
      */
     #[DataProvider('getUpdateData')]
     public function testUpdateReturnsCorrectResponse(int $id, array $parameters, string $expectedPath, string $expectedBody, int $responseCode, string $response): void

--- a/tests/Unit/Api/IssueCategoryTest.php
+++ b/tests/Unit/Api/IssueCategoryTest.php
@@ -81,6 +81,7 @@ class IssueCategoryTest extends TestCase
      * Test all().
      *
      * @dataProvider getAllDAta
+     * @param mixed $expectedResponse
      */
     #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponseWithProject(string $response, string $responseType, $expectedResponse): void

--- a/tests/Unit/Api/IssueCategoryTest.php
+++ b/tests/Unit/Api/IssueCategoryTest.php
@@ -110,6 +110,9 @@ class IssueCategoryTest extends TestCase
         $this->assertSame($expectedResponse, $api->all($projectId));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getAllData(): array
     {
         return [

--- a/tests/Unit/Api/IssueCategoryTest.php
+++ b/tests/Unit/Api/IssueCategoryTest.php
@@ -81,6 +81,7 @@ class IssueCategoryTest extends TestCase
      * Test all().
      *
      * @dataProvider getAllDAta
+     *
      * @param mixed $expectedResponse
      */
     #[DataProvider('getAllData')]

--- a/tests/Unit/Api/IssuePriority/ListTest.php
+++ b/tests/Unit/Api/IssuePriority/ListTest.php
@@ -5,7 +5,6 @@ namespace Redmine\Tests\Unit\Api\IssuePriority;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\IssuePriority;
-use Redmine\Client\Client;
 use Redmine\Exception\UnexpectedResponseException;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 

--- a/tests/Unit/Api/IssuePriorityTest.php
+++ b/tests/Unit/Api/IssuePriorityTest.php
@@ -81,6 +81,7 @@ class IssuePriorityTest extends TestCase
      * Test all().
      *
      * @dataProvider getAllData
+     *
      * @param mixed $expectedResponse
      */
     #[DataProvider('getAllData')]

--- a/tests/Unit/Api/IssuePriorityTest.php
+++ b/tests/Unit/Api/IssuePriorityTest.php
@@ -107,6 +107,9 @@ class IssuePriorityTest extends TestCase
         $this->assertSame($expectedResponse, $api->all());
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getAllData(): array
     {
         return [

--- a/tests/Unit/Api/IssuePriorityTest.php
+++ b/tests/Unit/Api/IssuePriorityTest.php
@@ -81,6 +81,7 @@ class IssuePriorityTest extends TestCase
      * Test all().
      *
      * @dataProvider getAllData
+     * @param mixed $expectedResponse
      */
     #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse(string $response, string $responseType, $expectedResponse): void

--- a/tests/Unit/Api/IssueRelation/CreateTest.php
+++ b/tests/Unit/Api/IssueRelation/CreateTest.php
@@ -16,6 +16,9 @@ class CreateTest extends TestCase
 {
     /**
      * @dataProvider getCreateData
+     *
+     * @param array<mixed> $parameters
+     * @param array<mixed> $expectedReturn
      */
     #[DataProvider('getCreateData')]
     public function testCreateReturnsCorrectResponse(int $issueId, array $parameters, string $expectedPath, string $expectedBody, int $responseCode, string $response, array $expectedReturn): void
@@ -100,6 +103,8 @@ class CreateTest extends TestCase
 
     /**
      * @dataProvider incompleteCreateParameterProvider
+     *
+     * @param array<mixed> $parameters
      */
     #[DataProvider('incompleteCreateParameterProvider')]
     public function testCreateThrowsExceptionIfMandatoyParametersAreMissing(array $parameters): void

--- a/tests/Unit/Api/IssueRelation/CreateTest.php
+++ b/tests/Unit/Api/IssueRelation/CreateTest.php
@@ -46,6 +46,9 @@ class CreateTest extends TestCase
         $this->assertSame($expectedReturn, $return);
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getCreateData(): array
     {
         return [
@@ -125,7 +128,7 @@ class CreateTest extends TestCase
     /**
      * Provider for incomplete create parameters.
      *
-     * @return array[]
+     * @return array<array<mixed>>
      */
     public static function incompleteCreateParameterProvider(): array
     {

--- a/tests/Unit/Api/IssueRelation/ListByIssueIdTest.php
+++ b/tests/Unit/Api/IssueRelation/ListByIssueIdTest.php
@@ -5,7 +5,6 @@ namespace Redmine\Tests\Unit\Api\IssueRelation;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\IssueRelation;
-use Redmine\Client\Client;
 use Redmine\Exception\UnexpectedResponseException;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 

--- a/tests/Unit/Api/IssueRelation/RemoveTest.php
+++ b/tests/Unit/Api/IssueRelation/RemoveTest.php
@@ -37,6 +37,9 @@ class RemoveTest extends TestCase
         $this->assertSame($response, $api->remove($issueId));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getRemoveData(): array
     {
         return [

--- a/tests/Unit/Api/IssueRelation/ShowTest.php
+++ b/tests/Unit/Api/IssueRelation/ShowTest.php
@@ -13,6 +13,7 @@ class ShowTest extends TestCase
 {
     /**
      * @dataProvider getShowData
+     *
      * @param mixed $id
      */
     #[DataProvider('getShowData')]

--- a/tests/Unit/Api/IssueRelation/ShowTest.php
+++ b/tests/Unit/Api/IssueRelation/ShowTest.php
@@ -14,7 +14,8 @@ class ShowTest extends TestCase
     /**
      * @dataProvider getShowData
      *
-     * @param mixed $id
+     * @param string|int $id
+     * @param array<mixed> $expectedReturn
      */
     #[DataProvider('getShowData')]
     public function testShowReturnsCorrectResponse($id, string $expectedPath, string $response, array $expectedReturn): void

--- a/tests/Unit/Api/IssueRelation/ShowTest.php
+++ b/tests/Unit/Api/IssueRelation/ShowTest.php
@@ -13,6 +13,7 @@ class ShowTest extends TestCase
 {
     /**
      * @dataProvider getShowData
+     * @param mixed $id
      */
     #[DataProvider('getShowData')]
     public function testShowReturnsCorrectResponse($id, string $expectedPath, string $response, array $expectedReturn): void

--- a/tests/Unit/Api/IssueRelation/ShowTest.php
+++ b/tests/Unit/Api/IssueRelation/ShowTest.php
@@ -40,6 +40,9 @@ class ShowTest extends TestCase
         $this->assertSame($expectedReturn, $api->show($id));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getShowData(): array
     {
         return [

--- a/tests/Unit/Api/IssueRelationTest.php
+++ b/tests/Unit/Api/IssueRelationTest.php
@@ -81,6 +81,7 @@ class IssueRelationTest extends TestCase
      * Test all().
      *
      * @dataProvider getAllData
+     *
      * @param mixed $expectedResponse
      */
     #[DataProvider('getAllData')]

--- a/tests/Unit/Api/IssueRelationTest.php
+++ b/tests/Unit/Api/IssueRelationTest.php
@@ -81,6 +81,7 @@ class IssueRelationTest extends TestCase
      * Test all().
      *
      * @dataProvider getAllData
+     * @param mixed $expectedResponse
      */
     #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponseWithProject(string $response, string $responseType, $expectedResponse): void

--- a/tests/Unit/Api/IssueRelationTest.php
+++ b/tests/Unit/Api/IssueRelationTest.php
@@ -107,6 +107,9 @@ class IssueRelationTest extends TestCase
         $this->assertSame($expectedResponse, $api->all(5));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getAllData(): array
     {
         return [

--- a/tests/Unit/Api/IssueStatus/ListNamesTest.php
+++ b/tests/Unit/Api/IssueStatus/ListNamesTest.php
@@ -41,6 +41,9 @@ class ListNamesTest extends TestCase
         $this->assertSame($expectedResponse, $api->listNames());
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getListNamesData(): array
     {
         return [

--- a/tests/Unit/Api/IssueStatus/ListNamesTest.php
+++ b/tests/Unit/Api/IssueStatus/ListNamesTest.php
@@ -15,6 +15,8 @@ class ListNamesTest extends TestCase
 {
     /**
      * @dataProvider getListNamesData
+     *
+     * @param array<mixed> $expectedResponse
      */
     #[DataProvider('getListNamesData')]
     public function testListNamesReturnsCorrectResponse(string $expectedPath, int $responseCode, string $response, array $expectedResponse): void

--- a/tests/Unit/Api/IssueStatusTest.php
+++ b/tests/Unit/Api/IssueStatusTest.php
@@ -107,6 +107,9 @@ class IssueStatusTest extends TestCase
         $this->assertSame($expectedResponse, $api->all());
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getAllData(): array
     {
         return [

--- a/tests/Unit/Api/IssueStatusTest.php
+++ b/tests/Unit/Api/IssueStatusTest.php
@@ -81,6 +81,7 @@ class IssueStatusTest extends TestCase
      * Test all().
      *
      * @dataProvider getAllData
+     *
      * @param mixed $expectedResponse
      */
     #[DataProvider('getAllData')]

--- a/tests/Unit/Api/IssueStatusTest.php
+++ b/tests/Unit/Api/IssueStatusTest.php
@@ -81,6 +81,7 @@ class IssueStatusTest extends TestCase
      * Test all().
      *
      * @dataProvider getAllData
+     * @param mixed $expectedResponse
      */
     #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse(string $response, string $responseType, $expectedResponse): void

--- a/tests/Unit/Api/IssueTest.php
+++ b/tests/Unit/Api/IssueTest.php
@@ -59,6 +59,9 @@ class IssueTest extends TestCase
         new Issue($this->createStub(HttpClient::class));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getPriorityConstantsData(): array
     {
         return [
@@ -135,6 +138,9 @@ class IssueTest extends TestCase
         $this->assertSame($expectedResponse, $api->all());
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getAllData(): array
     {
         return [

--- a/tests/Unit/Api/IssueTest.php
+++ b/tests/Unit/Api/IssueTest.php
@@ -109,6 +109,7 @@ class IssueTest extends TestCase
      * Test all().
      *
      * @dataProvider getAllData
+     *
      * @param mixed $expectedResponse
      */
     #[DataProvider('getAllData')]

--- a/tests/Unit/Api/IssueTest.php
+++ b/tests/Unit/Api/IssueTest.php
@@ -109,6 +109,7 @@ class IssueTest extends TestCase
      * Test all().
      *
      * @dataProvider getAllData
+     * @param mixed $expectedResponse
      */
     #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse(string $response, string $responseType, $expectedResponse): void

--- a/tests/Unit/Api/Membership/CreateTest.php
+++ b/tests/Unit/Api/Membership/CreateTest.php
@@ -16,6 +16,8 @@ class CreateTest extends TestCase
 {
     /**
      * @dataProvider getCreateData
+     *
+     * @param array<mixed> $parameters
      */
     #[DataProvider('getCreateData')]
     public function testCreateReturnsCorrectResponse(int $identifier, array $parameters, string $expectedPath, string $expectedBody, int $responseCode, string $response): void
@@ -105,6 +107,8 @@ class CreateTest extends TestCase
 
     /**
      * @dataProvider incompleteCreateParameterProvider
+     *
+     * @param array<mixed> $parameters
      */
     #[DataProvider('incompleteCreateParameterProvider')]
     public function testCreateThrowsExceptionIfMandatoyParametersAreMissing(array $parameters): void

--- a/tests/Unit/Api/Membership/CreateTest.php
+++ b/tests/Unit/Api/Membership/CreateTest.php
@@ -45,6 +45,9 @@ class CreateTest extends TestCase
         $this->assertXmlStringEqualsXmlString($response, $return->asXml());
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getCreateData(): array
     {
         return [
@@ -128,7 +131,7 @@ class CreateTest extends TestCase
     /**
      * Provider for incomplete create parameters.
      *
-     * @return array[]
+     * @return array<array<mixed>>
      */
     public static function incompleteCreateParameterProvider(): array
     {

--- a/tests/Unit/Api/Membership/ListByProjectTest.php
+++ b/tests/Unit/Api/Membership/ListByProjectTest.php
@@ -70,6 +70,7 @@ class ListByProjectTest extends TestCase
 
     /**
      * @dataProvider Redmine\Tests\Fixtures\TestDataProvider::getInvalidProjectIdentifiers
+     *
      * @param mixed $projectIdentifier
      */
     #[DataProviderExternal(TestDataProvider::class, 'getInvalidProjectIdentifiers')]

--- a/tests/Unit/Api/Membership/ListByProjectTest.php
+++ b/tests/Unit/Api/Membership/ListByProjectTest.php
@@ -70,6 +70,7 @@ class ListByProjectTest extends TestCase
 
     /**
      * @dataProvider Redmine\Tests\Fixtures\TestDataProvider::getInvalidProjectIdentifiers
+     * @param mixed $projectIdentifier
      */
     #[DataProviderExternal(TestDataProvider::class, 'getInvalidProjectIdentifiers')]
     public function testListByProjectWithWrongProjectIdentifierThrowsException($projectIdentifier): void

--- a/tests/Unit/Api/Membership/RemoveMemberTest.php
+++ b/tests/Unit/Api/Membership/RemoveMemberTest.php
@@ -13,15 +13,17 @@ class RemoveMemberTest extends TestCase
 {
     /**
      * @dataProvider getRemoveMemberData
+     *
+     * @param array<mixed> $parameters
      */
     #[DataProvider('getRemoveMemberData')]
-    public function testRemoveMemberReturnsCorrectResponse(int $projectIdentifier, int $userId, array $params, string $expectedPath, int $responseCode, string $response): void
+    public function testRemoveMemberReturnsCorrectResponse(int $projectIdentifier, int $userId, array $parameters, string $expectedPath, int $responseCode, string $response): void
     {
         $client = AssertingHttpClient::create(
             $this,
             [
                 'GET',
-                '/projects/' . $projectIdentifier . '/memberships.json' . (($params !== []) ? '?' . http_build_query($params) : ''),
+                '/projects/' . $projectIdentifier . '/memberships.json' . (($parameters !== []) ? '?' . http_build_query($parameters) : ''),
                 'application/json',
                 '',
                 200,
@@ -43,7 +45,7 @@ class RemoveMemberTest extends TestCase
         $api = Membership::fromHttpClient($client);
 
         // Perform the tests
-        $this->assertSame($response, $api->removeMember($projectIdentifier, $userId, $params));
+        $this->assertSame($response, $api->removeMember($projectIdentifier, $userId, $parameters));
     }
 
     public static function getRemoveMemberData(): array

--- a/tests/Unit/Api/Membership/RemoveMemberTest.php
+++ b/tests/Unit/Api/Membership/RemoveMemberTest.php
@@ -48,6 +48,9 @@ class RemoveMemberTest extends TestCase
         $this->assertSame($response, $api->removeMember($projectIdentifier, $userId, $parameters));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getRemoveMemberData(): array
     {
         return [

--- a/tests/Unit/Api/Membership/RemoveTest.php
+++ b/tests/Unit/Api/Membership/RemoveTest.php
@@ -37,6 +37,9 @@ class RemoveTest extends TestCase
         $this->assertSame($response, $api->remove($id));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getRemoveData(): array
     {
         return [

--- a/tests/Unit/Api/Membership/UpdateTest.php
+++ b/tests/Unit/Api/Membership/UpdateTest.php
@@ -15,6 +15,8 @@ class UpdateTest extends TestCase
 {
     /**
      * @dataProvider getUpdateData
+     *
+     * @param array<mixed> $parameters
      */
     #[DataProvider('getUpdateData')]
     public function testUpdateReturnsCorrectResponse(int $id, array $parameters, string $expectedPath, string $expectedBody, int $responseCode, string $response): void
@@ -103,6 +105,8 @@ class UpdateTest extends TestCase
 
     /**
      * @dataProvider incompleteUpdateParameterProvider
+     *
+     * @param array<mixed> $parameters
      */
     #[DataProvider('incompleteUpdateParameterProvider')]
     public function testUpdateThrowsExceptionIfMandatoyParametersAreMissing(array $parameters): void

--- a/tests/Unit/Api/Membership/UpdateTest.php
+++ b/tests/Unit/Api/Membership/UpdateTest.php
@@ -41,6 +41,9 @@ class UpdateTest extends TestCase
         $this->assertSame('', $api->update($id, $parameters));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getUpdateData(): array
     {
         return [
@@ -127,7 +130,7 @@ class UpdateTest extends TestCase
     /**
      * Provider for incomplete create parameters.
      *
-     * @return array[]
+     * @return array<array<mixed>>
      */
     public static function incompleteUpdateParameterProvider(): array
     {

--- a/tests/Unit/Api/MembershipTest.php
+++ b/tests/Unit/Api/MembershipTest.php
@@ -81,6 +81,7 @@ class MembershipTest extends TestCase
      * Test all().
      *
      * @dataProvider getAllData
+     * @param mixed $expectedResponse
      */
     #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponseWithProject(string $response, string $responseType, $expectedResponse): void

--- a/tests/Unit/Api/MembershipTest.php
+++ b/tests/Unit/Api/MembershipTest.php
@@ -81,6 +81,7 @@ class MembershipTest extends TestCase
      * Test all().
      *
      * @dataProvider getAllData
+     *
      * @param mixed $expectedResponse
      */
     #[DataProvider('getAllData')]

--- a/tests/Unit/Api/MembershipTest.php
+++ b/tests/Unit/Api/MembershipTest.php
@@ -107,6 +107,9 @@ class MembershipTest extends TestCase
         $this->assertSame($expectedResponse, $api->all(5));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getAllData(): array
     {
         return [

--- a/tests/Unit/Api/News/ListByProjectTest.php
+++ b/tests/Unit/Api/News/ListByProjectTest.php
@@ -72,6 +72,7 @@ class ListByProjectTest extends TestCase
 
     /**
      * @dataProvider Redmine\Tests\Fixtures\TestDataProvider::getInvalidProjectIdentifiers
+     *
      * @param mixed $projectIdentifier
      */
     #[DataProviderExternal(TestDataProvider::class, 'getInvalidProjectIdentifiers')]

--- a/tests/Unit/Api/News/ListByProjectTest.php
+++ b/tests/Unit/Api/News/ListByProjectTest.php
@@ -72,6 +72,7 @@ class ListByProjectTest extends TestCase
 
     /**
      * @dataProvider Redmine\Tests\Fixtures\TestDataProvider::getInvalidProjectIdentifiers
+     * @param mixed $projectIdentifier
      */
     #[DataProviderExternal(TestDataProvider::class, 'getInvalidProjectIdentifiers')]
     public function testListByProjectWithWrongProjectIdentifierThrowsException($projectIdentifier): void

--- a/tests/Unit/Api/NewsTest.php
+++ b/tests/Unit/Api/NewsTest.php
@@ -107,6 +107,9 @@ class NewsTest extends TestCase
         $this->assertSame($expectedResponse, $api->all());
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getAllData(): array
     {
         return [

--- a/tests/Unit/Api/NewsTest.php
+++ b/tests/Unit/Api/NewsTest.php
@@ -81,6 +81,7 @@ class NewsTest extends TestCase
      * Test all().
      *
      * @dataProvider getAllData
+     *
      * @param mixed $expectedResponse
      */
     #[DataProvider('getAllData')]

--- a/tests/Unit/Api/NewsTest.php
+++ b/tests/Unit/Api/NewsTest.php
@@ -81,6 +81,7 @@ class NewsTest extends TestCase
      * Test all().
      *
      * @dataProvider getAllData
+     * @param mixed $expectedResponse
      */
     #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse(string $response, string $responseType, $expectedResponse): void

--- a/tests/Unit/Api/Project/CreateTest.php
+++ b/tests/Unit/Api/Project/CreateTest.php
@@ -16,6 +16,8 @@ class CreateTest extends TestCase
 {
     /**
      * @dataProvider getCreateData
+     *
+     * @param array<mixed> $parameters
      */
     #[DataProvider('getCreateData')]
     public function testCreateReturnsCorrectResponse(array $parameters, string $expectedPath, string $expectedBody, int $responseCode, string $response): void
@@ -172,6 +174,8 @@ class CreateTest extends TestCase
 
     /**
      * @dataProvider incompleteCreateParameterProvider
+     *
+     * @param array<mixed> $parameters
      */
     #[DataProvider('incompleteCreateParameterProvider')]
     public function testCreateThrowsExceptionIfMandatoyParametersAreMissing(array $parameters): void

--- a/tests/Unit/Api/Project/CreateTest.php
+++ b/tests/Unit/Api/Project/CreateTest.php
@@ -45,6 +45,9 @@ class CreateTest extends TestCase
         $this->assertXmlStringEqualsXmlString($response, $return->asXml());
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getCreateData(): array
     {
         return [
@@ -196,7 +199,7 @@ class CreateTest extends TestCase
     /**
      * Provider for incomplete create parameters.
      *
-     * @return array[]
+     * @return array<array<mixed>>
      */
     public static function incompleteCreateParameterProvider(): array
     {

--- a/tests/Unit/Api/Project/ListNamesTest.php
+++ b/tests/Unit/Api/Project/ListNamesTest.php
@@ -41,6 +41,9 @@ class ListNamesTest extends TestCase
         $this->assertSame($expectedResponse, $api->listNames());
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getListNamesData(): array
     {
         return [

--- a/tests/Unit/Api/Project/ListNamesTest.php
+++ b/tests/Unit/Api/Project/ListNamesTest.php
@@ -15,6 +15,8 @@ class ListNamesTest extends TestCase
 {
     /**
      * @dataProvider getListNamesData
+     *
+     * @param array<mixed> $expectedResponse
      */
     #[DataProvider('getListNamesData')]
     public function testListNamesReturnsCorrectResponse(string $expectedPath, int $responseCode, string $response, array $expectedResponse): void

--- a/tests/Unit/Api/Project/RemoveTest.php
+++ b/tests/Unit/Api/Project/RemoveTest.php
@@ -37,6 +37,9 @@ class RemoveTest extends TestCase
         $this->assertSame($response, $api->remove($id));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getRemoveData(): array
     {
         return [

--- a/tests/Unit/Api/Project/ShowTest.php
+++ b/tests/Unit/Api/Project/ShowTest.php
@@ -15,10 +15,11 @@ class ShowTest extends TestCase
      * @dataProvider getShowData
      *
      * @param mixed $identifier
+     * @param array<mixed> $parameters
      * @param mixed $expectedReturn
      */
     #[DataProvider('getShowData')]
-    public function testShowReturnsCorrectResponse($identifier, array $params, string $expectedPath, string $response, $expectedReturn): void
+    public function testShowReturnsCorrectResponse($identifier, array $parameters, string $expectedPath, string $response, $expectedReturn): void
     {
         $client = AssertingHttpClient::create(
             $this,
@@ -37,7 +38,7 @@ class ShowTest extends TestCase
         $api = Project::fromHttpClient($client);
 
         // Perform the tests
-        $this->assertSame($expectedReturn, $api->show($identifier, $params));
+        $this->assertSame($expectedReturn, $api->show($identifier, $parameters));
     }
 
     public static function getShowData(): array

--- a/tests/Unit/Api/Project/ShowTest.php
+++ b/tests/Unit/Api/Project/ShowTest.php
@@ -13,6 +13,7 @@ class ShowTest extends TestCase
 {
     /**
      * @dataProvider getShowData
+     *
      * @param mixed $identifier
      * @param mixed $expectedReturn
      */

--- a/tests/Unit/Api/Project/ShowTest.php
+++ b/tests/Unit/Api/Project/ShowTest.php
@@ -41,6 +41,9 @@ class ShowTest extends TestCase
         $this->assertSame($expectedReturn, $api->show($identifier, $parameters));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getShowData(): array
     {
         return [

--- a/tests/Unit/Api/Project/ShowTest.php
+++ b/tests/Unit/Api/Project/ShowTest.php
@@ -13,6 +13,8 @@ class ShowTest extends TestCase
 {
     /**
      * @dataProvider getShowData
+     * @param mixed $identifier
+     * @param mixed $expectedReturn
      */
     #[DataProvider('getShowData')]
     public function testShowReturnsCorrectResponse($identifier, array $params, string $expectedPath, string $response, $expectedReturn): void

--- a/tests/Unit/Api/Project/UpdateTest.php
+++ b/tests/Unit/Api/Project/UpdateTest.php
@@ -41,6 +41,9 @@ class UpdateTest extends TestCase
         $this->assertSame('', $api->update($id, $parameters));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getUpdateData(): array
     {
         return [

--- a/tests/Unit/Api/Project/UpdateTest.php
+++ b/tests/Unit/Api/Project/UpdateTest.php
@@ -15,6 +15,8 @@ class UpdateTest extends TestCase
 {
     /**
      * @dataProvider getUpdateData
+     *
+     * @param array<mixed> $parameters
      */
     #[DataProvider('getUpdateData')]
     public function testUpdateReturnsCorrectResponse(int $id, array $parameters, string $expectedPath, string $expectedBody, int $responseCode, string $response): void

--- a/tests/Unit/Api/ProjectTest.php
+++ b/tests/Unit/Api/ProjectTest.php
@@ -109,6 +109,9 @@ class ProjectTest extends TestCase
         $this->assertSame($expectedResponse, $api->all());
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getAllData(): array
     {
         return [

--- a/tests/Unit/Api/ProjectTest.php
+++ b/tests/Unit/Api/ProjectTest.php
@@ -83,6 +83,7 @@ class ProjectTest extends TestCase
      * Test all().
      *
      * @dataProvider getAllData
+     *
      * @param mixed $expectedResponse
      */
     #[DataProvider('getAllData')]

--- a/tests/Unit/Api/ProjectTest.php
+++ b/tests/Unit/Api/ProjectTest.php
@@ -83,6 +83,7 @@ class ProjectTest extends TestCase
      * Test all().
      *
      * @dataProvider getAllData
+     * @param mixed $expectedResponse
      */
     #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse(string $response, string $responseType, $expectedResponse): void

--- a/tests/Unit/Api/Query/ListTest.php
+++ b/tests/Unit/Api/Query/ListTest.php
@@ -5,7 +5,6 @@ namespace Redmine\Tests\Unit\Api\Query;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Query;
-use Redmine\Client\Client;
 use Redmine\Exception\UnexpectedResponseException;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 

--- a/tests/Unit/Api/QueryTest.php
+++ b/tests/Unit/Api/QueryTest.php
@@ -81,6 +81,7 @@ class QueryTest extends TestCase
      * Test all().
      *
      * @dataProvider getAllData
+     * @param mixed $expectedResponse
      */
     #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse(string $response, string $responseType, $expectedResponse): void

--- a/tests/Unit/Api/QueryTest.php
+++ b/tests/Unit/Api/QueryTest.php
@@ -107,6 +107,9 @@ class QueryTest extends TestCase
         $this->assertSame($expectedResponse, $api->all());
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getAllData(): array
     {
         return [

--- a/tests/Unit/Api/QueryTest.php
+++ b/tests/Unit/Api/QueryTest.php
@@ -81,6 +81,7 @@ class QueryTest extends TestCase
      * Test all().
      *
      * @dataProvider getAllData
+     *
      * @param mixed $expectedResponse
      */
     #[DataProvider('getAllData')]

--- a/tests/Unit/Api/Role/ListNamesTest.php
+++ b/tests/Unit/Api/Role/ListNamesTest.php
@@ -41,6 +41,9 @@ class ListNamesTest extends TestCase
         $this->assertSame($expectedResponse, $api->listNames());
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getListNamesData(): array
     {
         return [

--- a/tests/Unit/Api/Role/ListNamesTest.php
+++ b/tests/Unit/Api/Role/ListNamesTest.php
@@ -15,6 +15,8 @@ class ListNamesTest extends TestCase
 {
     /**
      * @dataProvider getListNamesData
+     *
+     * @param array<mixed> $expectedResponse
      */
     #[DataProvider('getListNamesData')]
     public function testListNamesReturnsCorrectResponse(string $expectedPath, int $responseCode, string $response, array $expectedResponse): void

--- a/tests/Unit/Api/Role/ShowTest.php
+++ b/tests/Unit/Api/Role/ShowTest.php
@@ -13,6 +13,8 @@ class ShowTest extends TestCase
 {
     /**
      * @dataProvider getShowData
+     * @param mixed $id
+     * @param mixed $expectedReturn
      */
     #[DataProvider('getShowData')]
     public function testShowReturnsCorrectResponse($id, string $expectedPath, string $response, $expectedReturn): void

--- a/tests/Unit/Api/Role/ShowTest.php
+++ b/tests/Unit/Api/Role/ShowTest.php
@@ -40,6 +40,9 @@ class ShowTest extends TestCase
         $this->assertSame($expectedReturn, $api->show($id));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getShowData(): array
     {
         return [

--- a/tests/Unit/Api/Role/ShowTest.php
+++ b/tests/Unit/Api/Role/ShowTest.php
@@ -13,6 +13,7 @@ class ShowTest extends TestCase
 {
     /**
      * @dataProvider getShowData
+     *
      * @param mixed $id
      * @param mixed $expectedReturn
      */

--- a/tests/Unit/Api/RoleTest.php
+++ b/tests/Unit/Api/RoleTest.php
@@ -81,6 +81,7 @@ class RoleTest extends TestCase
      * Test all().
      *
      * @dataProvider getAllData
+     * @param mixed $expectedResponse
      */
     #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse(string $response, string $responseType, $expectedResponse): void

--- a/tests/Unit/Api/RoleTest.php
+++ b/tests/Unit/Api/RoleTest.php
@@ -107,6 +107,9 @@ class RoleTest extends TestCase
         $this->assertSame($expectedResponse, $api->all());
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getAllData(): array
     {
         return [

--- a/tests/Unit/Api/RoleTest.php
+++ b/tests/Unit/Api/RoleTest.php
@@ -81,6 +81,7 @@ class RoleTest extends TestCase
      * Test all().
      *
      * @dataProvider getAllData
+     *
      * @param mixed $expectedResponse
      */
     #[DataProvider('getAllData')]

--- a/tests/Unit/Api/Search/ListByQueryTest.php
+++ b/tests/Unit/Api/Search/ListByQueryTest.php
@@ -5,7 +5,6 @@ namespace Redmine\Tests\Unit\Api\Search;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Search;
-use Redmine\Client\Client;
 use Redmine\Exception\UnexpectedResponseException;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 

--- a/tests/Unit/Api/Search/SearchTest.php
+++ b/tests/Unit/Api/Search/SearchTest.php
@@ -62,6 +62,9 @@ class SearchTest extends TestCase
         $this->assertSame($expectedResponse, $api->search('query'));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getAllData(): array
     {
         return [

--- a/tests/Unit/Api/Search/SearchTest.php
+++ b/tests/Unit/Api/Search/SearchTest.php
@@ -6,7 +6,6 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Redmine\Api\Search;
-use Redmine\Client\Client;
 use Redmine\Http\HttpClient;
 use Redmine\Tests\Fixtures\AssertingHttpClient;
 

--- a/tests/Unit/Api/Search/SearchTest.php
+++ b/tests/Unit/Api/Search/SearchTest.php
@@ -36,6 +36,7 @@ class SearchTest extends TestCase
 
     /**
      * @dataProvider getAllData
+     *
      * @param mixed $expectedResponse
      */
     #[DataProvider('getAllData')]

--- a/tests/Unit/Api/Search/SearchTest.php
+++ b/tests/Unit/Api/Search/SearchTest.php
@@ -36,6 +36,7 @@ class SearchTest extends TestCase
 
     /**
      * @dataProvider getAllData
+     * @param mixed $expectedResponse
      */
     #[DataProvider('getAllData')]
     public function testSearchReturnsClientGetResponse(string $response, string $responseType, $expectedResponse): void

--- a/tests/Unit/Api/TimeEntry/CreateTest.php
+++ b/tests/Unit/Api/TimeEntry/CreateTest.php
@@ -45,6 +45,9 @@ class CreateTest extends TestCase
         $this->assertXmlStringEqualsXmlString($response, $return->asXml());
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getCreateData(): array
     {
         return [
@@ -171,7 +174,7 @@ class CreateTest extends TestCase
     /**
      * Provider for incomplete create parameters.
      *
-     * @return array[]
+     * @return array<array<mixed>>
      */
     public static function incompleteCreateParameterProvider(): array
     {

--- a/tests/Unit/Api/TimeEntry/CreateTest.php
+++ b/tests/Unit/Api/TimeEntry/CreateTest.php
@@ -16,6 +16,8 @@ class CreateTest extends TestCase
 {
     /**
      * @dataProvider getCreateData
+     *
+     * @param array<mixed> $parameters
      */
     #[DataProvider('getCreateData')]
     public function testCreateReturnsCorrectResponse(array $parameters, string $expectedPath, string $expectedBody, int $responseCode, string $response): void
@@ -147,6 +149,8 @@ class CreateTest extends TestCase
 
     /**
      * @dataProvider incompleteCreateParameterProvider
+     *
+     * @param array<mixed> $parameters
      */
     #[DataProvider('incompleteCreateParameterProvider')]
     public function testCreateThrowsExceptionIfValueIsMissingInParameters(array $parameters): void

--- a/tests/Unit/Api/TimeEntry/RemoveTest.php
+++ b/tests/Unit/Api/TimeEntry/RemoveTest.php
@@ -37,6 +37,9 @@ class RemoveTest extends TestCase
         $this->assertSame($response, $api->remove($id));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getRemoveData(): array
     {
         return [

--- a/tests/Unit/Api/TimeEntry/ShowTest.php
+++ b/tests/Unit/Api/TimeEntry/ShowTest.php
@@ -13,6 +13,8 @@ class ShowTest extends TestCase
 {
     /**
      * @dataProvider getShowData
+     * @param mixed $id
+     * @param mixed $expectedReturn
      */
     #[DataProvider('getShowData')]
     public function testShowReturnsCorrectResponse($id, string $expectedPath, string $response, $expectedReturn): void

--- a/tests/Unit/Api/TimeEntry/ShowTest.php
+++ b/tests/Unit/Api/TimeEntry/ShowTest.php
@@ -40,6 +40,9 @@ class ShowTest extends TestCase
         $this->assertSame($expectedReturn, $api->show($id));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getShowData(): array
     {
         return [

--- a/tests/Unit/Api/TimeEntry/ShowTest.php
+++ b/tests/Unit/Api/TimeEntry/ShowTest.php
@@ -13,6 +13,7 @@ class ShowTest extends TestCase
 {
     /**
      * @dataProvider getShowData
+     *
      * @param mixed $id
      * @param mixed $expectedReturn
      */

--- a/tests/Unit/Api/TimeEntry/UpdateTest.php
+++ b/tests/Unit/Api/TimeEntry/UpdateTest.php
@@ -41,6 +41,9 @@ class UpdateTest extends TestCase
         $this->assertSame('', $api->update($id, $parameters));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getUpdateData(): array
     {
         return [

--- a/tests/Unit/Api/TimeEntry/UpdateTest.php
+++ b/tests/Unit/Api/TimeEntry/UpdateTest.php
@@ -15,6 +15,8 @@ class UpdateTest extends TestCase
 {
     /**
      * @dataProvider getUpdateData
+     *
+     * @param array<mixed> $parameters
      */
     #[DataProvider('getUpdateData')]
     public function testUpdateReturnsCorrectResponse(int $id, array $parameters, string $expectedPath, string $expectedBody, int $responseCode, string $response): void

--- a/tests/Unit/Api/TimeEntryActivity/ListNamesTest.php
+++ b/tests/Unit/Api/TimeEntryActivity/ListNamesTest.php
@@ -41,6 +41,9 @@ class ListNamesTest extends TestCase
         $this->assertSame($expectedResponse, $api->listNames());
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getListNamesData(): array
     {
         return [

--- a/tests/Unit/Api/TimeEntryActivity/ListNamesTest.php
+++ b/tests/Unit/Api/TimeEntryActivity/ListNamesTest.php
@@ -15,6 +15,8 @@ class ListNamesTest extends TestCase
 {
     /**
      * @dataProvider getListNamesData
+     *
+     * @param array<mixed> $expectedResponse
      */
     #[DataProvider('getListNamesData')]
     public function testListNamesReturnsCorrectResponse(string $expectedPath, int $responseCode, string $response, array $expectedResponse): void

--- a/tests/Unit/Api/TimeEntryActivityTest.php
+++ b/tests/Unit/Api/TimeEntryActivityTest.php
@@ -107,6 +107,9 @@ class TimeEntryActivityTest extends TestCase
         $this->assertSame($expectedResponse, $api->all());
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getAllData(): array
     {
         return [

--- a/tests/Unit/Api/TimeEntryActivityTest.php
+++ b/tests/Unit/Api/TimeEntryActivityTest.php
@@ -81,6 +81,7 @@ class TimeEntryActivityTest extends TestCase
      * Test all().
      *
      * @dataProvider getAllData
+     * @param mixed $expectedResponse
      */
     #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse(string $response, string $responseType, $expectedResponse): void

--- a/tests/Unit/Api/TimeEntryActivityTest.php
+++ b/tests/Unit/Api/TimeEntryActivityTest.php
@@ -81,6 +81,7 @@ class TimeEntryActivityTest extends TestCase
      * Test all().
      *
      * @dataProvider getAllData
+     *
      * @param mixed $expectedResponse
      */
     #[DataProvider('getAllData')]

--- a/tests/Unit/Api/TimeEntryTest.php
+++ b/tests/Unit/Api/TimeEntryTest.php
@@ -81,6 +81,7 @@ class TimeEntryTest extends TestCase
      * Test all().
      *
      * @dataProvider getAllData
+     *
      * @param mixed $expectedResponse
      */
     #[DataProvider('getAllData')]

--- a/tests/Unit/Api/TimeEntryTest.php
+++ b/tests/Unit/Api/TimeEntryTest.php
@@ -81,6 +81,7 @@ class TimeEntryTest extends TestCase
      * Test all().
      *
      * @dataProvider getAllData
+     * @param mixed $expectedResponse
      */
     #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse(string $response, string $responseType, $expectedResponse): void

--- a/tests/Unit/Api/TimeEntryTest.php
+++ b/tests/Unit/Api/TimeEntryTest.php
@@ -107,6 +107,9 @@ class TimeEntryTest extends TestCase
         $this->assertSame($expectedResponse, $api->all());
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getAllData(): array
     {
         return [

--- a/tests/Unit/Api/Tracker/ListNamesTest.php
+++ b/tests/Unit/Api/Tracker/ListNamesTest.php
@@ -41,6 +41,9 @@ class ListNamesTest extends TestCase
         $this->assertSame($expectedResponse, $api->listNames());
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getListNamesData(): array
     {
         return [

--- a/tests/Unit/Api/Tracker/ListNamesTest.php
+++ b/tests/Unit/Api/Tracker/ListNamesTest.php
@@ -15,6 +15,8 @@ class ListNamesTest extends TestCase
 {
     /**
      * @dataProvider getListNamesData
+     *
+     * @param array<mixed> $expectedResponse
      */
     #[DataProvider('getListNamesData')]
     public function testListNamesReturnsCorrectResponse(string $expectedPath, int $responseCode, string $response, array $expectedResponse): void

--- a/tests/Unit/Api/TrackerTest.php
+++ b/tests/Unit/Api/TrackerTest.php
@@ -81,6 +81,7 @@ class TrackerTest extends TestCase
      * Test all().
      *
      * @dataProvider getAllData
+     * @param mixed $expectedResponse
      */
     #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse(string $response, string $responseType, $expectedResponse): void

--- a/tests/Unit/Api/TrackerTest.php
+++ b/tests/Unit/Api/TrackerTest.php
@@ -81,6 +81,7 @@ class TrackerTest extends TestCase
      * Test all().
      *
      * @dataProvider getAllData
+     *
      * @param mixed $expectedResponse
      */
     #[DataProvider('getAllData')]

--- a/tests/Unit/Api/TrackerTest.php
+++ b/tests/Unit/Api/TrackerTest.php
@@ -107,6 +107,9 @@ class TrackerTest extends TestCase
         $this->assertSame($expectedResponse, $api->all());
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getAllData(): array
     {
         return [

--- a/tests/Unit/Api/User/CreateTest.php
+++ b/tests/Unit/Api/User/CreateTest.php
@@ -45,6 +45,9 @@ class CreateTest extends TestCase
         $this->assertXmlStringEqualsXmlString($response, $return->asXml());
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getCreateData(): array
     {
         return [
@@ -158,7 +161,7 @@ class CreateTest extends TestCase
     /**
      * Provider for incomplete create parameters.
      *
-     * @return array[]
+     * @return array<array<mixed>>
      */
     public static function incompleteCreateParameterProvider(): array
     {

--- a/tests/Unit/Api/User/CreateTest.php
+++ b/tests/Unit/Api/User/CreateTest.php
@@ -16,6 +16,8 @@ class CreateTest extends TestCase
 {
     /**
      * @dataProvider getCreateData
+     *
+     * @param array<mixed> $parameters
      */
     #[DataProvider('getCreateData')]
     public function testCreateReturnsCorrectResponse(array $parameters, string $expectedPath, string $expectedBody, int $responseCode, string $response): void
@@ -134,6 +136,8 @@ class CreateTest extends TestCase
 
     /**
      * @dataProvider incompleteCreateParameterProvider
+     *
+     * @param array<mixed> $parameters
      */
     #[DataProvider('incompleteCreateParameterProvider')]
     public function testCreateThrowsExceptionIfValueIsMissingInParameters(array $parameters): void

--- a/tests/Unit/Api/User/ListLoginsTest.php
+++ b/tests/Unit/Api/User/ListLoginsTest.php
@@ -15,6 +15,8 @@ class ListLoginsTest extends TestCase
 {
     /**
      * @dataProvider getListLoginsData
+     *
+     * @param array<mixed> $expectedResponse
      */
     #[DataProvider('getListLoginsData')]
     public function testListLoginsReturnsCorrectResponse(string $expectedPath, int $responseCode, string $response, array $expectedResponse): void

--- a/tests/Unit/Api/User/ListLoginsTest.php
+++ b/tests/Unit/Api/User/ListLoginsTest.php
@@ -41,6 +41,9 @@ class ListLoginsTest extends TestCase
         $this->assertSame($expectedResponse, $api->listLogins());
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getListLoginsData(): array
     {
         return [

--- a/tests/Unit/Api/User/RemoveTest.php
+++ b/tests/Unit/Api/User/RemoveTest.php
@@ -37,6 +37,9 @@ class RemoveTest extends TestCase
         $this->assertSame($response, $api->remove($id));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getRemoveData(): array
     {
         return [

--- a/tests/Unit/Api/User/ShowTest.php
+++ b/tests/Unit/Api/User/ShowTest.php
@@ -13,6 +13,8 @@ class ShowTest extends TestCase
 {
     /**
      * @dataProvider getShowData
+     * @param mixed $userId
+     * @param mixed $expectedReturn
      */
     #[DataProvider('getShowData')]
     public function testShowReturnsCorrectResponse($userId, array $params, string $expectedPath, string $response, $expectedReturn): void

--- a/tests/Unit/Api/User/ShowTest.php
+++ b/tests/Unit/Api/User/ShowTest.php
@@ -14,11 +14,12 @@ class ShowTest extends TestCase
     /**
      * @dataProvider getShowData
      *
-     * @param mixed $userId
+     * @param int|string $userId
+     * @param array<mixed> $parameters
      * @param mixed $expectedReturn
      */
     #[DataProvider('getShowData')]
-    public function testShowReturnsCorrectResponse($userId, array $params, string $expectedPath, string $response, $expectedReturn): void
+    public function testShowReturnsCorrectResponse($userId, array $parameters, string $expectedPath, string $response, $expectedReturn): void
     {
         $client = AssertingHttpClient::create(
             $this,
@@ -37,7 +38,7 @@ class ShowTest extends TestCase
         $api = User::fromHttpClient($client);
 
         // Perform the tests
-        $this->assertSame($expectedReturn, $api->show($userId, $params));
+        $this->assertSame($expectedReturn, $api->show($userId, $parameters));
     }
 
     public static function getShowData(): array

--- a/tests/Unit/Api/User/ShowTest.php
+++ b/tests/Unit/Api/User/ShowTest.php
@@ -41,6 +41,9 @@ class ShowTest extends TestCase
         $this->assertSame($expectedReturn, $api->show($userId, $parameters));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getShowData(): array
     {
         return [

--- a/tests/Unit/Api/User/ShowTest.php
+++ b/tests/Unit/Api/User/ShowTest.php
@@ -13,6 +13,7 @@ class ShowTest extends TestCase
 {
     /**
      * @dataProvider getShowData
+     *
      * @param mixed $userId
      * @param mixed $expectedReturn
      */

--- a/tests/Unit/Api/User/UpdateTest.php
+++ b/tests/Unit/Api/User/UpdateTest.php
@@ -41,6 +41,9 @@ class UpdateTest extends TestCase
         $this->assertSame('', $api->update($id, $parameters));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getUpdateData(): array
     {
         return [

--- a/tests/Unit/Api/User/UpdateTest.php
+++ b/tests/Unit/Api/User/UpdateTest.php
@@ -15,6 +15,8 @@ class UpdateTest extends TestCase
 {
     /**
      * @dataProvider getUpdateData
+     *
+     * @param array<mixed> $parameters
      */
     #[DataProvider('getUpdateData')]
     public function testUpdateReturnsCorrectResponse(int $id, array $parameters, string $expectedPath, string $expectedBody, int $responseCode, string $response): void

--- a/tests/Unit/Api/UserTest.php
+++ b/tests/Unit/Api/UserTest.php
@@ -201,6 +201,9 @@ class UserTest extends TestCase
         $this->assertSame($expectedResponse, $api->all());
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getAllData(): array
     {
         return [

--- a/tests/Unit/Api/UserTest.php
+++ b/tests/Unit/Api/UserTest.php
@@ -175,6 +175,7 @@ class UserTest extends TestCase
      * Test all().
      *
      * @dataProvider getAllData
+     * @param mixed $expectedResponse
      */
     #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse(string $response, string $responseType, $expectedResponse): void

--- a/tests/Unit/Api/UserTest.php
+++ b/tests/Unit/Api/UserTest.php
@@ -175,6 +175,7 @@ class UserTest extends TestCase
      * Test all().
      *
      * @dataProvider getAllData
+     *
      * @param mixed $expectedResponse
      */
     #[DataProvider('getAllData')]

--- a/tests/Unit/Api/Version/CreateTest.php
+++ b/tests/Unit/Api/Version/CreateTest.php
@@ -17,6 +17,8 @@ class CreateTest extends TestCase
 {
     /**
      * @dataProvider getCreateData
+     *
+     * @param array<mixed> $parameters
      */
     #[DataProvider('getCreateData')]
     public function testCreateReturnsCorrectResponse(int $identifier, array $parameters, string $expectedPath, string $expectedBody, int $responseCode, string $response): void

--- a/tests/Unit/Api/Version/CreateTest.php
+++ b/tests/Unit/Api/Version/CreateTest.php
@@ -46,6 +46,9 @@ class CreateTest extends TestCase
         $this->assertXmlStringEqualsXmlString($response, $return->asXml());
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getCreateData(): array
     {
         return [

--- a/tests/Unit/Api/Version/ListByProjectTest.php
+++ b/tests/Unit/Api/Version/ListByProjectTest.php
@@ -73,6 +73,7 @@ class ListByProjectTest extends TestCase
 
     /**
      * @dataProvider Redmine\Tests\Fixtures\TestDataProvider::getInvalidProjectIdentifiers
+     *
      * @param mixed $projectIdentifier
      */
     #[DataProviderExternal(TestDataProvider::class, 'getInvalidProjectIdentifiers')]

--- a/tests/Unit/Api/Version/ListByProjectTest.php
+++ b/tests/Unit/Api/Version/ListByProjectTest.php
@@ -73,6 +73,7 @@ class ListByProjectTest extends TestCase
 
     /**
      * @dataProvider Redmine\Tests\Fixtures\TestDataProvider::getInvalidProjectIdentifiers
+     * @param mixed $projectIdentifier
      */
     #[DataProviderExternal(TestDataProvider::class, 'getInvalidProjectIdentifiers')]
     public function testListByProjectWithWrongProjectIdentifierThrowsException($projectIdentifier): void

--- a/tests/Unit/Api/Version/ListNamesByProjectTest.php
+++ b/tests/Unit/Api/Version/ListNamesByProjectTest.php
@@ -20,7 +20,8 @@ class ListNamesByProjectTest extends TestCase
     /**
      * @dataProvider getListNamesByProjectData
      *
-     * @param mixed $projectIdentifier
+     * @param string|int $projectIdentifier
+     * @param array<mixed> $expectedResponse
      */
     #[DataProvider('getListNamesByProjectData')]
     public function testListNamesByProjectReturnsCorrectResponse($projectIdentifier, string $expectedPath, int $responseCode, string $response, array $expectedResponse): void

--- a/tests/Unit/Api/Version/ListNamesByProjectTest.php
+++ b/tests/Unit/Api/Version/ListNamesByProjectTest.php
@@ -19,6 +19,7 @@ class ListNamesByProjectTest extends TestCase
 {
     /**
      * @dataProvider getListNamesByProjectData
+     * @param mixed $projectIdentifier
      */
     #[DataProvider('getListNamesByProjectData')]
     public function testListNamesByProjectReturnsCorrectResponse($projectIdentifier, string $expectedPath, int $responseCode, string $response, array $expectedResponse): void
@@ -114,6 +115,7 @@ class ListNamesByProjectTest extends TestCase
 
     /**
      * @dataProvider Redmine\Tests\Fixtures\TestDataProvider::getInvalidProjectIdentifiers
+     * @param mixed $projectIdentifier
      */
     #[DataProviderExternal(TestDataProvider::class, 'getInvalidProjectIdentifiers')]
     public function testListNamesByProjectWithWrongProjectIdentifierThrowsException($projectIdentifier): void

--- a/tests/Unit/Api/Version/ListNamesByProjectTest.php
+++ b/tests/Unit/Api/Version/ListNamesByProjectTest.php
@@ -19,6 +19,7 @@ class ListNamesByProjectTest extends TestCase
 {
     /**
      * @dataProvider getListNamesByProjectData
+     *
      * @param mixed $projectIdentifier
      */
     #[DataProvider('getListNamesByProjectData')]
@@ -115,6 +116,7 @@ class ListNamesByProjectTest extends TestCase
 
     /**
      * @dataProvider Redmine\Tests\Fixtures\TestDataProvider::getInvalidProjectIdentifiers
+     *
      * @param mixed $projectIdentifier
      */
     #[DataProviderExternal(TestDataProvider::class, 'getInvalidProjectIdentifiers')]

--- a/tests/Unit/Api/Version/ListNamesByProjectTest.php
+++ b/tests/Unit/Api/Version/ListNamesByProjectTest.php
@@ -46,6 +46,9 @@ class ListNamesByProjectTest extends TestCase
         $this->assertSame($expectedResponse, $api->listNamesByProject($projectIdentifier));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getListNamesByProjectData(): array
     {
         return [

--- a/tests/Unit/Api/Version/RemoveTest.php
+++ b/tests/Unit/Api/Version/RemoveTest.php
@@ -13,6 +13,7 @@ class RemoveTest extends TestCase
 {
     /**
      * @dataProvider getRemoveData
+     *
      * @param mixed $id
      */
     #[DataProvider('getRemoveData')]

--- a/tests/Unit/Api/Version/RemoveTest.php
+++ b/tests/Unit/Api/Version/RemoveTest.php
@@ -13,6 +13,7 @@ class RemoveTest extends TestCase
 {
     /**
      * @dataProvider getRemoveData
+     * @param mixed $id
      */
     #[DataProvider('getRemoveData')]
     public function testRemoveReturnsCorrectResponse($id, string $expectedPath, int $responseCode, string $response): void

--- a/tests/Unit/Api/Version/RemoveTest.php
+++ b/tests/Unit/Api/Version/RemoveTest.php
@@ -39,6 +39,9 @@ class RemoveTest extends TestCase
         $this->assertSame($response, $api->remove($id));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getRemoveData(): array
     {
         return [

--- a/tests/Unit/Api/Version/ShowTest.php
+++ b/tests/Unit/Api/Version/ShowTest.php
@@ -13,6 +13,7 @@ class ShowTest extends TestCase
 {
     /**
      * @dataProvider getShowData
+     *
      * @param mixed $version
      * @param mixed $expectedReturn
      */

--- a/tests/Unit/Api/Version/ShowTest.php
+++ b/tests/Unit/Api/Version/ShowTest.php
@@ -40,6 +40,9 @@ class ShowTest extends TestCase
         $this->assertSame($expectedReturn, $api->show($version));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getShowData(): array
     {
         return [

--- a/tests/Unit/Api/Version/ShowTest.php
+++ b/tests/Unit/Api/Version/ShowTest.php
@@ -13,6 +13,8 @@ class ShowTest extends TestCase
 {
     /**
      * @dataProvider getShowData
+     * @param mixed $version
+     * @param mixed $expectedReturn
      */
     #[DataProvider('getShowData')]
     public function testShowReturnsCorrectResponse($version, string $expectedPath, string $response, $expectedReturn): void

--- a/tests/Unit/Api/Version/UpdateTest.php
+++ b/tests/Unit/Api/Version/UpdateTest.php
@@ -41,6 +41,9 @@ class UpdateTest extends TestCase
         $this->assertSame($response, $api->update($id, $parameters));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getUpdateData(): array
     {
         return [

--- a/tests/Unit/Api/Version/UpdateTest.php
+++ b/tests/Unit/Api/Version/UpdateTest.php
@@ -15,6 +15,8 @@ class UpdateTest extends TestCase
 {
     /**
      * @dataProvider getUpdateData
+     *
+     * @param array<mixed> $parameters
      */
     #[DataProvider('getUpdateData')]
     public function testUpdateReturnsCorrectResponse(int $id, array $parameters, string $expectedPath, string $expectedBody, int $responseCode, string $response): void

--- a/tests/Unit/Api/VersionTest.php
+++ b/tests/Unit/Api/VersionTest.php
@@ -82,6 +82,7 @@ class VersionTest extends TestCase
      * Test all().
      *
      * @dataProvider getAllData
+     *
      * @param mixed $expectedResponse
      */
     #[DataProvider('getAllData')]

--- a/tests/Unit/Api/VersionTest.php
+++ b/tests/Unit/Api/VersionTest.php
@@ -108,6 +108,9 @@ class VersionTest extends TestCase
         $this->assertSame($expectedResponse, $api->all(5));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getAllData(): array
     {
         return [
@@ -424,7 +427,7 @@ class VersionTest extends TestCase
     /**
      * Data provider for invalid sharing values.
      *
-     * @return array[]
+     * @return array<array<mixed>>
      */
     public static function invalidSharingProvider(): array
     {

--- a/tests/Unit/Api/VersionTest.php
+++ b/tests/Unit/Api/VersionTest.php
@@ -82,6 +82,7 @@ class VersionTest extends TestCase
      * Test all().
      *
      * @dataProvider getAllData
+     * @param mixed $expectedResponse
      */
     #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse(string $response, string $responseType, $expectedResponse): void

--- a/tests/Unit/Api/Wiki/CreateTest.php
+++ b/tests/Unit/Api/Wiki/CreateTest.php
@@ -45,6 +45,9 @@ class CreateTest extends TestCase
         $this->assertXmlStringEqualsXmlString($response, $return->asXml());
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getCreateData(): array
     {
         return [

--- a/tests/Unit/Api/Wiki/CreateTest.php
+++ b/tests/Unit/Api/Wiki/CreateTest.php
@@ -16,6 +16,8 @@ class CreateTest extends TestCase
 {
     /**
      * @dataProvider getCreateData
+     *
+     * @param array<mixed> $parameters
      */
     #[DataProvider('getCreateData')]
     public function testCreateReturnsCorrectResponse(int $id, string $page, array $parameters, string $expectedPath, string $expectedBody, int $responseCode, string $response): void

--- a/tests/Unit/Api/Wiki/ListByProjectTest.php
+++ b/tests/Unit/Api/Wiki/ListByProjectTest.php
@@ -73,6 +73,7 @@ class ListByProjectTest extends TestCase
 
     /**
      * @dataProvider Redmine\Tests\Fixtures\TestDataProvider::getInvalidProjectIdentifiers
+     *
      * @param mixed $projectIdentifier
      */
     #[DataProviderExternal(TestDataProvider::class, 'getInvalidProjectIdentifiers')]

--- a/tests/Unit/Api/Wiki/ListByProjectTest.php
+++ b/tests/Unit/Api/Wiki/ListByProjectTest.php
@@ -73,6 +73,7 @@ class ListByProjectTest extends TestCase
 
     /**
      * @dataProvider Redmine\Tests\Fixtures\TestDataProvider::getInvalidProjectIdentifiers
+     * @param mixed $projectIdentifier
      */
     #[DataProviderExternal(TestDataProvider::class, 'getInvalidProjectIdentifiers')]
     public function testListByProjectWithWrongProjectIdentifierThrowsException($projectIdentifier): void

--- a/tests/Unit/Api/Wiki/RemoveTest.php
+++ b/tests/Unit/Api/Wiki/RemoveTest.php
@@ -39,6 +39,9 @@ class RemoveTest extends TestCase
         $this->assertSame('', $api->remove($id, $page));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getRemoveData(): array
     {
         return [

--- a/tests/Unit/Api/Wiki/ShowTest.php
+++ b/tests/Unit/Api/Wiki/ShowTest.php
@@ -13,6 +13,7 @@ class ShowTest extends TestCase
 {
     /**
      * @dataProvider getShowData
+     *
      * @param mixed $identifier
      * @param mixed $expectedReturn
      */

--- a/tests/Unit/Api/Wiki/ShowTest.php
+++ b/tests/Unit/Api/Wiki/ShowTest.php
@@ -13,6 +13,8 @@ class ShowTest extends TestCase
 {
     /**
      * @dataProvider getShowData
+     * @param mixed $identifier
+     * @param mixed $expectedReturn
      */
     #[DataProvider('getShowData')]
     public function testShowReturnsCorrectResponse($identifier, string $page, ?int $version, string $expectedPath, string $response, $expectedReturn): void

--- a/tests/Unit/Api/Wiki/ShowTest.php
+++ b/tests/Unit/Api/Wiki/ShowTest.php
@@ -40,6 +40,9 @@ class ShowTest extends TestCase
         $this->assertSame($expectedReturn, $api->show($identifier, $page, $version));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getShowData(): array
     {
         return [

--- a/tests/Unit/Api/Wiki/UpdateTest.php
+++ b/tests/Unit/Api/Wiki/UpdateTest.php
@@ -15,6 +15,8 @@ class UpdateTest extends TestCase
 {
     /**
      * @dataProvider getUpdateData
+     *
+     * @param array<mixed> $parameters
      */
     #[DataProvider('getUpdateData')]
     public function testUpdateReturnsCorrectResponse(int $id, string $page, array $parameters, string $expectedPath, string $expectedBody, int $responseCode, string $response): void

--- a/tests/Unit/Api/Wiki/UpdateTest.php
+++ b/tests/Unit/Api/Wiki/UpdateTest.php
@@ -41,6 +41,9 @@ class UpdateTest extends TestCase
         $this->assertSame('', $api->update($id, $page, $parameters));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getUpdateData(): array
     {
         return [

--- a/tests/Unit/Api/WikiTest.php
+++ b/tests/Unit/Api/WikiTest.php
@@ -81,6 +81,7 @@ class WikiTest extends TestCase
      * Test all().
      *
      * @dataProvider getAllData
+     * @param mixed $expectedResponse
      */
     #[DataProvider('getAllData')]
     public function testAllReturnsClientGetResponse(string $response, string $responseType, $expectedResponse): void

--- a/tests/Unit/Api/WikiTest.php
+++ b/tests/Unit/Api/WikiTest.php
@@ -81,6 +81,7 @@ class WikiTest extends TestCase
      * Test all().
      *
      * @dataProvider getAllData
+     *
      * @param mixed $expectedResponse
      */
     #[DataProvider('getAllData')]

--- a/tests/Unit/Api/WikiTest.php
+++ b/tests/Unit/Api/WikiTest.php
@@ -107,6 +107,9 @@ class WikiTest extends TestCase
         $this->assertSame($expectedResponse, $api->all(5));
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getAllData(): array
     {
         return [

--- a/tests/Unit/Client/NativeCurlClient/RequestTest.php
+++ b/tests/Unit/Client/NativeCurlClient/RequestTest.php
@@ -64,6 +64,9 @@ class RequestTest extends TestCase
         $this->assertSame($content, $response->getContent());
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getRequestReponseData(): array
     {
         return [

--- a/tests/Unit/Client/NativeCurlClientTest.php
+++ b/tests/Unit/Client/NativeCurlClientTest.php
@@ -711,6 +711,9 @@ class NativeCurlClientTest extends TestCase
         $this->assertSame($content, $client->getLastResponseBody());
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getRequestReponseData(): array
     {
         return [
@@ -976,6 +979,9 @@ class NativeCurlClientTest extends TestCase
         $this->assertInstanceOf($class, $client->getApi($apiName));
     }
 
+    /**
+     * @return array<array{string, class-string}>
+     */
     public static function getApiClassesProvider(): array
     {
         return [

--- a/tests/Unit/Client/Psr18Client/RequestTest.php
+++ b/tests/Unit/Client/Psr18Client/RequestTest.php
@@ -67,6 +67,9 @@ class RequestTest extends TestCase
         $this->assertSame($content, $response->getContent());
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getRequestReponseData(): array
     {
         return [

--- a/tests/Unit/Client/Psr18ClientTest.php
+++ b/tests/Unit/Client/Psr18ClientTest.php
@@ -12,7 +12,6 @@ use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestFactoryInterface;
-use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Redmine\Client\Client;

--- a/tests/Unit/Client/Psr18ClientTest.php
+++ b/tests/Unit/Client/Psr18ClientTest.php
@@ -292,6 +292,9 @@ class Psr18ClientTest extends TestCase
         $this->assertSame($content, $client->getLastResponseBody());
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getRequestReponseData(): array
     {
         return [
@@ -475,6 +478,9 @@ class Psr18ClientTest extends TestCase
         $this->assertInstanceOf($class, $client->getApi($apiName));
     }
 
+    /**
+     * @return array<array{string, class-string}>
+     */
     public static function getApiClassesProvider(): array
     {
         return [

--- a/tests/Unit/Serializer/JsonSerializerTest.php
+++ b/tests/Unit/Serializer/JsonSerializerTest.php
@@ -64,6 +64,7 @@ class JsonSerializerTest extends TestCase
 
     /**
      * @param mixed $expected
+     *
      * @dataProvider getEncodedToNormalizedData
      */
     #[DataProvider('getEncodedToNormalizedData')]
@@ -193,6 +194,7 @@ class JsonSerializerTest extends TestCase
 
     /**
      * @param array<mixed> $data
+     *
      * @dataProvider getNormalizedToEncodedData
      */
     #[DataProvider('getNormalizedToEncodedData')]
@@ -218,6 +220,7 @@ class JsonSerializerTest extends TestCase
 
     /**
      * @param array<mixed> $data
+     *
      * @dataProvider getInvalidSerializedData
      */
     #[DataProvider('getInvalidSerializedData')]

--- a/tests/Unit/Serializer/JsonSerializerTest.php
+++ b/tests/Unit/Serializer/JsonSerializerTest.php
@@ -13,6 +13,9 @@ use Redmine\Serializer\JsonSerializer;
 #[CoversClass(JsonSerializer::class)]
 class JsonSerializerTest extends TestCase
 {
+    /**
+     * @return array<mixed>
+     */
     public static function getEncodedToNormalizedData(): array
     {
         return [
@@ -60,6 +63,7 @@ class JsonSerializerTest extends TestCase
     }
 
     /**
+     * @param mixed $expected
      * @dataProvider getEncodedToNormalizedData
      */
     #[DataProvider('getEncodedToNormalizedData')]
@@ -70,6 +74,9 @@ class JsonSerializerTest extends TestCase
         $this->assertSame($expected, $serializer->getNormalized());
     }
 
+    /**
+     * @return array<array<string>>
+     */
     public static function getInvalidEncodedData(): array
     {
         return [
@@ -97,6 +104,9 @@ class JsonSerializerTest extends TestCase
         JsonSerializer::createFromString($data);
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getNormalizedToEncodedData(): array
     {
         return [
@@ -182,6 +192,7 @@ class JsonSerializerTest extends TestCase
     }
 
     /**
+     * @param array<mixed> $data
      * @dataProvider getNormalizedToEncodedData
      */
     #[DataProvider('getNormalizedToEncodedData')]
@@ -192,6 +203,9 @@ class JsonSerializerTest extends TestCase
         $this->assertJsonStringEqualsJsonString($expected, $serializer->__toString());
     }
 
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getInvalidSerializedData(): array
     {
         return [
@@ -203,6 +217,7 @@ class JsonSerializerTest extends TestCase
     }
 
     /**
+     * @param array<mixed> $data
      * @dataProvider getInvalidSerializedData
      */
     #[DataProvider('getInvalidSerializedData')]

--- a/tests/Unit/Serializer/PathSerializerTest.php
+++ b/tests/Unit/Serializer/PathSerializerTest.php
@@ -55,6 +55,7 @@ class PathSerializerTest extends TestCase
 
     /**
      * @param array<mixed> $params
+     *
      * @dataProvider getPathData
      */
     #[DataProvider('getPathData')]

--- a/tests/Unit/Serializer/PathSerializerTest.php
+++ b/tests/Unit/Serializer/PathSerializerTest.php
@@ -12,6 +12,9 @@ use Redmine\Serializer\PathSerializer;
 #[CoversClass(PathSerializer::class)]
 class PathSerializerTest extends TestCase
 {
+    /**
+     * @return array<array<mixed>>
+     */
     public static function getPathData(): array
     {
         return [
@@ -51,6 +54,7 @@ class PathSerializerTest extends TestCase
     }
 
     /**
+     * @param array<mixed> $params
      * @dataProvider getPathData
      */
     #[DataProvider('getPathData')]

--- a/tests/Unit/Serializer/XmlSerializerTest.php
+++ b/tests/Unit/Serializer/XmlSerializerTest.php
@@ -15,6 +15,7 @@ class XmlSerializerTest extends TestCase
 {
     /**
      * @param array<mixed> $expected
+     *
      * @dataProvider getEncodedToNormalizedData
      */
     #[DataProvider('getEncodedToNormalizedData')]
@@ -79,6 +80,7 @@ class XmlSerializerTest extends TestCase
 
     /**
      * @param array<mixed> $expectedMessages
+     *
      * @dataProvider getInvalidEncodedData
      */
     #[DataProvider('getInvalidEncodedData')]
@@ -139,6 +141,7 @@ class XmlSerializerTest extends TestCase
 
     /**
      * @param array<mixed> $data
+     *
      * @dataProvider getNormalizedToEncodedData
      */
     #[DataProvider('getNormalizedToEncodedData')]
@@ -328,6 +331,7 @@ class XmlSerializerTest extends TestCase
 
     /**
      * @param array<mixed> $data
+     *
      * @dataProvider getInvalidSerializedData
      */
     #[DataProvider('getInvalidSerializedData')]

--- a/tests/Unit/Serializer/XmlSerializerTest.php
+++ b/tests/Unit/Serializer/XmlSerializerTest.php
@@ -14,6 +14,7 @@ use Redmine\Serializer\XmlSerializer;
 class XmlSerializerTest extends TestCase
 {
     /**
+     * @param array<mixed> $expected
      * @dataProvider getEncodedToNormalizedData
      */
     #[DataProvider('getEncodedToNormalizedData')]
@@ -24,6 +25,9 @@ class XmlSerializerTest extends TestCase
         $this->assertSame($expected, $serializer->getNormalized());
     }
 
+    /**
+     * @return array<string,array<mixed>>
+     */
     public static function getEncodedToNormalizedData(): array
     {
         return [
@@ -74,6 +78,7 @@ class XmlSerializerTest extends TestCase
     }
 
     /**
+     * @param array<mixed> $expectedMessages
      * @dataProvider getInvalidEncodedData
      */
     #[DataProvider('getInvalidEncodedData')]
@@ -87,6 +92,9 @@ class XmlSerializerTest extends TestCase
         }
     }
 
+    /**
+     * @return array<string,array<mixed>>
+     */
     public static function getInvalidEncodedData(): array
     {
         return [
@@ -130,6 +138,7 @@ class XmlSerializerTest extends TestCase
     }
 
     /**
+     * @param array<mixed> $data
      * @dataProvider getNormalizedToEncodedData
      */
     #[DataProvider('getNormalizedToEncodedData')]
@@ -140,6 +149,9 @@ class XmlSerializerTest extends TestCase
         $this->assertXmlStringEqualsXmlString($expected, $serializer->__toString());
     }
 
+    /**
+     * @return array<string,array<mixed>>
+     */
     public static function getNormalizedToEncodedData(): array
     {
         return [
@@ -315,6 +327,7 @@ class XmlSerializerTest extends TestCase
     }
 
     /**
+     * @param array<mixed> $data
      * @dataProvider getInvalidSerializedData
      */
     #[DataProvider('getInvalidSerializedData')]
@@ -326,6 +339,9 @@ class XmlSerializerTest extends TestCase
         XmlSerializer::createFromArray($data);
     }
 
+    /**
+     * @return array<string,array<mixed>>
+     */
     public static function getInvalidSerializedData(): array
     {
         return [


### PR DESCRIPTION
This PR bumps the version to `v2.10.0-dev`,  fixes all ignored PHPStan errors and updates the code style to PER-CS 3.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped package version to v2.10.0-dev
  * Upgraded code-quality presets and tightened static-analysis configuration

* **Tests**
  * Added/expanded PHPDoc type annotations and data-provider return shapes
  * Added explicit void return types to many test step methods and helpers

* **Style**
  * Cleaned up docblock blank lines and adjusted minor formatting for consistency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->