### PR TITLE
Behat tests with Github Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,14 +38,26 @@ jobs:
         run: composer run phpunit -- --no-coverage
 
   behat:
-    name: Tests (Behat with PHP ${{ matrix.php }})
+    name: Behat ${{ matrix.suite }} (PHP ${{ matrix.php }})
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        operating-system: ["ubuntu-latest"]
         php: ["8.3"]
+        include:
+          - suite: redmine_6_1
+            service: redmine-6-1
+            port: 5061
+            data-dir: redmine-60101_data
+          - suite: redmine_6_0
+            service: redmine-6-0
+            port: 5060
+            data-dir: redmine-60008_data
+          - suite: redmine_5_1
+            service: redmine-5-1
+            port: 5051
+            data-dir: redmine-50111_data
 
     steps:
       - name: Checkout
@@ -64,43 +76,33 @@ jobs:
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v2
 
-      - name: Create data directories
+      - name: Create data directory
         run: |
-          mkdir -p .docker/redmine-60101_data/{files,sqlite}
-          mkdir -p .docker/redmine-60008_data/{files,sqlite}
-          mkdir -p .docker/redmine-50111_data/{files,sqlite}
-          chmod -R 777 .docker/redmine-*_data/
+          mkdir -p .docker/${{ matrix.data-dir }}/{files,sqlite}
+          chmod -R 777 .docker/${{ matrix.data-dir }}/
 
-      - name: Start Redmine containers
-        run: docker compose up -d redmine-6-1 redmine-6-0 redmine-5-1
+      - name: Start Redmine container
+        run: docker compose up -d ${{ matrix.service }}
 
-      - name: Wait for Redmine instances to be healthy
+      - name: Wait for Redmine to be healthy
         run: |
           for i in $(seq 1 60); do
-            if curl -sf http://localhost:5061 > /dev/null 2>&1 && \
-               curl -sf http://localhost:5060 > /dev/null 2>&1 && \
-               curl -sf http://localhost:5051 > /dev/null 2>&1; then
-              echo "All Redmine instances are ready"
+            if curl -sf http://localhost:${{ matrix.port }} > /dev/null 2>&1; then
+              echo "Redmine ${{ matrix.service }} is ready"
               exit 0
             fi
-            echo "Waiting for Redmine instances... ($i/60)"
+            echo "Waiting... ($i/60)"
             sleep 5
           done
-          echo "Redmine instances did not become ready in time"
-          docker compose logs redmine-6-1 redmine-6-0 redmine-5-1
+          echo "Redmine ${{ matrix.service }} did not become ready"
+          docker compose logs ${{ matrix.service }}
           exit 1
 
       - name: Fix permissions
-        run: sudo chmod -R 777 .docker/redmine-*_data/
+        run: sudo chmod -R 777 .docker/${{ matrix.data-dir }}/sqlite/
 
-      - name: Run behat [Redmine 6.1]
-        run: vendor/bin/behat --config tests/Behat/behat.yml --profile=github-actions --format=progress --suite=redmine_6_1
-
-      - name: Run behat [Redmine 6.0]
-        run: vendor/bin/behat --config tests/Behat/behat.yml --profile=github-actions --format=progress --suite=redmine_6_0
-
-      - name: Run behat [Redmine 5.1]
-        run: vendor/bin/behat --config tests/Behat/behat.yml --profile=github-actions --format=progress --suite=redmine_5_1
+      - name: Run behat
+        run: vendor/bin/behat --config tests/Behat/behat.yml --profile=github-actions --format=progress --suite=${{ matrix.suite }}
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,6 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ["8.3"]
+        suite: [redmine_6_1, redmine_6_0, redmine_5_1]
         include:
           - suite: redmine_6_1
             service: redmine-6-1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,6 +40,8 @@ jobs:
   behat:
     name: Behat ${{ matrix.suite }} (PHP ${{ matrix.php }})
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -99,7 +99,7 @@ jobs:
           exit 1
 
       - name: Fix permissions
