### PR TITLE
declare strict_types in all files

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -14,6 +14,7 @@ return (new \PhpCsFixer\Config())
         '@PER-CS3x0' => true,
         '@PER-CS3x0:risky' => true,
         '@PHPUnit100Migration:risky' => true,
+        'declare_strict_types' => true,
         'linebreak_after_opening_tag' => true,
         'ordered_imports' => true,
         'no_empty_phpdoc' => true,

--- a/src/Redmine/Api.php
+++ b/src/Redmine/Api.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine;
 
 /**

--- a/src/Redmine/Api/AbstractApi.php
+++ b/src/Redmine/Api/AbstractApi.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Api;
 
 use InvalidArgumentException;

--- a/src/Redmine/Api/Attachment.php
+++ b/src/Redmine/Api/Attachment.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Api;
 
 use Redmine\Client\Client;

--- a/src/Redmine/Api/CustomField.php
+++ b/src/Redmine/Api/CustomField.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Api;
 
 use Redmine\Client\Client;

--- a/src/Redmine/Api/CustomField.php
+++ b/src/Redmine/Api/CustomField.php
@@ -151,7 +151,7 @@ class CustomField extends AbstractApi
     {
         @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.7.0, use `' . self::class . '::listNames()` instead.', E_USER_DEPRECATED);
 
-        return $this->doListing($forceUpdate, $params);
+        return $this->doListing((bool) $forceUpdate, $params);
     }
 
     /**

--- a/src/Redmine/Api/Group.php
+++ b/src/Redmine/Api/Group.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Api;
 
 use Redmine\Client\Client;

--- a/src/Redmine/Api/Group.php
+++ b/src/Redmine/Api/Group.php
@@ -277,7 +277,7 @@ class Group extends AbstractApi
     {
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeXmlRequest(
             'DELETE',
-            '/groups/' . $id . '.xml',
+            '/groups/' . strval($id) . '.xml',
         ));
 
         return $this->lastResponse->getContent();
@@ -297,7 +297,7 @@ class Group extends AbstractApi
     {
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeXmlRequest(
             'POST',
-            '/groups/' . $id . '/users.xml',
+            '/groups/' . strval($id) . '/users.xml',
             XmlSerializer::createFromArray(['user_id' => $userId])->getEncoded(),
         ));
 
@@ -324,7 +324,7 @@ class Group extends AbstractApi
     {
         $this->lastResponse = $this->getHttpClient()->request(HttpFactory::makeXmlRequest(
             'DELETE',
-            '/groups/' . $id . '/users/' . $userId . '.xml',
+            '/groups/' . strval($id) . '/users/' . strval($userId) . '.xml',
         ));
 
         return $this->lastResponse->getContent();

--- a/src/Redmine/Api/Issue.php
+++ b/src/Redmine/Api/Issue.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Api;
 
 use Redmine\Client\Client;

--- a/src/Redmine/Api/IssueCategory.php
+++ b/src/Redmine/Api/IssueCategory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Api;
 
 use Redmine\Client\Client;

--- a/src/Redmine/Api/IssueCategory.php
+++ b/src/Redmine/Api/IssueCategory.php
@@ -177,7 +177,7 @@ class IssueCategory extends AbstractApi
     {
         @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.7.0, use `' . self::class . '::listNamesByProject()` instead.', E_USER_DEPRECATED);
 
-        return $this->doListing($project, $forceUpdate);
+        return $this->doListing($project, (bool) $forceUpdate);
     }
 
     /**

--- a/src/Redmine/Api/IssuePriority.php
+++ b/src/Redmine/Api/IssuePriority.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Api;
 
 use Redmine\Client\Client;

--- a/src/Redmine/Api/IssueRelation.php
+++ b/src/Redmine/Api/IssueRelation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Api;
 
 use Redmine\Client\Client;

--- a/src/Redmine/Api/IssueStatus.php
+++ b/src/Redmine/Api/IssueStatus.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Api;
 
 use Redmine\Client\Client;

--- a/src/Redmine/Api/IssueStatus.php
+++ b/src/Redmine/Api/IssueStatus.php
@@ -150,7 +150,7 @@ class IssueStatus extends AbstractApi
     {
         @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.7.0, use `' . self::class . '::listNames()` instead.', E_USER_DEPRECATED);
 
-        return $this->doListing($forceUpdate);
+        return $this->doListing((bool) $forceUpdate);
     }
 
     /**

--- a/src/Redmine/Api/Membership.php
+++ b/src/Redmine/Api/Membership.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Api;
 
 use Redmine\Client\Client;

--- a/src/Redmine/Api/News.php
+++ b/src/Redmine/Api/News.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Api;
 
 use Redmine\Client\Client;

--- a/src/Redmine/Api/Project.php
+++ b/src/Redmine/Api/Project.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Api;
 
 use InvalidArgumentException;

--- a/src/Redmine/Api/Project.php
+++ b/src/Redmine/Api/Project.php
@@ -172,7 +172,7 @@ class Project extends AbstractApi
     {
         @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.7.0, use `' . self::class . '::listNames()` instead.', E_USER_DEPRECATED);
 
-        return $this->doListing($forceUpdate, $reverse, $params);
+        return $this->doListing((bool) $forceUpdate, $reverse, $params);
     }
 
     /**

--- a/src/Redmine/Api/Query.php
+++ b/src/Redmine/Api/Query.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Api;
 
 use Redmine\Client\Client;

--- a/src/Redmine/Api/Role.php
+++ b/src/Redmine/Api/Role.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Api;
 
 use Redmine\Client\Client;

--- a/src/Redmine/Api/Search.php
+++ b/src/Redmine/Api/Search.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Api;
 
 use Redmine\Client\Client;

--- a/src/Redmine/Api/Search.php
+++ b/src/Redmine/Api/Search.php
@@ -86,7 +86,7 @@ class Search extends AbstractApi
         @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.4.0, use `' . self::class . '::listByQuery()` instead.', E_USER_DEPRECATED);
 
         try {
-            $results = $this->listByQuery($query, $params);
+            $results = $this->listByQuery((string) $query, $params);
         } catch (Exception $e) {
             if ($this->getLastResponse()->getContent() === '') {
                 return false;

--- a/src/Redmine/Api/TimeEntry.php
+++ b/src/Redmine/Api/TimeEntry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Api;
 
 use Redmine\Client\Client;

--- a/src/Redmine/Api/TimeEntryActivity.php
+++ b/src/Redmine/Api/TimeEntryActivity.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Api;
 
 use Redmine\Client\Client;

--- a/src/Redmine/Api/Tracker.php
+++ b/src/Redmine/Api/Tracker.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Api;
 
 use Redmine\Client\Client;

--- a/src/Redmine/Api/Tracker.php
+++ b/src/Redmine/Api/Tracker.php
@@ -149,7 +149,7 @@ class Tracker extends AbstractApi
     {
         @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.7.0, use `' . self::class . '::listNames()` instead.', E_USER_DEPRECATED);
 
-        return $this->doListing($forceUpdate);
+        return $this->doListing((bool) $forceUpdate);
     }
 
     /**

--- a/src/Redmine/Api/User.php
+++ b/src/Redmine/Api/User.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Api;
 
 use Redmine\Client\Client;

--- a/src/Redmine/Api/User.php
+++ b/src/Redmine/Api/User.php
@@ -170,7 +170,7 @@ class User extends AbstractApi
     {
         @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.7.0, use `' . self::class . '::listLogins()` instead.', E_USER_DEPRECATED);
 
-        return $this->doListing($forceUpdate, $params);
+        return $this->doListing((bool) $forceUpdate, $params);
     }
 
     /**

--- a/src/Redmine/Api/Version.php
+++ b/src/Redmine/Api/Version.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Api;
 
 use Redmine\Client\Client;

--- a/src/Redmine/Api/Version.php
+++ b/src/Redmine/Api/Version.php
@@ -179,7 +179,7 @@ class Version extends AbstractApi
     {
         @trigger_error('`' . __METHOD__ . '()` is deprecated since v2.7.0, use `' . self::class . '::listNamesByProject()` instead.', E_USER_DEPRECATED);
 
-        return $this->doListing($project, $forceUpdate, $reverse, $params);
+        return $this->doListing($project, (bool) $forceUpdate, $reverse, $params);
     }
 
     /**

--- a/src/Redmine/Api/Wiki.php
+++ b/src/Redmine/Api/Wiki.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Api;
 
 use Redmine\Client\Client;

--- a/src/Redmine/Client/Client.php
+++ b/src/Redmine/Client/Client.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Client;
 
 use Redmine\Api;

--- a/src/Redmine/Client/ClientApiTrait.php
+++ b/src/Redmine/Client/ClientApiTrait.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Client;
 
 use Redmine\Api;

--- a/src/Redmine/Exception.php
+++ b/src/Redmine/Exception.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine;
 
 use Throwable;

--- a/src/Redmine/Exception/ClientException.php
+++ b/src/Redmine/Exception/ClientException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Exception;
 
 use Exception;

--- a/src/Redmine/Exception/InvalidApiNameException.php
+++ b/src/Redmine/Exception/InvalidApiNameException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Exception;
 
 use InvalidArgumentException;

--- a/src/Redmine/Exception/InvalidParameterException.php
+++ b/src/Redmine/Exception/InvalidParameterException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Exception;
 
 use InvalidArgumentException;

--- a/src/Redmine/Exception/MissingParameterException.php
+++ b/src/Redmine/Exception/MissingParameterException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Exception;
 
 use InvalidArgumentException;

--- a/src/Redmine/Exception/SerializerException.php
+++ b/src/Redmine/Exception/SerializerException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Exception;
 
 use Redmine\Exception as RedmineException;

--- a/src/Redmine/Serializer/JsonSerializer.php
+++ b/src/Redmine/Serializer/JsonSerializer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Serializer;
 
 use JsonException;

--- a/src/Redmine/Serializer/PathSerializer.php
+++ b/src/Redmine/Serializer/PathSerializer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Serializer;
 
 use Stringable;

--- a/src/Redmine/Serializer/XmlSerializer.php
+++ b/src/Redmine/Serializer/XmlSerializer.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Serializer;
 
+use Exception;
 use JsonException;
 use Redmine\Exception\SerializerException;
 use SimpleXMLElement;
 use Stringable;
-use Throwable;
 
 /**
  * XmlSerializer.
@@ -75,7 +77,7 @@ final class XmlSerializer implements Stringable
 
         try {
             $this->deserialized = new SimpleXMLElement($encoded);
-        } catch (Throwable $e) {
+        } catch (Exception $e) {
             $errors = [];
             $code = $e->getCode();
 
@@ -123,8 +125,8 @@ final class XmlSerializer implements Stringable
         $prevSetting = libxml_use_internal_errors(true);
 
         try {
-            $this->deserialized = $this->createXmlElement($rootElementName, $this->normalized[$rootElementName]);
-        } catch (Throwable $e) {
+            $this->deserialized = $this->createXmlElement((string) $rootElementName, $this->normalized[$rootElementName]);
+        } catch (Exception $e) {
             $errors = [];
 
             foreach (libxml_get_errors() as $error) {
@@ -196,7 +198,7 @@ final class XmlSerializer implements Stringable
             $array = $xml->addChild($k, '');
             $array->addAttribute('type', 'array');
             foreach ($v as $id) {
-                $array->addChild($specialParams[$k], $id);
+                $array->addChild($specialParams[$k], (string) $id);
             }
         } elseif (is_array($v)) {
             $array = $xml->addChild($k, '');
@@ -231,7 +233,7 @@ final class XmlSerializer implements Stringable
                 $_field->addAttribute('field_format', $field['field_format']);
             }
             if (isset($field['id'])) {
-                $_field->addAttribute('id', $field['id']);
+                $_field->addAttribute('id', strval($field['id']));
             }
             if (array_key_exists('value', $field) && is_array($field['value'])) {
                 $_field->addAttribute('multiple', 'true');
@@ -243,7 +245,7 @@ final class XmlSerializer implements Stringable
                 } else {
                     $_values->addAttribute('type', 'array');
                     foreach ($field['value'] as $val) {
-                        $_values->addChild('value', $val);
+                        $_values->addChild('value', (string) $val);
                     }
                 }
             } else {

--- a/tests/Unit/Api/AbstractApiTest.php
+++ b/tests/Unit/Api/AbstractApiTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api;
 
 use InvalidArgumentException;

--- a/tests/Unit/Api/Attachment/DownloadTest.php
+++ b/tests/Unit/Api/Attachment/DownloadTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Attachment;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Attachment/FromHttpClientTest.php
+++ b/tests/Unit/Api/Attachment/FromHttpClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Attachment;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Attachment/ShowTest.php
+++ b/tests/Unit/Api/Attachment/ShowTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Attachment;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Attachment/UpdateTest.php
+++ b/tests/Unit/Api/Attachment/UpdateTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Attachment;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Attachment/UploadTest.php
+++ b/tests/Unit/Api/Attachment/UploadTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Attachment;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/AttachmentTest.php
+++ b/tests/Unit/Api/AttachmentTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/CustomField/FromHttpClientTest.php
+++ b/tests/Unit/Api/CustomField/FromHttpClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\CustomField;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/CustomField/ListTest.php
+++ b/tests/Unit/Api/CustomField/ListTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\CustomField;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/CustomFieldTest.php
+++ b/tests/Unit/Api/CustomFieldTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/CustomFieldTest.php
+++ b/tests/Unit/Api/CustomFieldTest.php
@@ -338,7 +338,8 @@ class CustomFieldTest extends TestCase
 
         // Perform the tests
         $this->assertSame($expectedReturn, $api->listing(true));
-        $this->assertSame($expectedReturn, $api->listing(true));
+        // @phpstan-ignore argument.type(Test casting int to bool)
+        $this->assertSame($expectedReturn, $api->listing(1));
     }
 
     /**

--- a/tests/Unit/Api/Group/AddUserTest.php
+++ b/tests/Unit/Api/Group/AddUserTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Group;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Group/FromHttpClientTest.php
+++ b/tests/Unit/Api/Group/FromHttpClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Group;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Group/ListTest.php
+++ b/tests/Unit/Api/Group/ListTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Group;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Group/ShowTest.php
+++ b/tests/Unit/Api/Group/ShowTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Group;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/GroupTest.php
+++ b/tests/Unit/Api/GroupTest.php
@@ -294,6 +294,7 @@ class GroupTest extends TestCase
 
         // Perform the tests
         $this->assertSame($expectedReturn, $api->listing(true));
-        $this->assertSame($expectedReturn, $api->listing(true));
+        // @phpstan-ignore argument.type(Test casting int to bool)
+        $this->assertSame($expectedReturn, $api->listing(1));
     }
 }

--- a/tests/Unit/Api/Issue/AddWatcherTest.php
+++ b/tests/Unit/Api/Issue/AddWatcherTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Issue;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Issue/AttachManyTest.php
+++ b/tests/Unit/Api/Issue/AttachManyTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Issue;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Issue/AttachTest.php
+++ b/tests/Unit/Api/Issue/AttachTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Issue;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Issue/CreateTest.php
+++ b/tests/Unit/Api/Issue/CreateTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Issue;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Issue/FromHttpClientTest.php
+++ b/tests/Unit/Api/Issue/FromHttpClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Issue;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Issue/ListTest.php
+++ b/tests/Unit/Api/Issue/ListTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Issue;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Issue/RemoveTest.php
+++ b/tests/Unit/Api/Issue/RemoveTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Issue;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Issue/RemoveWatcherTest.php
+++ b/tests/Unit/Api/Issue/RemoveWatcherTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Issue;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Issue/SetIssueStatusTest.php
+++ b/tests/Unit/Api/Issue/SetIssueStatusTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Issue;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Issue/ShowTest.php
+++ b/tests/Unit/Api/Issue/ShowTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Issue;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/IssueCategory/CreateTest.php
+++ b/tests/Unit/Api/IssueCategory/CreateTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\IssueCategory;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/IssueCategory/FromHttpClientTest.php
+++ b/tests/Unit/Api/IssueCategory/FromHttpClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\IssueCategory;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/IssueCategory/ListByProjectTest.php
+++ b/tests/Unit/Api/IssueCategory/ListByProjectTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\IssueCategory;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/IssueCategory/RemoveTest.php
+++ b/tests/Unit/Api/IssueCategory/RemoveTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\IssueCategory;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/IssueCategory/ShowTest.php
+++ b/tests/Unit/Api/IssueCategory/ShowTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\IssueCategory;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/IssueCategoryTest.php
+++ b/tests/Unit/Api/IssueCategoryTest.php
@@ -259,7 +259,8 @@ class IssueCategoryTest extends TestCase
 
         // Perform the tests
         $this->assertSame($expectedReturn, $api->listing(5, true));
-        $this->assertSame($expectedReturn, $api->listing(5, true));
+        // @phpstan-ignore argument.type(Test casting int to bool)
+        $this->assertSame($expectedReturn, $api->listing(5, 1));
     }
 
     /**

--- a/tests/Unit/Api/IssueCategoryTest.php
+++ b/tests/Unit/Api/IssueCategoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/IssuePriority/FromHttpClientTest.php
+++ b/tests/Unit/Api/IssuePriority/FromHttpClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\IssuePriority;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/IssuePriority/ListTest.php
+++ b/tests/Unit/Api/IssuePriority/ListTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\IssuePriority;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/IssuePriorityTest.php
+++ b/tests/Unit/Api/IssuePriorityTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/IssueRelation/CreateTest.php
+++ b/tests/Unit/Api/IssueRelation/CreateTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\IssueRelation;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/IssueRelation/FromHttpClientTest.php
+++ b/tests/Unit/Api/IssueRelation/FromHttpClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\IssueRelation;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/IssueRelation/ListByIssueIdTest.php
+++ b/tests/Unit/Api/IssueRelation/ListByIssueIdTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\IssueRelation;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/IssueRelation/RemoveTest.php
+++ b/tests/Unit/Api/IssueRelation/RemoveTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\IssueRelation;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/IssueRelation/ShowTest.php
+++ b/tests/Unit/Api/IssueRelation/ShowTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\IssueRelation;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/IssueRelationTest.php
+++ b/tests/Unit/Api/IssueRelationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/IssueStatus/FromHttpClientTest.php
+++ b/tests/Unit/Api/IssueStatus/FromHttpClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\IssueStatus;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/IssueStatus/ListTest.php
+++ b/tests/Unit/Api/IssueStatus/ListTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\IssueStatus;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/IssueStatusTest.php
+++ b/tests/Unit/Api/IssueStatusTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/IssueStatusTest.php
+++ b/tests/Unit/Api/IssueStatusTest.php
@@ -255,7 +255,8 @@ class IssueStatusTest extends TestCase
 
         // Perform the tests
         $this->assertSame($expectedReturn, $api->listing(true));
-        $this->assertSame($expectedReturn, $api->listing(true));
+        // @phpstan-ignore argument.type(Test casting int to bool)
+        $this->assertSame($expectedReturn, $api->listing(1));
     }
 
     /**

--- a/tests/Unit/Api/IssueTest.php
+++ b/tests/Unit/Api/IssueTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Membership/CreateTest.php
+++ b/tests/Unit/Api/Membership/CreateTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Membership;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Membership/FromHttpClientTest.php
+++ b/tests/Unit/Api/Membership/FromHttpClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Membership;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Membership/ListByProjectTest.php
+++ b/tests/Unit/Api/Membership/ListByProjectTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Membership;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Membership/RemoveMemberTest.php
+++ b/tests/Unit/Api/Membership/RemoveMemberTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Membership;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Membership/RemoveTest.php
+++ b/tests/Unit/Api/Membership/RemoveTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Membership;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Membership/UpdateTest.php
+++ b/tests/Unit/Api/Membership/UpdateTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Membership;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/MembershipTest.php
+++ b/tests/Unit/Api/MembershipTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/News/FromHttpClientTest.php
+++ b/tests/Unit/Api/News/FromHttpClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\News;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/News/ListByProjectTest.php
+++ b/tests/Unit/Api/News/ListByProjectTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\News;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/News/ListTest.php
+++ b/tests/Unit/Api/News/ListTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\News;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/NewsTest.php
+++ b/tests/Unit/Api/NewsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Project/CloseTest.php
+++ b/tests/Unit/Api/Project/CloseTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Project;
 
 use InvalidArgumentException;

--- a/tests/Unit/Api/Project/CreateTest.php
+++ b/tests/Unit/Api/Project/CreateTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Project;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Project/FromHttpClientTest.php
+++ b/tests/Unit/Api/Project/FromHttpClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Project;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Project/ListTest.php
+++ b/tests/Unit/Api/Project/ListTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Project;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Project/RemoveTest.php
+++ b/tests/Unit/Api/Project/RemoveTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Project;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Project/ReopenTest.php
+++ b/tests/Unit/Api/Project/ReopenTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Project;
 
 use InvalidArgumentException;

--- a/tests/Unit/Api/Project/ShowTest.php
+++ b/tests/Unit/Api/Project/ShowTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Project;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Project/UnarchiveTest.php
+++ b/tests/Unit/Api/Project/UnarchiveTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Project;
 
 use InvalidArgumentException;

--- a/tests/Unit/Api/ProjectTest.php
+++ b/tests/Unit/Api/ProjectTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/ProjectTest.php
+++ b/tests/Unit/Api/ProjectTest.php
@@ -257,7 +257,8 @@ class ProjectTest extends TestCase
 
         // Perform the tests
         $this->assertSame($expectedReturn, $api->listing(true));
-        $this->assertSame($expectedReturn, $api->listing(true));
+        // @phpstan-ignore argument.type(Test casting int to bool)
+        $this->assertSame($expectedReturn, $api->listing(1));
     }
 
     /**

--- a/tests/Unit/Api/Query/FromHttpClientTest.php
+++ b/tests/Unit/Api/Query/FromHttpClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Query;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Query/ListTest.php
+++ b/tests/Unit/Api/Query/ListTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Query;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/QueryTest.php
+++ b/tests/Unit/Api/QueryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Role/FromHttpClientTest.php
+++ b/tests/Unit/Api/Role/FromHttpClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Role;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Role/ListTest.php
+++ b/tests/Unit/Api/Role/ListTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Role;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Role/ShowTest.php
+++ b/tests/Unit/Api/Role/ShowTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Role;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/RoleTest.php
+++ b/tests/Unit/Api/RoleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/RoleTest.php
+++ b/tests/Unit/Api/RoleTest.php
@@ -255,7 +255,8 @@ class RoleTest extends TestCase
 
         // Perform the tests
         $this->assertSame($expectedReturn, $api->listing(true));
-        $this->assertSame($expectedReturn, $api->listing(true));
+        // @phpstan-ignore argument.type(Test casting int to bool)
+        $this->assertSame($expectedReturn, $api->listing(1));
     }
 
     /**

--- a/tests/Unit/Api/Search/FromHttpClientTest.php
+++ b/tests/Unit/Api/Search/FromHttpClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Search;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Search/ListByQueryTest.php
+++ b/tests/Unit/Api/Search/ListByQueryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Search;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Search/SearchTest.php
+++ b/tests/Unit/Api/Search/SearchTest.php
@@ -86,7 +86,7 @@ class SearchTest extends TestCase
             $this,
             [
                 'GET',
-                '/search.json?limit=25&offset=0&0=not-used&q=query',
+                '/search.json?limit=25&offset=0&0=not-used&q=12345',
                 'application/json',
                 '',
                 200,
@@ -98,7 +98,7 @@ class SearchTest extends TestCase
         // Create the object under test
         $api = Search::fromHttpClient($client);
 
-        // Perform the tests
-        $this->assertSame($expectedReturn, $api->search('query', $parameters));
+        // @phpstan-ignore argument.type(Test casting int to string)
+        $this->assertSame($expectedReturn, $api->search(12345, $parameters));
     }
 }

--- a/tests/Unit/Api/Search/SearchTest.php
+++ b/tests/Unit/Api/Search/SearchTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Search;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/SearchTest.php
+++ b/tests/Unit/Api/SearchTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/TimeEntry/CreateTest.php
+++ b/tests/Unit/Api/TimeEntry/CreateTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\TimeEntry;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/TimeEntry/FromHttpClientTest.php
+++ b/tests/Unit/Api/TimeEntry/FromHttpClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\TimeEntry;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/TimeEntry/ListTest.php
+++ b/tests/Unit/Api/TimeEntry/ListTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\TimeEntry;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/TimeEntry/RemoveTest.php
+++ b/tests/Unit/Api/TimeEntry/RemoveTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\TimeEntry;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/TimeEntry/ShowTest.php
+++ b/tests/Unit/Api/TimeEntry/ShowTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\TimeEntry;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/TimeEntryActivity/FromHttpClientTest.php
+++ b/tests/Unit/Api/TimeEntryActivity/FromHttpClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\TimeEntryActivity;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/TimeEntryActivity/ListTest.php
+++ b/tests/Unit/Api/TimeEntryActivity/ListTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\TimeEntryActivity;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/TimeEntryActivityTest.php
+++ b/tests/Unit/Api/TimeEntryActivityTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/TimeEntryActivityTest.php
+++ b/tests/Unit/Api/TimeEntryActivityTest.php
@@ -210,7 +210,8 @@ class TimeEntryActivityTest extends TestCase
         $api = TimeEntryActivity::fromHttpClient($client);
 
         $this->assertSame($expectedReturn, $api->listing(true));
-        $this->assertSame($expectedReturn, $api->listing(true));
+        // @phpstan-ignore argument.type(Test casting int to bool)
+        $this->assertSame($expectedReturn, $api->listing(1));
     }
 
     /**

--- a/tests/Unit/Api/TimeEntryTest.php
+++ b/tests/Unit/Api/TimeEntryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Tracker/FromHttpClientTest.php
+++ b/tests/Unit/Api/Tracker/FromHttpClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Tracker;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Tracker/ListTest.php
+++ b/tests/Unit/Api/Tracker/ListTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Tracker;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/TrackerTest.php
+++ b/tests/Unit/Api/TrackerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/TrackerTest.php
+++ b/tests/Unit/Api/TrackerTest.php
@@ -255,7 +255,8 @@ class TrackerTest extends TestCase
 
         // Perform the tests
         $this->assertSame($expectedReturn, $api->listing(true));
-        $this->assertSame($expectedReturn, $api->listing(true));
+        // @phpstan-ignore argument.type(Test casting int to bool)
+        $this->assertSame($expectedReturn, $api->listing(1));
     }
 
     /**

--- a/tests/Unit/Api/User/CreateTest.php
+++ b/tests/Unit/Api/User/CreateTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\User;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/User/FromHttpClientTest.php
+++ b/tests/Unit/Api/User/FromHttpClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\User;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/User/ListTest.php
+++ b/tests/Unit/Api/User/ListTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\User;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/User/RemoveTest.php
+++ b/tests/Unit/Api/User/RemoveTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\User;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/User/ShowTest.php
+++ b/tests/Unit/Api/User/ShowTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\User;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/UserTest.php
+++ b/tests/Unit/Api/UserTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/UserTest.php
+++ b/tests/Unit/Api/UserTest.php
@@ -352,7 +352,8 @@ class UserTest extends TestCase
 
         // Perform the tests
         $this->assertSame($expectedReturn, $api->listing(true));
-        $this->assertSame($expectedReturn, $api->listing(true));
+        // @phpstan-ignore argument.type(Test casting int to bool)
+        $this->assertSame($expectedReturn, $api->listing(1));
     }
 
     /**

--- a/tests/Unit/Api/Version/CreateTest.php
+++ b/tests/Unit/Api/Version/CreateTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Version;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Version/FromHttpClientTest.php
+++ b/tests/Unit/Api/Version/FromHttpClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Version;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Version/ListByProjectTest.php
+++ b/tests/Unit/Api/Version/ListByProjectTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Version;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Version/RemoveTest.php
+++ b/tests/Unit/Api/Version/RemoveTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Version;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Version/ShowTest.php
+++ b/tests/Unit/Api/Version/ShowTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Version;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Version/UpdateTest.php
+++ b/tests/Unit/Api/Version/UpdateTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Version;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/VersionTest.php
+++ b/tests/Unit/Api/VersionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/VersionTest.php
+++ b/tests/Unit/Api/VersionTest.php
@@ -291,7 +291,8 @@ class VersionTest extends TestCase
 
         // Perform the tests
         $this->assertSame($expectedReturn, $api->listing(5, true));
-        $this->assertSame($expectedReturn, $api->listing(5, true));
+        // @phpstan-ignore argument.type(Test casting int to bool)
+        $this->assertSame($expectedReturn, $api->listing(5, 1));
     }
 
     /**

--- a/tests/Unit/Api/Wiki/FromHttpClientTest.php
+++ b/tests/Unit/Api/Wiki/FromHttpClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Wiki;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Wiki/ListByProjectTest.php
+++ b/tests/Unit/Api/Wiki/ListByProjectTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Wiki;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/Wiki/ShowTest.php
+++ b/tests/Unit/Api/Wiki/ShowTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api\Wiki;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Api/WikiTest.php
+++ b/tests/Unit/Api/WikiTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Api;
 
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Client/NativeCurlClient/RequestTest.php
+++ b/tests/Unit/Client/NativeCurlClient/RequestTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Client\NativeCurlClientTest;
 
 use phpmock\phpunit\PHPMock;

--- a/tests/Unit/Client/Psr18Client/RequestTest.php
+++ b/tests/Unit/Client/Psr18Client/RequestTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Client\Psr18ClientTest;
 
 use Exception;

--- a/tests/Unit/Client/Psr18ClientTest.php
+++ b/tests/Unit/Client/Psr18ClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Client;
 
 use Exception;

--- a/tests/Unit/Exception/ClientExceptionTest.php
+++ b/tests/Unit/Exception/ClientExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Exception;
 
 use Exception;

--- a/tests/Unit/Exception/InvalidApiNameExceptionTest.php
+++ b/tests/Unit/Exception/InvalidApiNameExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Exception;
 
 use InvalidArgumentException;

--- a/tests/Unit/Exception/InvalidParameterExceptionTest.php
+++ b/tests/Unit/Exception/InvalidParameterExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Exception;
 
 use Exception;

--- a/tests/Unit/Exception/MissingParameterExceptionTest.php
+++ b/tests/Unit/Exception/MissingParameterExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Redmine\Tests\Unit\Exception;
 
 use Exception;


### PR DESCRIPTION
closes #464.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled strict type checking across the codebase to improve type safety and runtime consistency.
  * Updated legacy listing calls to consistently pass boolean flags.
* **Bug Fixes**
  * Improved XML serialization to consistently treat values and attributes as strings, reducing parsing edge cases.
* **Tests**
  * Test files updated to opt into strict typing to match production behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->