-        run: sudo chmod -R 777 .docker/${{ matrix.data-dir }}/sqlite/
+        run: sudo chmod -R 777 .docker/${{ matrix.data-dir }}/
 
       - name: Run behat
         run: vendor/bin/behat --config tests/Behat/behat.yml --profile=github-actions --format=progress --suite=${{ matrix.suite }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,6 +90,9 @@ jobs:
           docker compose logs redmine-6-1 redmine-6-0 redmine-5-1
           exit 1
 
+      - name: Fix permissions
+        run: sudo chmod -R 777 .docker/redmine-*_data/
+
       - name: Run behat
         run: vendor/bin/behat --config tests/Behat/behat.yml --profile=github-actions --suite=redmine_6_1
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,53 +37,65 @@ jobs:
       - name: Run tests
         run: composer run phpunit -- --no-coverage
 
-  # This does not work
-  # behat:
-  #   name: Tests (Behat with PHP ${{ matrix.php }})
-  #   runs-on: ubuntu-latest
+  behat:
+    name: Tests (Behat with PHP ${{ matrix.php }})
+    runs-on: ubuntu-latest
 
-  #   services:
-  #     redmine-6-0:
-  #       image: redmine:6.0.7
-  #       ports:
-  #           - "5060:3000"
-  #       env:
-  #           # Workaround: Remove secret for Rails 7.2 so it will be generated automatically
-  #           # @see https://github.com/docker-library/redmine/issues/349#issuecomment-2516634932
-  #           # REDMINE_SECRET_KEY_BASE: supersecretkey
-  #           REDMINE_PLUGINS_MIGRATE: true
-  #       volumes:
-  #           - /home/runner/work/_temp/redmine-60007_data/files:/usr/src/redmine/files
-  #           - /home/runner/work/_temp/redmine-60007_data/sqlite:/usr/src/redmine/sqlite
-  #       options: --health-cmd="wget -O /dev/null http://localhost:3000" --health-start-period=30s --health-interval=30s --health-timeout=30s --health-retries=3
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: ["ubuntu-latest"]
+        php: ["8.3"]
 
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       operating-system: ["ubuntu-latest"]
-  #       php: ["8.3"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
 
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: 2
+      - name: Setup PHP, with composer and extensions
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          tools: phpunit
+          extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, curl
+          coverage: xdebug
 
-  #     - name: Setup PHP, with composer and extensions
-  #       uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
-  #       with:
-  #         php-version: ${{ matrix.php }}
-  #         tools: phpunit
-  #         extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite
-  #         coverage: xdebug
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v2
 
-  #     # Install composer dependencies and handle caching in one go.
-  #     # @link https://github.com/marketplace/actions/install-composer-dependencies
-  #     - name: "Install Composer dependencies"
-  #       uses: "ramsey/composer-install@v2"
+      - name: Create data directories
+        run: |
+          mkdir -p .docker/redmine-60101_data/{files,sqlite}
+          mkdir -p .docker/redmine-60008_data/{files,sqlite}
+          mkdir -p .docker/redmine-50111_data/{files,sqlite}
+          chmod -R 777 .docker/redmine-*_data/
 
-  #     - name: Run behat
-  #       run: vendor/bin/behat --config tests/Behat/behat.yml --profile=github-actions --suite=redmine_6_0
+      - name: Start Redmine containers
+        run: docker compose up -d redmine-6-1 redmine-6-0 redmine-5-1
+
+      - name: Wait for Redmine instances to be healthy
+        run: |
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:5061 > /dev/null 2>&1 && \
+               curl -sf http://localhost:5060 > /dev/null 2>&1 && \
+               curl -sf http://localhost:5051 > /dev/null 2>&1; then
+              echo "All Redmine instances are ready"
+              exit 0
+            fi
+            echo "Waiting for Redmine instances... ($i/60)"
+            sleep 5
+          done
+          echo "Redmine instances did not become ready in time"
+          docker compose logs redmine-6-1 redmine-6-0 redmine-5-1
+          exit 1
+
+      - name: Run behat
+        run: vendor/bin/behat --config tests/Behat/behat.yml --profile=github-actions --suite=redmine_6_1
+
+      - name: Cleanup
+        if: always()
+        run: docker compose down -v
 
   code-quality:
     name: Check ${{ matrix.tool }} (PHP ${{ matrix.php }})

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,8 +93,14 @@ jobs:
       - name: Fix permissions
         run: sudo chmod -R 777 .docker/redmine-*_data/
 
-      - name: Run behat
-        run: vendor/bin/behat --config tests/Behat/behat.yml --profile=github-actions --suite=redmine_6_1
+      - name: Run behat [Redmine 6.1]
+        run: vendor/bin/behat --config tests/Behat/behat.yml --profile=github-actions --format=progress --suite=redmine_6_1
+
+      - name: Run behat [Redmine 6.0]
+        run: vendor/bin/behat --config tests/Behat/behat.yml --profile=github-actions --format=progress --suite=redmine_6_0
+
+      - name: Run behat [Redmine 5.1]
+        run: vendor/bin/behat --config tests/Behat/behat.yml --profile=github-actions --format=progress --suite=redmine_5_1
 
       - name: Cleanup
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /composer.lock
 /phpunit.xml
 /vendor
+.env
+.env.local

--- a/tests/Behat/Bootstrap/FeatureContext.php
+++ b/tests/Behat/Bootstrap/FeatureContext.php
@@ -84,7 +84,7 @@ final class FeatureContext implements Context
      */
     private array $lastReturnAsArray;
 
-    public function __construct(string $redmineVersion, string $rootPath, ?string $redmineUrl = null)
+    public function __construct(string $redmineVersion, string $rootPath, string $redmineUrl)
     {
         $version = RedmineVersion::tryFrom($redmineVersion);
 

--- a/tests/Behat/Bootstrap/FeatureContext.php
+++ b/tests/Behat/Bootstrap/FeatureContext.php
@@ -84,7 +84,7 @@ final class FeatureContext implements Context
      */
     private array $lastReturnAsArray;
 
-    public function __construct(string $redmineVersion, string $rootPath)
+    public function __construct(string $redmineVersion, string $rootPath, ?string $redmineUrl = null)
     {
         $version = RedmineVersion::tryFrom($redmineVersion);
 
@@ -92,7 +92,7 @@ final class FeatureContext implements Context
             throw new InvalidArgumentException('Redmine ' . $redmineVersion . ' is not supported.');
         }
 
-        $this->redmine = self::$tracer::getRedmineInstance($version, $rootPath);
+        $this->redmine = self::$tracer::getRedmineInstance($version, $rootPath, $redmineUrl);
     }
 
     /**

--- a/tests/Behat/behat.yml
+++ b/tests/Behat/behat.yml
@@ -6,22 +6,26 @@ default:
             contexts:
                 - Redmine\Tests\Behat\Bootstrap\FeatureContext:
                     redmineVersion: '6.1.1'
-                    rootPath: '%paths.base%/../../.docker'
+                    rootPath: '%paths.base%/../../.docker/redmine-dev_data'
+                    redmineUrl: 'http://redmine-dev:3000'
         redmine_6_1:
             contexts:
                 - Redmine\Tests\Behat\Bootstrap\FeatureContext:
                     redmineVersion: '6.1.1'
-                    rootPath: '%paths.base%/../../.docker'
+                    rootPath: '%paths.base%/../../.docker/redmine-60101_data'
+                    redmineUrl: 'http://redmine-6-1:3000'
         redmine_6_0:
             contexts:
                 - Redmine\Tests\Behat\Bootstrap\FeatureContext:
                     redmineVersion: '6.0.8'
-                    rootPath: '%paths.base%/../../.docker'
+                    rootPath: '%paths.base%/../../.docker/redmine-60008_data'
+                    redmineUrl: 'http://redmine-6-0:3000'
         redmine_5_1:
             contexts:
                 - Redmine\Tests\Behat\Bootstrap\FeatureContext:
                     redmineVersion: '5.1.11'
-                    rootPath: '%paths.base%/../../.docker'
+                    rootPath: '%paths.base%/../../.docker/redmine-50111_data'
+                    redmineUrl: 'http://redmine-5-1:3000'
 
 github-actions:
     suites:
@@ -29,17 +33,17 @@ github-actions:
             contexts:
                 - Redmine\Tests\Behat\Bootstrap\FeatureContext:
                     redmineVersion: '6.1.1'
-                    rootPath: '%paths.base%/../../.docker'
+                    rootPath: '%paths.base%/../../.docker/redmine-60101_data'
                     redmineUrl: 'http://localhost:5061'
         redmine_6_0:
             contexts:
                 - Redmine\Tests\Behat\Bootstrap\FeatureContext:
                     redmineVersion: '6.0.8'
-                    rootPath: '%paths.base%/../../.docker'
+                    rootPath: '%paths.base%/../../.docker/redmine-60008_data'
                     redmineUrl: 'http://localhost:5060'
         redmine_5_1:
             contexts:
                 - Redmine\Tests\Behat\Bootstrap\FeatureContext:
                     redmineVersion: '5.1.11'
-                    rootPath: '%paths.base%/../../.docker'
+                    rootPath: '%paths.base%/../../.docker/redmine-50111_data'
                     redmineUrl: 'http://localhost:5051'

--- a/tests/Behat/behat.yml
+++ b/tests/Behat/behat.yml
@@ -29,14 +29,17 @@ github-actions:
             contexts:
                 - Redmine\Tests\Behat\Bootstrap\FeatureContext:
                     redmineVersion: '6.1.1'
-                    rootPath: '/home/runner/work/_temp'
+                    rootPath: '%paths.base%/../../.docker'
+                    redmineUrl: 'http://localhost:5061'
         redmine_6_0:
             contexts:
                 - Redmine\Tests\Behat\Bootstrap\FeatureContext:
                     redmineVersion: '6.0.8'
-                    rootPath: '/home/runner/work/_temp'
+                    rootPath: '%paths.base%/../../.docker'
+                    redmineUrl: 'http://localhost:5060'
         redmine_5_1:
             contexts:
                 - Redmine\Tests\Behat\Bootstrap\FeatureContext:
                     redmineVersion: '5.1.11'
-                    rootPath: '/home/runner/work/_temp'
+                    rootPath: '%paths.base%/../../.docker'
+                    redmineUrl: 'http://localhost:5051'

--- a/tests/RedmineExtension/BehatHookTracer.php
+++ b/tests/RedmineExtension/BehatHookTracer.php
@@ -19,14 +19,14 @@ final class BehatHookTracer implements InstanceRegistration
      */
     private static array $instances = [];
 
-    public static function getRedmineInstance(RedmineVersion $redmineVersion, string $rootPath): RedmineInstance
+    public static function getRedmineInstance(RedmineVersion $redmineVersion, string $rootPath, ?string $redmineUrl = null): RedmineInstance
     {
         if (!self::$tracer instanceof \Redmine\Tests\RedmineExtension\BehatHookTracer) {
             throw new RuntimeException('You can only get a Redmine instance while a Behat Suite is running.');
         }
 
         if (! array_key_exists($redmineVersion->asId(), self::$instances)) {
-            RedmineInstance::create(self::$tracer, $redmineVersion, $rootPath);
+            RedmineInstance::create(self::$tracer, $redmineVersion, $rootPath, $redmineUrl);
         }
 
         return self::$instances[$redmineVersion->asId()];

--- a/tests/RedmineExtension/BehatHookTracer.php
+++ b/tests/RedmineExtension/BehatHookTracer.php
@@ -19,7 +19,7 @@ final class BehatHookTracer implements InstanceRegistration
      */
     private static array $instances = [];
 
-    public static function getRedmineInstance(RedmineVersion $redmineVersion, string $rootPath, ?string $redmineUrl = null): RedmineInstance
+    public static function getRedmineInstance(RedmineVersion $redmineVersion, string $rootPath, string $redmineUrl): RedmineInstance
     {
         if (!self::$tracer instanceof \Redmine\Tests\RedmineExtension\BehatHookTracer) {
             throw new RuntimeException('You can only get a Redmine instance while a Behat Suite is running.');

--- a/tests/RedmineExtension/RedmineInstance.php
+++ b/tests/RedmineExtension/RedmineInstance.php
@@ -13,8 +13,10 @@ final class RedmineInstance
 {
     /**
      * @param InstanceRegistration $tracer Required to ensure that RedmineInstance is created while Test Runner is running
+     * @param string $rootPath The full path to the Redmine instance data directory (e.g. '/path/to/.docker/redmine-dev_data')
+     * @param string $redmineUrl The full URL to the Redmine instance (e.g. 'http://localhost:5061')
      */
-    public static function create(InstanceRegistration $tracer, RedmineVersion $version, string $rootPath, ?string $redmineUrl = null): void
+    public static function create(InstanceRegistration $tracer, RedmineVersion $version, string $rootPath, string $redmineUrl): void
     {
         $tracer->registerInstance(new self($tracer, $version, $rootPath, $redmineUrl));
     }
@@ -41,19 +43,14 @@ final class RedmineInstance
 
     private string $apiKey;
 
-    private function __construct(InstanceRegistration $tracer, RedmineVersion $version, string $rootPath, ?string $redmineUrl = null)
+    private function __construct(InstanceRegistration $tracer, RedmineVersion $version, string $rootPath, string $redmineUrl)
     {
         $this->tracer = $tracer;
         $this->version = $version;
 
         $versionId = strval($version->asId());
 
-        // Default to .docker folder
-        if ($rootPath === '') {
-            $rootPath = dirname(__FILE__, 3) . '/.docker';
-        }
-
-        $this->dataPath = $rootPath . '/redmine-' . $versionId . '_data/';
+        $this->dataPath = rtrim($rootPath, '/') . '/';
 
         $this->workingDB = 'sqlite/redmine.db';
         $this->migratedDB = 'sqlite/redmine-migrated.db';
@@ -63,9 +60,7 @@ final class RedmineInstance
         $this->migratedFiles = 'files-migrated/';
         $this->backupFiles = 'files-bak/';
 
-        $parts = explode('.', $version->asString());
-
-        $this->redmineUrl = $redmineUrl ?? ('http://redmine-' . intval($parts[0]) . '-' . intval($parts[1]) . ':3000');
+        $this->redmineUrl = $redmineUrl;
         $this->apiKey = sha1($versionId . time());
 
         $this->runHealthChecks($version);

--- a/tests/RedmineExtension/RedmineInstance.php
+++ b/tests/RedmineExtension/RedmineInstance.php
@@ -45,6 +45,14 @@ final class RedmineInstance
 
     private function __construct(InstanceRegistration $tracer, RedmineVersion $version, string $rootPath, string $redmineUrl)
     {
+        if (trim($rootPath) === '') {
+            throw new InvalidArgumentException('Redmine data path cannot be empty.');
+        }
+
+        if (trim($redmineUrl) === '') {
+            throw new InvalidArgumentException('Redmine url cannot be empty.');
+        }
+
         $this->tracer = $tracer;
         $this->version = $version;
 

--- a/tests/RedmineExtension/RedmineInstance.php
+++ b/tests/RedmineExtension/RedmineInstance.php
@@ -14,9 +14,9 @@ final class RedmineInstance
     /**
      * @param InstanceRegistration $tracer Required to ensure that RedmineInstance is created while Test Runner is running
      */
-    public static function create(InstanceRegistration $tracer, RedmineVersion $version, string $rootPath): void
+    public static function create(InstanceRegistration $tracer, RedmineVersion $version, string $rootPath, ?string $redmineUrl = null): void
     {
-        $tracer->registerInstance(new self($tracer, $version, $rootPath));
+        $tracer->registerInstance(new self($tracer, $version, $rootPath, $redmineUrl));
     }
 
     private InstanceRegistration $tracer;
@@ -41,7 +41,7 @@ final class RedmineInstance
 
     private string $apiKey;
 
-    private function __construct(InstanceRegistration $tracer, RedmineVersion $version, string $rootPath)
+    private function __construct(InstanceRegistration $tracer, RedmineVersion $version, string $rootPath, ?string $redmineUrl = null)
     {
         $this->tracer = $tracer;
         $this->version = $version;
@@ -65,7 +65,7 @@ final class RedmineInstance
 
         $parts = explode('.', $version->asString());
 
-        $this->redmineUrl = 'http://redmine-' . intval($parts[0]) . '-' . intval($parts[1]) . ':3000';
+        $this->redmineUrl = $redmineUrl ?? ('http://redmine-' . intval($parts[0]) . '-' . intval($parts[1]) . ':3000');
         $this->apiKey = sha1($versionId . time());
 
         $this->runHealthChecks($version);


### PR DESCRIPTION
Another try to run the behat tests with Github Actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Activated Behat testing in GitHub Actions across multiple Redmine versions (6.1, 6.0, 5.1) using Docker Compose, with PHP 8.3 and per-suite readiness checks.
  * Updated Behat configuration to use version-specific Docker data directories and suite-specific Redmine base URLs for more consistent, environment-agnostic runs.
* **Chores**
  * Added `.env` and `.env.local` to ignore lists to keep local configuration files out of version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->